### PR TITLE
[GGBE4-57--profile-image-delete-api] 유저 프로필 이미지 강제 삭제(관리자)

### DIFF
--- a/src/main/java/com/gg/server/admin/user/controller/UserAdminController.java
+++ b/src/main/java/com/gg/server/admin/user/controller/UserAdminController.java
@@ -62,4 +62,10 @@ public class UserAdminController {
 
         return new ResponseEntity(HttpStatus.NO_CONTENT);
     }
+
+    @DeleteMapping("/{intraId}")
+    public ResponseEntity deleteUserProfileImage(@PathVariable String intraId) {
+        userAdminService.deleteUserProfileImage(intraId);
+        return new ResponseEntity(HttpStatus.NO_CONTENT);
+    }
 }

--- a/src/main/java/com/gg/server/admin/user/data/UserImageAdminRepository.java
+++ b/src/main/java/com/gg/server/admin/user/data/UserImageAdminRepository.java
@@ -1,0 +1,11 @@
+package com.gg.server.admin.user.data;
+
+import com.gg.server.domain.user.data.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import com.gg.server.domain.user.data.UserImage;
+
+import java.util.Optional;
+
+public interface UserImageAdminRepository extends JpaRepository<UserImage, Long>{
+    Optional<UserImage> findTopByUserAndIsDeletedOrderByIdDesc(User user, Boolean isDeleted);
+}

--- a/src/main/java/com/gg/server/admin/user/service/UserAdminService.java
+++ b/src/main/java/com/gg/server/admin/user/service/UserAdminService.java
@@ -2,6 +2,7 @@ package com.gg.server.admin.user.service;
 import com.gg.server.admin.rank.service.RankRedisAdminService;
 import com.gg.server.admin.season.data.SeasonAdminRepository;
 import com.gg.server.admin.user.data.UserAdminRepository;
+import com.gg.server.admin.user.data.UserImageAdminRepository;
 import com.gg.server.admin.user.dto.UserDetailAdminResponseDto;
 import com.gg.server.admin.user.dto.UserSearchAdminDto;
 import com.gg.server.admin.user.dto.UserSearchAdminResponseDto;
@@ -20,7 +21,6 @@ import com.gg.server.domain.user.data.UserImage;
 import com.gg.server.domain.user.data.UserImageRepository;
 import com.gg.server.domain.user.exception.UserNotFoundException;
 import com.gg.server.domain.user.service.UserFindService;
-import com.gg.server.domain.user.service.UserService;
 import com.gg.server.global.utils.aws.AsyncNewUserImageUploader;
 import lombok.AllArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -45,7 +45,7 @@ public class UserAdminService {
     private final RankRedisAdminService rankRedisAdminService;
     private final AsyncNewUserImageUploader asyncNewUserImageUploader;
     private final UserFindService userFindService;
-    private final UserImageRepository userImageRepository;
+    private final UserImageAdminRepository userImageAdminRepository;
 
     @Transactional(readOnly = true)
     public UserSearchAdminResponseDto searchAll(Pageable pageable) {
@@ -119,7 +119,14 @@ public class UserAdminService {
     }
 
     public String getUserImageToString(User user) {
-        UserImage userImage = userImageRepository.findTopByUserAndIsDeletedOrderByIdDesc(user, false).orElse(null);
+        UserImage userImage = userImageAdminRepository.findTopByUserAndIsDeletedOrderByIdDesc(user, false).orElse(null);
         return userImage.toString();
+    }
+
+    @Transactional
+    public void deleteUserProfileImage(String intraId) {
+        User user = userAdminRepository.findByIntraId(intraId).orElseThrow(UserNotFoundException::new);
+        UserImage userImage = userImageAdminRepository.findTopByUserAndIsDeletedOrderByIdDesc(user, false).orElseThrow(UserNotFoundException::new);
+        userImage.setIsDeleted(true);
     }
 }

--- a/src/main/java/com/gg/server/domain/user/data/UserImage.java
+++ b/src/main/java/com/gg/server/domain/user/data/UserImage.java
@@ -4,6 +4,7 @@ import com.sun.istack.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
@@ -12,6 +13,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @Entity
 @Getter
+@Setter
 public class UserImage {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/gg/server/domain/user/data/UserImage.java
+++ b/src/main/java/com/gg/server/domain/user/data/UserImage.java
@@ -13,7 +13,6 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @Entity
 @Getter
-@Setter
 public class UserImage {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -33,6 +32,7 @@ public class UserImage {
     private LocalDateTime createdAt;
 
     @NotNull
+    @Setter
     @Column(name = "is_deleted")
     private Boolean isDeleted;
 


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - admin에서 부적절한 유저 이미지를 삭제하는 api 입니다
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - admin에 새로운 userImageAdminRepository를 만들어서 isDeleted 열을 setter로 수정하였습니다.
 ## ✅ 변경로직 <!-- 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
  -
