### PR TITLE
[GGBE4-25--receipt] 관리자 거래내역 조회 API 추가

### DIFF
--- a/src/main/java/com/gg/server/admin/receipt/controller/ReceiptAdminController.java
+++ b/src/main/java/com/gg/server/admin/receipt/controller/ReceiptAdminController.java
@@ -23,7 +23,7 @@ public class ReceiptAdminController {
     @GetMapping("/list")
     public ReceiptListResponseDto getReceiptList(@ModelAttribute @Valid PageRequestDto pageRequestDto) {
         Pageable pageable = PageRequest.of(pageRequestDto.getPage() - 1, pageRequestDto.getSize(),
-                Sort.by("purchasedAt").descending());
+                Sort.by("createdAt").descending());
         return receiptAdminService.getAllReceipt(pageable);
     }
 }

--- a/src/main/java/com/gg/server/admin/receipt/controller/ReceiptAdminController.java
+++ b/src/main/java/com/gg/server/admin/receipt/controller/ReceiptAdminController.java
@@ -1,0 +1,29 @@
+package com.gg.server.admin.receipt.controller;
+
+import com.gg.server.admin.receipt.dto.ReceiptListResponseDto;
+import com.gg.server.admin.receipt.service.ReceiptAdminService;
+import com.gg.server.global.dto.PageRequestDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/pingpong/admin/receipt")
+public class ReceiptAdminController {
+    private final ReceiptAdminService receiptAdminService;
+
+    @GetMapping("/list")
+    public ReceiptListResponseDto getReceiptList(@ModelAttribute @Valid PageRequestDto pageRequestDto) {
+        Pageable pageable = PageRequest.of(pageRequestDto.getPage() - 1, pageRequestDto.getSize(),
+                Sort.by("purchasedAt").descending());
+        return receiptAdminService.getAllReceipt(pageable);
+    }
+}

--- a/src/main/java/com/gg/server/admin/receipt/data/ReceiptAdminRepository.java
+++ b/src/main/java/com/gg/server/admin/receipt/data/ReceiptAdminRepository.java
@@ -1,0 +1,10 @@
+package com.gg.server.admin.receipt.data;
+
+import com.gg.server.domain.receipt.data.Receipt;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReceiptAdminRepository extends JpaRepository<Receipt, Long> {
+    Page<Receipt> findAll(Pageable pageable);
+}

--- a/src/main/java/com/gg/server/admin/receipt/dto/ReceiptListResponseDto.java
+++ b/src/main/java/com/gg/server/admin/receipt/dto/ReceiptListResponseDto.java
@@ -1,0 +1,15 @@
+package com.gg.server.admin.receipt.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReceiptListResponseDto {
+    List<ReceiptResponseDto> receiptList;
+    Integer totalPage;
+}

--- a/src/main/java/com/gg/server/admin/receipt/dto/ReceiptResponseDto.java
+++ b/src/main/java/com/gg/server/admin/receipt/dto/ReceiptResponseDto.java
@@ -1,0 +1,33 @@
+package com.gg.server.admin.receipt.dto;
+
+import com.gg.server.domain.item.data.Item;
+import com.gg.server.domain.receipt.data.Receipt;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReceiptResponseDto {
+    private Long receiptId;
+    private LocalDateTime createdAt;
+    private String itemName;
+    private Integer itemPrice;
+    private String purchaserIntraId;
+    private String ownerIntraId;
+    private Enum itemStatusType;
+
+    public ReceiptResponseDto(Receipt receipt) {
+        Item item = receipt.getItem();
+        this.itemName = item.getName();
+        this.itemPrice = item.getPrice() - (item.getPrice() * item.getDiscount() / 100);
+        this.receiptId = receipt.getId();
+        this.createdAt = receipt.getPurchasedAt();
+        this.purchaserIntraId = receipt.getPurchaserIntraId();
+        this.ownerIntraId = receipt.getOwnerIntraId();
+        this.itemStatusType = receipt.getStatus();
+    }
+}

--- a/src/main/java/com/gg/server/admin/receipt/dto/ReceiptResponseDto.java
+++ b/src/main/java/com/gg/server/admin/receipt/dto/ReceiptResponseDto.java
@@ -2,6 +2,7 @@ package com.gg.server.admin.receipt.dto;
 
 import com.gg.server.domain.item.data.Item;
 import com.gg.server.domain.receipt.data.Receipt;
+import com.gg.server.domain.receipt.type.ItemStatus;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -18,16 +19,29 @@ public class ReceiptResponseDto {
     private Integer itemPrice;
     private String purchaserIntraId;
     private String ownerIntraId;
-    private Enum itemStatusType;
+    private ItemStatus itemStatusType;
 
     public ReceiptResponseDto(Receipt receipt) {
         Item item = receipt.getItem();
         this.itemName = item.getName();
         this.itemPrice = item.getPrice() - (item.getPrice() * item.getDiscount() / 100);
         this.receiptId = receipt.getId();
-        this.createdAt = receipt.getPurchasedAt();
+        this.createdAt = receipt.getCreatedAt();
         this.purchaserIntraId = receipt.getPurchaserIntraId();
         this.ownerIntraId = receipt.getOwnerIntraId();
         this.itemStatusType = receipt.getStatus();
+    }
+
+    @Override
+    public String toString() {
+        return "ReceiptResponseDto{" +
+                "receiptId=" + receiptId +
+                ", createdAt=" + createdAt +
+                ", itemName='" + itemName + '\'' +
+                ", itemPrice=" + itemPrice +
+                ", purchaserIntraId='" + purchaserIntraId + '\'' +
+                ", ownerIntraId='" + ownerIntraId + '\'' +
+                ", itemStatusType=" + itemStatusType +
+                '}';
     }
 }

