### PR TITLE
[fix] 점수 입력 시 game table에 배타락 추가

### DIFF
--- a/src/main/java/com/gg/server/domain/game/data/GameRepository.java
+++ b/src/main/java/com/gg/server/domain/game/data/GameRepository.java
@@ -7,11 +7,13 @@ import java.time.LocalDateTime;
 import java.util.Optional;
 
 import com.gg.server.domain.team.dto.GameUser;
+import javax.persistence.LockModeType;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import com.gg.server.domain.game.dto.GameTeamUser;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -69,4 +71,7 @@ public interface GameRepository extends JpaRepository<Game, Long>, GameRepositor
             "team t, team_user tu, user u " +
             "WHERE g.id=t.game_id AND t.id = tu.team_id AND tu.user_id=u.id AND g.status = 'BEFORE'", nativeQuery = true)
     List<GameUser> findAllByStartTimeLessThanEqual(@Param("time") LocalDateTime time);
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query(value = "SELECT g FROM Game g WHERE g.id=:gamdId")
+    Optional<Game> findWithPessimisticLockById(@Param("gameId") Long gameId);
 }

--- a/src/main/java/com/gg/server/domain/game/service/GameService.java
+++ b/src/main/java/com/gg/server/domain/game/service/GameService.java
@@ -60,7 +60,8 @@ public class GameService {
     })
     public Boolean createRankResult(RankResultReqDto scoreDto, Long userId) {
         // 현재 게임 id
-        Game game = gameFindService.findByGameId(scoreDto.getGameId());
+        Game game = gameRepository.findWithPessimisticLockById(scoreDto.getGameId())
+                .orElseThrow(GameNotExistException::new);
         if (game.getStatus() != StatusType.WAIT && game.getStatus() != StatusType.LIVE) {
             return false;
         }


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 점수 입력 시 Service 메소드에 synchronized 가 되어있음에도 불구하고 insert 가 두번 되는 문제가 있어서 수정함
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - 점수 입력 시 Game 상태 체크를 위해 gameId 를 가지고 조회하는데, game Id 조회 시 배타락을 걸어 다른 트랜잭션에서 읽기 및 쓰기 작업을 제한함
