### PR TITLE
GGBE-134 admin 에서 랭킹 점수 수정 가능한 api 생성

### DIFF
--- a/src/main/java/com/gg/server/admin/game/controller/GameAdminController.java
+++ b/src/main/java/com/gg/server/admin/game/controller/GameAdminController.java
@@ -3,12 +3,20 @@ package com.gg.server.admin.game.controller;
 import com.gg.server.admin.game.dto.GameLogAdminRequestDto;
 import com.gg.server.admin.game.dto.GameLogListAdminResponseDto;
 import com.gg.server.admin.game.dto.GameUserLogAdminReqDto;
+import com.gg.server.admin.game.dto.RankGamePPPModifyReqDto;
 import com.gg.server.admin.game.service.GameAdminService;
+import com.gg.server.domain.game.dto.req.RankResultReqDto;
+import com.gg.server.global.exception.ErrorCode;
+import com.gg.server.global.exception.custom.InvalidParameterException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
 
 @RestController
 @RequiredArgsConstructor
@@ -34,5 +42,14 @@ public class GameAdminController {
 
         Pageable pageable = PageRequest.of(reqDto.getPage() - 1, reqDto.getSize());
         return gameAdminService.findGamesByIntraId(reqDto.getIntraId(), pageable);
+    }
+
+    @PutMapping("/{gameId}")
+    public ResponseEntity gameResultEdit(@Valid @RequestBody RankGamePPPModifyReqDto reqDto) {
+        if (reqDto.getTeam1Score() + reqDto.getTeam2Score() > 3 || reqDto.getTeam1Score() == reqDto.getTeam2Score()) {
+            throw new InvalidParameterException("점수를 잘못 입력했습니다.", ErrorCode.VALID_FAILED);
+        }
+        gameAdminService.rankResultEdit(reqDto);
+        return new ResponseEntity(HttpStatus.NO_CONTENT);
     }
 }

--- a/src/main/java/com/gg/server/admin/game/controller/GameAdminController.java
+++ b/src/main/java/com/gg/server/admin/game/controller/GameAdminController.java
@@ -17,6 +17,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Positive;
 
 @RestController
 @RequiredArgsConstructor
@@ -45,11 +47,12 @@ public class GameAdminController {
     }
 
     @PutMapping("/{gameId}")
-    public ResponseEntity gameResultEdit(@Valid @RequestBody RankGamePPPModifyReqDto reqDto) {
+    public ResponseEntity gameResultEdit(@Valid @RequestBody RankGamePPPModifyReqDto reqDto,
+                                         @PathVariable @Positive Long gameId) {
         if (reqDto.getTeam1Score() + reqDto.getTeam2Score() > 3 || reqDto.getTeam1Score() == reqDto.getTeam2Score()) {
             throw new InvalidParameterException("점수를 잘못 입력했습니다.", ErrorCode.VALID_FAILED);
         }
-        gameAdminService.rankResultEdit(reqDto);
+        gameAdminService.rankResultEdit(reqDto, gameId);
         return new ResponseEntity(HttpStatus.NO_CONTENT);
     }
 }