--- a/src/main/java/com/gg/server/admin/receipt/service/ReceiptAdminService.java
+++ b/src/main/java/com/gg/server/admin/receipt/service/ReceiptAdminService.java
@@ -1,0 +1,22 @@
+package com.gg.server.admin.receipt.service;
+
+import com.gg.server.admin.receipt.data.ReceiptAdminRepository;
+import com.gg.server.admin.receipt.dto.ReceiptListResponseDto;
+import com.gg.server.admin.receipt.dto.ReceiptResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ReceiptAdminService {
+    private final ReceiptAdminRepository receiptAdminRepository;
+
+    @Transactional(readOnly = true)
+    public ReceiptListResponseDto getAllReceipt(Pageable pageable) {
+        Page<ReceiptResponseDto> responseDtos = receiptAdminRepository.findAll(pageable).map(ReceiptResponseDto::new);
+        return new ReceiptListResponseDto(responseDtos.getContent(), responseDtos.getTotalPages());
+    }
+}

--- a/src/main/java/com/gg/server/domain/receipt/data/Receipt.java
+++ b/src/main/java/com/gg/server/domain/receipt/data/Receipt.java
@@ -37,8 +37,8 @@ public class Receipt {
     private ItemStatus status;
 
     @NotNull
-    @Column(name = "created_At")
-    private LocalDateTime purchasedAt;
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
 
     public Receipt(Item item, String purchaserIntraId, String ownerIntraId,
                    ItemStatus status, LocalDateTime purchasedAt){
@@ -46,7 +46,7 @@ public class Receipt {
         this.purchaserIntraId = purchaserIntraId;
         this.ownerIntraId = ownerIntraId;
         this.status = status;
-        this.purchasedAt = purchasedAt;
+        this.createdAt = purchasedAt;
     }
 
     @Override
@@ -57,7 +57,7 @@ public class Receipt {
                 ", purchaserIntraId='" + purchaserIntraId + '\'' +
                 ", ownerIntraId='" + ownerIntraId + '\'' +
                 ", status=" + status +
-                ", purchasedAt=" + purchasedAt +
+                ", purchasedAt=" + createdAt +
                 '}';
     }
 

--- a/src/test/java/com/gg/server/admin/receipt/controller/ReceiptAdminControllerTest.java
+++ b/src/test/java/com/gg/server/admin/receipt/controller/ReceiptAdminControllerTest.java
@@ -1,0 +1,62 @@
+package com.gg.server.admin.receipt.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gg.server.admin.receipt.data.ReceiptAdminRepository;
+import com.gg.server.admin.receipt.dto.ReceiptListResponseDto;
+import com.gg.server.admin.receipt.service.ReceiptAdminService;
+import com.gg.server.global.security.jwt.utils.AuthTokenProvider;
+import com.gg.server.utils.TestDataUtils;
+import org.apache.http.HttpHeaders;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class ReceiptAdminControllerTest {
+    @Autowired
+    ReceiptAdminService receiptAdminService;
+    @Autowired
+    ReceiptAdminRepository receiptAdminRepository;
+    @Autowired
+    TestDataUtils testDataUtils;
+    @Autowired
+    ObjectMapper objectMapper;
+    @Autowired
+    AuthTokenProvider tokenProvider;
+    @Autowired
+    MockMvc mockMvc;
+
+    @Test
+    @DisplayName("GET /pingpong/admin/receipt/list")
+    public void getAllReceipt() throws Exception {
+        String accessToken = testDataUtils.getAdminLoginAccessToken();
+        Integer page = 1;
+        Integer size = 20;
+        String url = "/pingpong/admin/receipt/list?page=" + page + "&size=" + size;
+        Pageable pageable = PageRequest.of(page - 1, size, Sort.by("createdAt").descending());
+        String contentAsString = mockMvc.perform(get(url)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        ReceiptListResponseDto expect = receiptAdminService.getAllReceipt(pageable);
+        ReceiptListResponseDto result = objectMapper.readValue(contentAsString, ReceiptListResponseDto.class);
+        assertThat(result.getReceiptList().get(0).getReceiptId()).isEqualTo(expect.getReceiptList().get(0).getReceiptId());
+        assertThat(result.getReceiptList().get(0).getCreatedAt()).isEqualTo(expect.getReceiptList().get(0).getCreatedAt());
+        assertThat(result.getReceiptList().get(0).getItemName()).isEqualTo(expect.getReceiptList().get(0).getItemName());
+        assertThat(result.getReceiptList().get(0).getItemPrice()).isEqualTo(expect.getReceiptList().get(0).getItemPrice());
+    }
+}


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 상품 거래내역 전체 조회 API
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - 관리자페이지에서 전체 거래내역 (receipt) 조회 가능하게 하였습니다.
  - 기존 receipt 엔티티에서 헷갈릴 수 있는 purchasedAt 컬럼을 다른 엔티티와 동일한 createdAt으로 변경하였습니다. (DB는 그대로)
