### PR TITLE
[GGBE4-41--search-user-storage-api] 유저별 아이템 보관함 리스트 조회 API

### DIFF
--- a/src/main/java/com/gg/server/domain/item/controller/ItemController.java
+++ b/src/main/java/com/gg/server/domain/item/controller/ItemController.java
@@ -2,14 +2,21 @@ package com.gg.server.domain.item.controller;
 
 import com.gg.server.domain.item.dto.ItemGiftRequestDto;
 import com.gg.server.domain.item.dto.ItemStoreListResponseDto;
+import com.gg.server.domain.item.dto.UserItemListResponseDto;
+import com.gg.server.domain.item.dto.UserItemPageRequestDto;
 import com.gg.server.domain.item.service.ItemService;
 import com.gg.server.domain.user.dto.UserDto;
 import com.gg.server.global.utils.argumentresolver.Login;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
 
 @RestController
 @RequiredArgsConstructor
@@ -37,4 +44,13 @@ public class ItemController {
         itemService.giftItem(itemId, recipient.getOwnerId(), userDto);
         return new ResponseEntity(HttpStatus.CREATED);
     }
+
+    @GetMapping
+    public UserItemListResponseDto getItemByUser(@ModelAttribute @Valid UserItemPageRequestDto req,
+                                                 @Parameter(hidden = true) @Login UserDto userDto) {
+        Pageable pageable = PageRequest.of(req.getPage() - 1, req.getSize(),
+                Sort.by("createdAt").descending());
+        return itemService.getItemByUser(userDto, pageable);
+    }
+
 }

--- a/src/main/java/com/gg/server/domain/item/data/UserItemRepository.java
+++ b/src/main/java/com/gg/server/domain/item/data/UserItemRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.repository.query.Param;
 
 public interface UserItemRepository extends JpaRepository<Receipt, Long> {
 
-    @Query("select r from Receipt r where r.ownerIntraId = :intraId and (r.status = 'BEFORE' or r.status = 'USING') order by r.createdAt desc")
+    @Query("select r from Receipt r where r.ownerIntraId = :intraId " +
+            "and (r.status = 'BEFORE' or r.status = 'USING' or r.status = 'WAITING') order by r.createdAt desc")
     Page<Receipt> findByOwnerIntraId(@Param("intraId") String intraId, Pageable pageable);
 }

--- a/src/main/java/com/gg/server/domain/item/data/UserItemRepository.java
+++ b/src/main/java/com/gg/server/domain/item/data/UserItemRepository.java
@@ -1,0 +1,14 @@
+package com.gg.server.domain.item.data;
+
+import com.gg.server.domain.receipt.data.Receipt;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface UserItemRepository extends JpaRepository<Receipt, Long> {
+
+    @Query("select r from Receipt r where r.ownerIntraId = :intraId and (r.status = 'BEFORE' or r.status = 'USING') order by r.createdAt desc")
+    Page<Receipt> findByOwnerIntraId(@Param("intraId") String intraId, Pageable pageable);
+}

--- a/src/main/java/com/gg/server/domain/item/dto/UserItemListResponseDto.java
+++ b/src/main/java/com/gg/server/domain/item/dto/UserItemListResponseDto.java
@@ -1,0 +1,19 @@
+package com.gg.server.domain.item.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class UserItemListResponseDto {
+    private List<UserItemResponseDto> storageItemList;
+    private Integer totalPage;
+
+    public UserItemListResponseDto(List<UserItemResponseDto> storageItemList, Integer totalPage){
+        this.storageItemList = storageItemList;
+        this.totalPage = totalPage;
+    }
+
+}

--- a/src/main/java/com/gg/server/domain/item/dto/UserItemPageRequestDto.java
+++ b/src/main/java/com/gg/server/domain/item/dto/UserItemPageRequestDto.java
@@ -1,0 +1,12 @@
+package com.gg.server.domain.item.dto;
+
+import com.gg.server.global.dto.PageRequestDto;
+import lombok.Getter;
+
+@Getter
+public class UserItemPageRequestDto extends PageRequestDto {
+
+    public UserItemPageRequestDto(Integer page, Integer size) {
+        super(page, size);
+    }
+}

