### PR TITLE
[GGBE4-41--search-user-storage-api] 유저별 아이템 보관함 조회에 itemType도 추가

### DIFF
--- a/src/main/java/com/gg/server/domain/item/dto/UserItemResponseDto.java
+++ b/src/main/java/com/gg/server/domain/item/dto/UserItemResponseDto.java
@@ -1,6 +1,7 @@
 package com.gg.server.domain.item.dto;
 
 import com.gg.server.domain.item.data.Item;
+import com.gg.server.domain.item.type.ItemType;
 import com.gg.server.domain.receipt.data.Receipt;
 import com.gg.server.domain.receipt.type.ItemStatus;
 import lombok.AllArgsConstructor;
@@ -16,6 +17,7 @@ public class UserItemResponseDto {
     private String imageUri;
     private String purchaserIntra;
     private ItemStatus itemStatus;
+    private ItemType itemType;
 
     public UserItemResponseDto(Receipt receipt) {
         Item item = receipt.getItem();
@@ -24,6 +26,7 @@ public class UserItemResponseDto {
         this.imageUri = item.getImageUri();
         this.purchaserIntra = receipt.getPurchaserIntraId();
         this.itemStatus = receipt.getStatus();
+        this.itemType = item.getType();
     }
 
 }


### PR DESCRIPTION

 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 유저별 아이템 보관함 조회 API에 itemType 추가
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - 
 ## ✅ 변경로직 <!-- 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
  - 기존 로직은 동일하며, Dto에 itemType하나만 추가했습니다
  - API 결과물에 이제 itemType도 추가됩니다