--- a/src/main/java/com/gg/server/admin/game/dto/RankGamePPPModifyReqDto.java
+++ b/src/main/java/com/gg/server/admin/game/dto/RankGamePPPModifyReqDto.java
@@ -9,9 +9,6 @@ import javax.validation.constraints.PositiveOrZero;
 
 @Getter
 public class RankGamePPPModifyReqDto {
-    @Positive
-    @NotNull(message = "gameId 는 필수 값입니다.")
-    private Long gameId;
     @NotNull(message = "TeamId1 는 필수 값입니다.")
     @Positive
     private Long Team1Id;

--- a/src/main/java/com/gg/server/admin/game/dto/RankGamePPPModifyReqDto.java
+++ b/src/main/java/com/gg/server/admin/game/dto/RankGamePPPModifyReqDto.java
@@ -1,0 +1,29 @@
+package com.gg.server.admin.game.dto;
+
+import lombok.Getter;
+
+import javax.validation.constraints.Max;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Positive;
+import javax.validation.constraints.PositiveOrZero;
+
+@Getter
+public class RankGamePPPModifyReqDto {
+    @Positive
+    @NotNull(message = "gameId 는 필수 값입니다.")
+    private Long gameId;
+    @NotNull(message = "TeamId1 는 필수 값입니다.")
+    @Positive
+    private Long Team1Id;
+    @NotNull(message = "Team1Score 는 필수 값입니다.")
+    @PositiveOrZero
+    @Max(2)
+    private int Team1Score;
+    @NotNull(message = "TeamId2 는 필수 값입니다.")
+    @Positive
+    private Long Team2Id;
+    @NotNull(message = "Team2Score 는 필수 값입니다.")
+    @PositiveOrZero
+    @Max(2)
+    private int Team2Score;
+}

--- a/src/main/java/com/gg/server/admin/game/exception/NotRecentlyGameException.java
+++ b/src/main/java/com/gg/server/admin/game/exception/NotRecentlyGameException.java
@@ -1,0 +1,10 @@
+package com.gg.server.admin.game.exception;
+
+import com.gg.server.global.exception.ErrorCode;
+import com.gg.server.global.exception.custom.InvalidParameterException;
+
+public class NotRecentlyGameException extends InvalidParameterException {
+    public NotRecentlyGameException() {
+        super(ErrorCode.GAME_NOT_RECENTLY.getMessage(), ErrorCode.GAME_NOT_RECENTLY);
+    }
+}

--- a/src/main/java/com/gg/server/admin/game/service/GameAdminService.java
+++ b/src/main/java/com/gg/server/admin/game/service/GameAdminService.java
@@ -94,10 +94,10 @@ public class GameAdminService {
     }
 
     @Transactional
-    public void rankResultEdit(RankGamePPPModifyReqDto reqDto) {
+    public void rankResultEdit(RankGamePPPModifyReqDto reqDto, Long gameId) {
         // 게임이 두명 다 가장 마지막 게임인지 확인 (그 game에 해당하는 팀이 맞는지 확인)
         List<TeamUser> teamUsers = teamUserAdminRepository.findUsersByTeamIdIn(List.of(reqDto.getTeam1Id(), reqDto.getTeam2Id()));
-        Game game = gameAdminRepository.findById(reqDto.getGameId())
+        Game game = gameAdminRepository.findById(gameId)
                 .orElseThrow(GameNotExistException::new);
         Season season = seasonAdminRepository.findById(game.getSeason().getId())
                 .orElseThrow(SeasonNotFoundException::new);
@@ -107,7 +107,7 @@ public class GameAdminService {
             List<PChange> pChanges = pChangeAdminRepository.findByTeamUser(teamUser.getUser().getId());
             rollbackGameResult(reqDto, season, teamUser, pChanges);
             // 최근 pchange 지우기
-            if (!pChanges.get(0).getGame().getId().equals(reqDto.getGameId())) {
+            if (!pChanges.get(0).getGame().getId().equals(gameId)) {
                 throw new NotRecentlyGameException();
             }
             pChangeAdminRepository.delete(pChanges.get(0));

--- a/src/main/java/com/gg/server/admin/game/service/GameAdminService.java
+++ b/src/main/java/com/gg/server/admin/game/service/GameAdminService.java
@@ -4,18 +4,24 @@ import com.gg.server.admin.game.dto.GameLogAdminDto;
 import com.gg.server.admin.game.dto.GameLogListAdminResponseDto;
 import com.gg.server.admin.game.data.GameAdminRepository;
 import com.gg.server.admin.game.dto.GameTeamAdminDto;
+import com.gg.server.admin.game.dto.RankGamePPPModifyReqDto;
+import com.gg.server.admin.game.exception.NotRecentlyGameException;
+import com.gg.server.admin.pchange.data.PChangeAdminRepository;
 import com.gg.server.admin.season.data.SeasonAdminRepository;
 import com.gg.server.admin.team.data.TeamAdminRepository;
 import com.gg.server.admin.team.data.TeamUserAdminRepository;
 import com.gg.server.admin.user.data.UserAdminRepository;
 import com.gg.server.domain.game.data.Game;
-import com.gg.server.domain.game.exception.GameNotFoundException;
+import com.gg.server.domain.game.exception.GameNotExistException;
 import com.gg.server.domain.pchange.data.PChange;
 import com.gg.server.domain.pchange.data.PChangeRepository;
 
+import com.gg.server.domain.rank.data.RankRepository;
+import com.gg.server.domain.rank.redis.RankRedisService;
 import com.gg.server.domain.season.data.Season;
 import com.gg.server.domain.season.exception.SeasonNotFoundException;
 import com.gg.server.domain.team.data.Team;
+import com.gg.server.domain.team.data.TeamUser;
 import com.gg.server.domain.user.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.*;
@@ -36,6 +42,9 @@ public class GameAdminService {
     private final SeasonAdminRepository seasonAdminRepository;
     private final UserAdminRepository userAdminRepository;
     private final PChangeRepository pChangeRepository;
+    private final PChangeAdminRepository pChangeAdminRepository;
+    private final RankRedisService rankRedisService;
+    private final RankRepository rankRepository;
 
     @Transactional(readOnly = true)
     public GameLogListAdminResponseDto findAllGamesByAdmin(Pageable pageable) {
@@ -82,5 +91,46 @@ public class GameAdminService {
         int end = Math.min((start + pageable.getPageSize()), gameList.size());
         Page<Game> games = new PageImpl<>(gameList.subList(start, end), pageable, gameList.size());
         return createGameLogAdminDto(games);
+    }
+
+    @Transactional
+    public void rankResultEdit(RankGamePPPModifyReqDto reqDto) {
+        // 게임이 두명 다 가장 마지막 게임인지 확인 (그 game에 해당하는 팀이 맞는지 확인)
+        List<TeamUser> teamUsers = teamUserAdminRepository.findUsersByTeamIdIn(List.of(reqDto.getTeam1Id(), reqDto.getTeam2Id()));
+        Game game = gameAdminRepository.findById(reqDto.getGameId())
+                .orElseThrow(GameNotExistException::new);
+        Season season = seasonAdminRepository.findById(game.getSeason().getId())
+                .orElseThrow(SeasonNotFoundException::new);
+        // pchange 가져와서 rank ppp 이전 값을 가지고 새 점수를 바탕으로 다시 계산
+        for (TeamUser teamUser :
+                teamUsers) {
+            List<PChange> pChanges = pChangeAdminRepository.findByTeamUser(teamUser.getUser().getId());
+            rollbackGameResult(reqDto, season, teamUser, pChanges);
+            // 최근 pchange 지우기
+            if (!pChanges.get(0).getGame().getId().equals(reqDto.getGameId())) {
+                throw new NotRecentlyGameException();
+            }
+            pChangeAdminRepository.delete(pChanges.get(0));
+        }
+        rankRedisService.updateRankRedis(teamUsers, game);
+    }
+
+    private void rollbackGameResult(RankGamePPPModifyReqDto reqDto, Season season, TeamUser teamUser, List<PChange> pChanges) {
+        // pchange ppp도 update
+        // rankredis 에 ppp 다시 반영
+        // rank zset 도 update
+        // 이전 ppp, exp 되돌리기
+        if (pChanges.size() == 1) {
+            rankRedisService.rollbackRank(teamUser, season.getStartPpp(), season.getId());
+            teamUser.getUser().updateExp(0);
+        } else {
+            rankRedisService.rollbackRank(teamUser, pChanges.get(1).getPppResult(), season.getId());
+            teamUser.getUser().updateExp(pChanges.get(1).getExp());
+        }
+        if (teamUser.getTeam().getId().equals(reqDto.getTeam1Id())) {
+            teamUser.getTeam().updateScore(reqDto.getTeam1Score(), reqDto.getTeam1Score() > reqDto.getTeam2Score());
+        } else if (teamUser.getTeam().getId().equals(reqDto.getTeam2Id())) {
+            teamUser.getTeam().updateScore(reqDto.getTeam2Score(), reqDto.getTeam2Score() > reqDto.getTeam1Score());
+        }
     }
 }

--- a/src/main/java/com/gg/server/admin/pchange/data/PChangeAdminRepository.java
+++ b/src/main/java/com/gg/server/admin/pchange/data/PChangeAdminRepository.java
@@ -1,0 +1,7 @@
+package com.gg.server.admin.pchange.data;
+
+import com.gg.server.domain.pchange.data.PChange;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PChangeAdminRepository extends JpaRepository<PChange, Long>, PChangeAdminRepositoryCustom {
+}

--- a/src/main/java/com/gg/server/admin/pchange/data/PChangeAdminRepositoryCustom.java
+++ b/src/main/java/com/gg/server/admin/pchange/data/PChangeAdminRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.gg.server.admin.pchange.data;
+
+import com.gg.server.domain.pchange.data.PChange;
+
+import java.util.List;
+
+public interface PChangeAdminRepositoryCustom {
+    List<PChange> findByTeamUser(Long userId);
+}

--- a/src/main/java/com/gg/server/admin/pchange/data/PChangeAdminRepositoryCustomImpl.java
+++ b/src/main/java/com/gg/server/admin/pchange/data/PChangeAdminRepositoryCustomImpl.java
@@ -1,0 +1,22 @@
+package com.gg.server.admin.pchange.data;
+
+import com.gg.server.domain.pchange.data.PChange;
+import lombok.RequiredArgsConstructor;
+
+import javax.persistence.EntityManager;
+import javax.persistence.LockModeType;
+import java.util.List;
+
+@RequiredArgsConstructor
+public class PChangeAdminRepositoryCustomImpl implements PChangeAdminRepositoryCustom {
+    private final EntityManager em;
+    @Override
+    public List<PChange> findByTeamUser(Long userId) {
+        String query = "SELECT p FROM PChange p WHERE p.user.id = :userId ORDER BY p.createdAt desc";
+        return em.createQuery(query, PChange.class)
+                .setParameter("userId", userId)
+                .setMaxResults(2)
+                .setLockMode(LockModeType.PESSIMISTIC_WRITE)
+                .getResultList();
+    }
+}

--- a/src/main/java/com/gg/server/admin/pchange/exception/PChangeNotExistException.java
+++ b/src/main/java/com/gg/server/admin/pchange/exception/PChangeNotExistException.java
@@ -1,0 +1,10 @@
+package com.gg.server.admin.pchange.exception;
+
+import com.gg.server.global.exception.ErrorCode;
+import com.gg.server.global.exception.custom.NotExistException;
+
+public class PChangeNotExistException extends NotExistException {
+    public PChangeNotExistException() {
+        super(ErrorCode.PCHANGE_NOT_FOUND.getMessage(), ErrorCode.PCHANGE_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/gg/server/admin/team/data/TeamUserAdminRepository.java
+++ b/src/main/java/com/gg/server/admin/team/data/TeamUserAdminRepository.java
@@ -12,4 +12,7 @@ import java.util.List;
 public interface TeamUserAdminRepository extends JpaRepository<TeamUser, Long> {
     @Query("SELECT tu.user FROM TeamUser tu WHERE tu.team.id = :teamId")
     List<User> findUsersByTeamId(@Param("teamId") Long teamId);
+
+    @Query("SELECT tu FROM TeamUser tu, Team t WHERE tu.team.id IN (:teamId) AND t.id = tu.team.id")
+    List<TeamUser> findUsersByTeamIdIn(@Param("teamId") List<Long> teamId);
 }

--- a/src/main/java/com/gg/server/domain/game/service/GameService.java
+++ b/src/main/java/com/gg/server/domain/game/service/GameService.java
@@ -55,7 +55,7 @@ public class GameService {
         if (game.getStatus() != StatusType.WAIT && game.getStatus() != StatusType.LIVE) {
             return false;
         }
-        return updateScore(game, scoreDto, game.getSeason().getId(), userId);
+        return updateScore(game, scoreDto, userId);
     }
 
     @Transactional
@@ -119,8 +119,7 @@ public class GameService {
     }
 
     private void setTeamScore(TeamUser tu, int teamScore, Boolean isWin) {
-        tu.getTeam().inputScore(teamScore);
-        tu.getTeam().setWin(isWin);
+        tu.getTeam().updateScore(teamScore, isWin);
     }
 
     private TeamUser findTeamId(Long teamId, List<TeamUser> teamUsers) {
@@ -132,7 +131,7 @@ public class GameService {
         }
         throw new TeamIdNotMatchException();
     }
-    private Boolean updateScore(Game game, RankResultReqDto scoreDto, Long seasonId, Long userId) {
+    private Boolean updateScore(Game game, RankResultReqDto scoreDto, Long userId) {
         List<TeamUser> teams = teamUserRepository.findAllByGameId(game.getId());
         TeamUser myTeam = findTeamId(scoreDto.getMyTeamId(), teams);
         TeamUser enemyTeam = findTeamId(scoreDto.getEnemyTeamId(), teams);
@@ -143,7 +142,7 @@ public class GameService {
                 setTeamScore(myTeam, scoreDto.getMyTeamScore(), scoreDto.getMyTeamScore() > scoreDto.getEnemyTeamScore());
                 setTeamScore(enemyTeam, scoreDto.getEnemyTeamScore(), scoreDto.getMyTeamScore() < scoreDto.getEnemyTeamScore());
                 expUpdates(game, teams);
-                rankRedisService.updateRankRedis(teams, seasonId, game);
+                rankRedisService.updateRankRedis(teams, game);
             } else {
                 // score 가 일치하지 않다는 에러
                 throw new ScoreNotMatchedException();

--- a/src/main/java/com/gg/server/domain/pchange/data/PChange.java
+++ b/src/main/java/com/gg/server/domain/pchange/data/PChange.java
@@ -41,4 +41,8 @@ public class PChange extends BaseTimeEntity {
         this.pppResult = pppResult;
         this.exp = user.getTotalExp();
     }
+
+    public void updatePPP(Integer ppp) {
+        this.pppResult = ppp;
+    }
 }

--- a/src/main/java/com/gg/server/domain/rank/data/Rank.java
+++ b/src/main/java/com/gg/server/domain/rank/data/Rank.java
@@ -75,13 +75,22 @@ public class Rank extends BaseTimeEntity implements Serializable {
         this.statusMessage = statusMessage;
     }
 
-    public void updatePpp(Integer changePpp) {
+    public void addPpp(Integer changePpp) {
         this.ppp += changePpp;
+    }
+    public void updatePpp(Integer changePpp) {
+        this.ppp = changePpp;
     }
 
     public void modifyUserRank(UserUpdateAdminRequestDto userUpdateAdminRequestDto) {
         this.ppp = userUpdateAdminRequestDto.getPpp();
         this.wins = userUpdateAdminRequestDto.getWins();
         this.losses = userUpdateAdminRequestDto.getLosses();
+    }
+
+    public void modifyUserRank(Integer ppp, int winChange, int lossesChange) {
+        this.ppp = ppp;
+        this.wins -= winChange;
+        this.losses -= lossesChange;
     }
 }

--- a/src/main/java/com/gg/server/domain/rank/redis/RankRedisService.java
+++ b/src/main/java/com/gg/server/domain/rank/redis/RankRedisService.java
@@ -5,6 +5,7 @@ import com.gg.server.domain.game.service.GameService;
 import com.gg.server.domain.pchange.service.PChangeService;
 import com.gg.server.domain.rank.data.Rank;
 import com.gg.server.domain.rank.data.RankRepository;
+import com.gg.server.domain.rank.exception.RankNotFoundException;
 import com.gg.server.domain.team.data.TeamUser;
 import com.gg.server.global.exception.ErrorCode;
 import com.gg.server.global.exception.custom.NotExistException;
@@ -21,23 +22,23 @@ public class RankRedisService {
     private final RankRedisRepository rankRedisRepository;
     private final PChangeService pChangeService;
     private final RankRepository rankRepository;
-    public void updateRankRedis(List<TeamUser> list, Long seasonId, Game game) {
+    public void updateRankRedis(List<TeamUser> list, Game game) {
         // 단식 -> 2명 기준
-        String key = RedisKeyManager.getHashKey(seasonId);
-        String zsetKey = RedisKeyManager.getZSetKey(seasonId);
+        String key = RedisKeyManager.getHashKey(game.getSeason().getId());
+        String zsetKey = RedisKeyManager.getZSetKey(game.getSeason().getId());
         RankRedis myTeam = rankRedisRepository.findRankByUserId(key, list.get(0).getUser().getId());
         RankRedis enemyTeam = rankRedisRepository.findRankByUserId(key, list.get(1).getUser().getId());
         Integer myPPP = myTeam.getPpp();
         Integer enemyPPP = enemyTeam.getPpp();
-        updatePPP(list.get(0), myTeam, list.get(1).getTeam().getScore(), myPPP, enemyPPP, seasonId);
-        updatePPP(list.get(1), enemyTeam, list.get(0).getTeam().getScore(), enemyPPP, myPPP, seasonId);
+        updatePPP(list.get(0), myTeam, list.get(1).getTeam().getScore(), myPPP, enemyPPP, game.getSeason().getId());
+        updatePPP(list.get(1), enemyTeam, list.get(0).getTeam().getScore(), enemyPPP, myPPP, game.getSeason().getId());
         updateRankUser(key, zsetKey, list.get(0).getUser().getId(), myTeam);
         updateRankUser(key, zsetKey, list.get(1).getUser().getId(), enemyTeam);
         pChangeService.addPChange(game, list.get(0).getUser(), myTeam.getPpp());
         pChangeService.addPChange(game, list.get(1).getUser(), enemyTeam.getPpp());
     }
 
-    public void updateRankUser(String hashKey, String zsetKey, Long userId, RankRedis userRank) {
+    private void updateRankUser(String hashKey, String zsetKey, Long userId, RankRedis userRank) {
         rankRedisRepository.updateRankData(hashKey, userId, userRank);
         rankRedisRepository.deleteFromZSet(zsetKey, userId);
         rankRedisRepository.addToZSet(zsetKey, userId, userRank.getPpp());
@@ -50,9 +51,21 @@ public class RankRedisService {
         // rank table 수정
         Rank rank = rankRepository.findByUserIdAndSeasonId(myTeam.getUserId(), seasonId)
                 .orElseThrow(() -> new NotExistException("rank 정보가 없습니다.", ErrorCode.NOT_FOUND));
-        rank.updatePpp(EloRating.pppChange(myPPP, enemyPPP,
+        rank.addPpp(EloRating.pppChange(myPPP, enemyPPP,
                 teamuser.getTeam().getWin(), Math.abs(teamuser.getTeam().getScore() - enemyScore) == 2));
         myTeam.updateRank(rank.getPpp(),
                 win, losses);
+    }
+
+    public void rollbackRank(TeamUser teamUser, int ppp, Long seasonId) {
+        String hashkey = RedisKeyManager.getHashKey(seasonId);
+        RankRedis myTeam = rankRedisRepository.findRankByUserId(hashkey, teamUser.getUser().getId());
+        int win = teamUser.getTeam().getWin() ? myTeam.getWins() - 1 : myTeam.getWins();
+        int losses = !teamUser.getTeam().getWin() ? myTeam.getLosses() - 1: myTeam.getLosses();
+        Rank rank = rankRepository.findByUserIdAndSeasonId(myTeam.getUserId(), seasonId)
+                .orElseThrow(RankNotFoundException::new);
+        rank.updatePpp(ppp);
+        myTeam.updateRank(ppp, win, losses);
+        updateRankUser(hashkey, RedisKeyManager.getZSetKey(seasonId), teamUser.getUser().getId(), myTeam);
     }
 }

--- a/src/main/java/com/gg/server/domain/team/data/Team.java
+++ b/src/main/java/com/gg/server/domain/team/data/Team.java
@@ -36,11 +36,8 @@ public class Team {
         this.win = win;
     }
 
-    public void inputScore(int score) {
+    public void updateScore(int score, Boolean win) {
         this.score = score;
-    }
-
-    public void setWin(Boolean win) {
         this.win = win;
     }
 }

--- a/src/main/java/com/gg/server/domain/user/User.java
+++ b/src/main/java/com/gg/server/domain/user/User.java
@@ -79,4 +79,8 @@ public class User extends BaseTimeEntity implements Serializable {
     public void addExp(int plus) {
         this.totalExp += plus;
     }
+
+    public void updateExp(int beforeExp) {
+        this.totalExp = beforeExp;
+    }
 }

--- a/src/main/java/com/gg/server/global/exception/ErrorCode.java
+++ b/src/main/java/com/gg/server/global/exception/ErrorCode.java
@@ -42,6 +42,7 @@ public enum ErrorCode {
     GAME_DB_NOT_VALID(500, "GM201", "GAME DB NOT CONSISTENCY"),
     SCORE_NOT_MATCHED(400, "GM202", "score 입력이 기존과 다릅니다."),
     GAME_NOT_FOUND(404, "GM101", "GAME 이 존재하지 않습니다."),
+    GAME_NOT_RECENTLY(400, "GM203", "가장 최근 게임이 아닙니다."),
 
     /** match **/
     SLOT_ENROLLED(400, "MA300", "SLOT ALREADY ENROLLED"),
@@ -67,6 +68,7 @@ public enum ErrorCode {
      * PChange
      **/
     PCHANGE_NOT_FOUND(404, "PC100", "PChange 가 존재하지 않습니다."),
+
 
     AWS_S3_ERR(500, "CL001", "AWS S3 Error"),
     AWS_SERVER_ERR(500, "CL002", "AWS Error"),

--- a/src/test/java/com/gg/server/game/GameControllerTest.java
+++ b/src/test/java/com/gg/server/game/GameControllerTest.java
@@ -117,7 +117,7 @@ public class GameControllerTest {
             teams.add(teamUserRepository.save(new TeamUser(team2, user2)));
             System.out.println("===========");
             gameService.expUpdates(game, teams);
-            rankRedisService.updateRankRedis(teams, season.getId(), game);
+            rankRedisService.updateRankRedis(teams, game);
             game = gameRepository.save(new Game(season, StatusType.WAIT, Mode.NORMAL, LocalDateTime.now().minusMinutes(15), LocalDateTime.now()));
             team1 = teamRepository.save(new Team(game, 0, false));
             team2 = teamRepository.save(new Team(game, 0, false));
@@ -143,7 +143,7 @@ public class GameControllerTest {
         teams.add(teamUserRepository.save(new TeamUser(team1, user1)));
         teams.add(teamUserRepository.save(new TeamUser(team2, user2)));
         gameService.expUpdates(game2, teams);
-        rankRedisService.updateRankRedis(teams, season.getId(), game2);
+        rankRedisService.updateRankRedis(teams, game2);
     }
 
     @AfterEach


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - admin 에서 게임 점수 수정 가능한 API 입니다.
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - 먼저 valid 체크 후에 가장 최근의 pchange 두개를 검색하여 RankRedis 와 Rank Table 에 있는 ppp 값을 이전 값으로 되돌림
  - RankRedis 값 update, Zset redis 도 수정
  - Team 에 저장된 게임 점수와 승패 여부 값을 Update
  - PPP 계산 다시 해서 redis 에 반영