--- a/src/main/java/com/gg/server/domain/item/dto/UserItemResponseDto.java
+++ b/src/main/java/com/gg/server/domain/item/dto/UserItemResponseDto.java
@@ -1,0 +1,29 @@
+package com.gg.server.domain.item.dto;
+
+import com.gg.server.domain.item.data.Item;
+import com.gg.server.domain.receipt.data.Receipt;
+import com.gg.server.domain.receipt.type.ItemStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserItemResponseDto {
+    private Long receiptId;
+    private String itemName;
+    private String imageUri;
+    private String purchaserIntra;
+    private ItemStatus itemStatus;
+
+    public UserItemResponseDto(Receipt receipt) {
+        Item item = receipt.getItem();
+        this.receiptId = receipt.getId();
+        this.itemName = item.getName();
+        this.imageUri = item.getImageUri();
+        this.purchaserIntra = receipt.getPurchaserIntraId();
+        this.itemStatus = receipt.getStatus();
+    }
+
+}

--- a/src/main/java/com/gg/server/domain/item/service/ItemService.java
+++ b/src/main/java/com/gg/server/domain/item/service/ItemService.java
@@ -2,8 +2,11 @@ package com.gg.server.domain.item.service;
 
 import com.gg.server.domain.item.data.Item;
 import com.gg.server.domain.item.data.ItemRepository;
+import com.gg.server.domain.item.data.UserItemRepository;
 import com.gg.server.domain.item.dto.ItemStoreListResponseDto;
 import com.gg.server.domain.item.dto.ItemStoreResponseDto;
+import com.gg.server.domain.item.dto.UserItemListResponseDto;
+import com.gg.server.domain.item.dto.UserItemResponseDto;
 import com.gg.server.domain.item.exception.InsufficientGgcoinException;
 import com.gg.server.domain.item.exception.ItemNotFoundException;
 import com.gg.server.domain.item.exception.ItemNotPurchasableException;
@@ -15,6 +18,8 @@ import com.gg.server.domain.user.data.UserRepository;
 import com.gg.server.domain.user.dto.UserDto;
 import com.gg.server.domain.user.exception.UserNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,7 +34,9 @@ public class ItemService {
     private final ItemRepository itemRepository;
     private final ReceiptRepository receiptRepository;
     private final UserRepository userRepository;
+    private final UserItemRepository userItemRepository;
 
+    @Transactional(readOnly = true)
     public ItemStoreListResponseDto getAllItems() {
 
         List<ItemStoreResponseDto> itemStoreListResponseDto = itemRepository.findAllByIsVisible(true)
@@ -108,5 +115,12 @@ public class ItemService {
         Receipt receipt = new Receipt(item, userDto.getIntraId(), ownerId,
                 ItemStatus.BEFORE, LocalDateTime.now());
         receiptRepository.save(receipt);
+    }
+
+    @Transactional(readOnly = true)
+    public UserItemListResponseDto getItemByUser(UserDto userDto, Pageable pageable) {
+        Page<Receipt> receipts = userItemRepository.findByOwnerIntraId(userDto.getIntraId(), pageable);
+        Page<UserItemResponseDto> responseDtos = receipts.map(UserItemResponseDto::new);
+        return new UserItemListResponseDto(responseDtos.getContent(), responseDtos.getTotalPages());
     }
 }

--- a/src/test/java/com/gg/server/domain/item/controller/UserItemResponseControllerTest.java
+++ b/src/test/java/com/gg/server/domain/item/controller/UserItemResponseControllerTest.java
@@ -1,0 +1,49 @@
+package com.gg.server.domain.item.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gg.server.domain.item.service.ItemService;
+import com.gg.server.utils.TestDataUtils;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+public class UserItemResponseControllerTest {
+
+    @Autowired
+    ItemService itemService;
+
+    @Autowired
+    TestDataUtils testDataUtils;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Test
+    @DisplayName("GET /pingpong/items?page=1&size=20")
+    public void getItemByUser() throws Exception {
+        String accessToken = testDataUtils.getLoginAccessToken();
+
+        Integer page = 1;
+        Integer size = 20;
+
+        String url = "/pingpong/items?page=" + page + "&size=" + size;
+
+        mockMvc.perform(get(url)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+    }
+}


### PR DESCRIPTION
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 유저가 자신의 아이템 보관함에서 아이템 리스트를 조회하는 API 입니다.
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - 조회 시점에 @Login을 통해 전달 받은 유저 정보 중 intraId를 통해, intraId가 owner인 receipt 내역들을 가져옵니다.
  - /pingpong/items?page=${page}&size=${size}처럼 명시된 바와 같이, 각각 page와 size를 조회 시 받아야 합니다
  - 아이템 보관함을 최신순으로 정렬하였습니다
  - 상점 아이템 조회, 유저별 아이템 보관함 조회. 이상 2개 GET 항목에 대해 service에서 @Transactional(readOnly = true) 로 수정하였습니다
 ## ✅ 변경로직 <!-- 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
  -
