### PR TITLE
[GGBE4-42--get-user-image-list-api] 유저 이미지 변경 내역 조회(관리자)

### DIFF
--- a/src/main/java/com/gg/server/admin/user/controller/UserAdminController.java
+++ b/src/main/java/com/gg/server/admin/user/controller/UserAdminController.java
@@ -1,11 +1,9 @@
 package com.gg.server.admin.user.controller;
 
-import com.gg.server.admin.user.dto.UserDetailAdminResponseDto;
-import com.gg.server.admin.user.dto.UserSearchAdminRequestDto;
-import com.gg.server.admin.user.dto.UserSearchAdminResponseDto;
-import com.gg.server.admin.user.dto.UserUpdateAdminRequestDto;
+import com.gg.server.admin.user.dto.*;
 import com.gg.server.admin.user.service.UserAdminService;
 import com.gg.server.domain.rank.exception.RankUpdateException;
+import com.gg.server.domain.user.dto.UserImageResponseDto;
 import com.gg.server.domain.user.exception.UserImageLargeException;
 import com.gg.server.domain.user.exception.UserImageTypeException;
 import com.gg.server.global.dto.PageRequestDto;
@@ -67,5 +65,14 @@ public class UserAdminController {
     public ResponseEntity deleteUserProfileImage(@PathVariable String intraId) {
         userAdminService.deleteUserProfileImage(intraId);
         return new ResponseEntity(HttpStatus.NO_CONTENT);
+    }
+
+    @GetMapping("/delete-list")
+    public ResponseEntity<UserImageListAdminResponseDto> getUserImageDeleteList(@ModelAttribute @Valid PageRequestDto pageRequestDto) {
+        Pageable pageable = PageRequest.of(pageRequestDto.getPage() - 1,
+                pageRequestDto.getSize(),
+                Sort.by("createdAt").descending());
+        return ResponseEntity.ok()
+                .body(userAdminService.getUserImageDeleteList(pageable));
     }
 }

--- a/src/main/java/com/gg/server/admin/user/controller/UserAdminController.java
+++ b/src/main/java/com/gg/server/admin/user/controller/UserAdminController.java
@@ -79,8 +79,7 @@ public class UserAdminController {
     @GetMapping("/images")
     public ResponseEntity<UserImageListAdminResponseDto> getUserImageList(@ModelAttribute @Valid PageRequestDto pageRequestDto) {
         Pageable pageable = PageRequest.of(pageRequestDto.getPage() - 1,
-                pageRequestDto.getSize(),
-                Sort.by("id").descending());
+                pageRequestDto.getSize());
         return ResponseEntity.ok()
                 .body(userAdminService.getUserImageList(pageable));
     }

--- a/src/main/java/com/gg/server/admin/user/controller/UserAdminController.java
+++ b/src/main/java/com/gg/server/admin/user/controller/UserAdminController.java
@@ -71,8 +71,17 @@ public class UserAdminController {
     public ResponseEntity<UserImageListAdminResponseDto> getUserImageDeleteList(@ModelAttribute @Valid PageRequestDto pageRequestDto) {
         Pageable pageable = PageRequest.of(pageRequestDto.getPage() - 1,
                 pageRequestDto.getSize(),
-                Sort.by("createdAt").descending());
+                Sort.by("id").descending());
         return ResponseEntity.ok()
                 .body(userAdminService.getUserImageDeleteList(pageable));
+    }
+
+    @GetMapping("/images")
+    public ResponseEntity<UserImageListAdminResponseDto> getUserImageList(@ModelAttribute @Valid PageRequestDto pageRequestDto) {
+        Pageable pageable = PageRequest.of(pageRequestDto.getPage() - 1,
+                pageRequestDto.getSize(),
+                Sort.by("id").descending());
+        return ResponseEntity.ok()
+                .body(userAdminService.getUserImageList(pageable));
     }
 }

--- a/src/main/java/com/gg/server/admin/user/data/UserImageAdminRepository.java
+++ b/src/main/java/com/gg/server/admin/user/data/UserImageAdminRepository.java
@@ -6,10 +6,16 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import com.gg.server.domain.user.data.UserImage;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
 public interface UserImageAdminRepository extends JpaRepository<UserImage, Long>{
     Optional<UserImage> findTopByUserAndIsDeletedOrderByIdDesc(User user, Boolean isDeleted);
     Page<UserImage> findAllByIsDeleted(Pageable pageable, Boolean isDeleted);
+
+    @Query(value = "SELECT * FROM user_image WHERE id NOT IN (" +
+            "SELECT MIN(id) FROM user_image GROUP BY user_id" +
+            ") ORDER BY id DESC", nativeQuery = true)
+    Page<UserImage> findChanged(Pageable pageable);
 }

--- a/src/main/java/com/gg/server/admin/user/data/UserImageAdminRepository.java
+++ b/src/main/java/com/gg/server/admin/user/data/UserImageAdminRepository.java
@@ -1,6 +1,9 @@
 package com.gg.server.admin.user.data;
 
+import com.gg.server.admin.user.dto.UserImageAdminDto;
 import com.gg.server.domain.user.data.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import com.gg.server.domain.user.data.UserImage;
 
@@ -8,4 +11,5 @@ import java.util.Optional;
 
 public interface UserImageAdminRepository extends JpaRepository<UserImage, Long>{
     Optional<UserImage> findTopByUserAndIsDeletedOrderByIdDesc(User user, Boolean isDeleted);
+    Page<UserImage> findAllByIsDeleted(Pageable pageable, Boolean isDeleted);
 }

--- a/src/main/java/com/gg/server/admin/user/dto/UserImageAdminDto.java
+++ b/src/main/java/com/gg/server/admin/user/dto/UserImageAdminDto.java
@@ -1,0 +1,27 @@
+package com.gg.server.admin.user.dto;
+
+import com.gg.server.domain.user.data.UserImage;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserImageAdminDto {
+    Long id;
+    Long userId;
+    String imageUri;
+    LocalDateTime createdAt;
+    Boolean isDeleted;
+
+    public UserImageAdminDto(UserImage userImage) {
+        this.id = userImage.getId();
+        this.userId = userImage.getUser().getId();
+        this.imageUri = userImage.getImageUri();
+        this.createdAt = userImage.getCreatedAt();
+        this.isDeleted = userImage.getIsDeleted();
+    }
+}

--- a/src/main/java/com/gg/server/admin/user/dto/UserImageListAdminResponseDto.java
+++ b/src/main/java/com/gg/server/admin/user/dto/UserImageListAdminResponseDto.java
@@ -1,0 +1,16 @@
+package com.gg.server.admin.user.dto;
+
+import com.gg.server.admin.coin.dto.CoinPolicyAdminResponseDto;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserImageListAdminResponseDto {
+    private List<UserImageAdminDto> userImageList;
+    private int totalPage;
+}

--- a/src/main/java/com/gg/server/admin/user/service/UserAdminService.java
+++ b/src/main/java/com/gg/server/admin/user/service/UserAdminService.java
@@ -3,10 +3,7 @@ import com.gg.server.admin.rank.service.RankRedisAdminService;
 import com.gg.server.admin.season.data.SeasonAdminRepository;
 import com.gg.server.admin.user.data.UserAdminRepository;
 import com.gg.server.admin.user.data.UserImageAdminRepository;
-import com.gg.server.admin.user.dto.UserDetailAdminResponseDto;
-import com.gg.server.admin.user.dto.UserSearchAdminDto;
-import com.gg.server.admin.user.dto.UserSearchAdminResponseDto;
-import com.gg.server.admin.user.dto.UserUpdateAdminRequestDto;
+import com.gg.server.admin.user.dto.*;
 import com.gg.server.domain.rank.data.Rank;
 import com.gg.server.domain.rank.data.RankRepository;
 import com.gg.server.domain.rank.exception.RankNotFoundException;
@@ -18,7 +15,6 @@ import com.gg.server.domain.season.data.Season;
 import com.gg.server.domain.season.exception.SeasonNotFoundException;
 import com.gg.server.domain.user.data.User;
 import com.gg.server.domain.user.data.UserImage;
-import com.gg.server.domain.user.data.UserImageRepository;
 import com.gg.server.domain.user.exception.UserNotFoundException;
 import com.gg.server.domain.user.service.UserFindService;
 import com.gg.server.global.utils.aws.AsyncNewUserImageUploader;
@@ -128,5 +124,13 @@ public class UserAdminService {
         User user = userAdminRepository.findByIntraId(intraId).orElseThrow(UserNotFoundException::new);
         UserImage userImage = userImageAdminRepository.findTopByUserAndIsDeletedOrderByIdDesc(user, false).orElseThrow(UserNotFoundException::new);
         userImage.setIsDeleted(true);
+    }
+
+    @Transactional(readOnly = true)
+    public UserImageListAdminResponseDto getUserImageDeleteList(Pageable pageable) {
+        Page<UserImage> userImagePage = userImageAdminRepository.findAllByIsDeleted(pageable, true);
+        Page<UserImageAdminDto> userImageAdminDto = userImagePage.map(UserImageAdminDto::new);
+
+        return new UserImageListAdminResponseDto(userImageAdminDto.getContent(), userImageAdminDto.getTotalPages());
     }
 }

--- a/src/main/java/com/gg/server/admin/user/service/UserAdminService.java
+++ b/src/main/java/com/gg/server/admin/user/service/UserAdminService.java
@@ -133,4 +133,12 @@ public class UserAdminService {
 
         return new UserImageListAdminResponseDto(userImageAdminDto.getContent(), userImageAdminDto.getTotalPages());
     }
+
+    @Transactional(readOnly = true)
+    public UserImageListAdminResponseDto getUserImageList(Pageable pageable) {
+        Page<UserImage> userImagePage = userImageAdminRepository.findChanged(pageable);
+        Page<UserImageAdminDto> userImageAdminDto = userImagePage.map(UserImageAdminDto::new);
+
+        return new UserImageListAdminResponseDto(userImageAdminDto.getContent(), userImageAdminDto.getTotalPages());
+    }
 }

--- a/src/test/java/com/gg/server/admin/user/controller/UserAdminControllerTest.java
+++ b/src/test/java/com/gg/server/admin/user/controller/UserAdminControllerTest.java
@@ -3,9 +3,7 @@ package com.gg.server.admin.user.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.gg.server.admin.user.data.UserAdminRepository;
 import com.gg.server.admin.user.data.UserImageAdminRepository;
-import com.gg.server.admin.user.dto.UserDetailAdminResponseDto;
-import com.gg.server.admin.user.dto.UserSearchAdminDto;
-import com.gg.server.admin.user.dto.UserSearchAdminResponseDto;
+import com.gg.server.admin.user.dto.*;
 import com.gg.server.admin.user.service.UserAdminService;
 import com.gg.server.domain.user.data.User;
 import com.gg.server.domain.user.data.UserImage;
@@ -169,5 +167,30 @@ class UserAdminControllerTest {
 
         UserImage CurrentUserImage = userImageAdminRepository.findTopByUserAndIsDeletedOrderByIdDesc(user, false).orElseThrow(UserNotFoundException::new);
         Assertions.assertThat(PrevUserImage.getId()).isNotEqualTo(CurrentUserImage.getId());
+    }
+
+    @Test
+    @DisplayName("GET /pingpong/admin/users/delete-list")
+    @Transactional
+    public void getUserImageDeleteListTest() throws Exception{
+        //given
+        String accessToken = testDataUtils.getAdminLoginAccessToken();
+        Long userId = tokenProvider.getUserIdFromAccessToken(accessToken);
+        int page = 1;
+        int size = 30;
+        String url = "/pingpong/admin/users/delete-list?page=1";
+
+        //when
+        //200 성공
+        String contentAsString = mockMvc.perform(get(url).header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        UserImageListAdminResponseDto actureResponse = objectMapper.readValue(contentAsString, UserImageListAdminResponseDto.class);
+
+        //then
+        //각 유저의 이미지가 삭제된 이미지인지 확인
+        List<UserImageAdminDto> actureUserImageList = actureResponse.getUserImageList();
+        for (UserImageAdminDto userImageDto : actureUserImageList)
+            Assertions.assertThat(userImageDto.getIsDeleted()).isEqualTo(true);
     }
 }

--- a/src/test/java/com/gg/server/admin/user/controller/UserAdminControllerTest.java
+++ b/src/test/java/com/gg/server/admin/user/controller/UserAdminControllerTest.java
@@ -28,6 +28,7 @@ import javax.transaction.Transactional;
 
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -192,5 +193,25 @@ class UserAdminControllerTest {
         List<UserImageAdminDto> actureUserImageList = actureResponse.getUserImageList();
         for (UserImageAdminDto userImageDto : actureUserImageList)
             Assertions.assertThat(userImageDto.getIsDeleted()).isEqualTo(true);
+    }
+
+    @Test
+    @DisplayName("GET /pingpong/admin/users/images")
+    @Transactional
+    public void getUserImageListTest() throws Exception{
+        //given
+        String accessToken = testDataUtils.getAdminLoginAccessToken();
+        String url = "/pingpong/admin/users/images?page=1";
+
+        //when
+        //200 성공
+        String contentAsString = mockMvc.perform(get(url).header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+
+        //then
+        //각 유저의 이미지가 삭제된 이미지인지 확인
+        UserImageListAdminResponseDto actureResponse = objectMapper.readValue(contentAsString, UserImageListAdminResponseDto.class);
+        assertThat(actureResponse.getUserImageList().size()).isEqualTo(3);
     }
 }


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 모든 유저의 이미지 변경내역을 조회하는 api입니다.
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - 각 유저의 처음 인트라넷 사진을 제외한 역대 이미지 내역을 보여주는 api 입니다.
  - 직접 쿼리문으로 유저별 min(id)를 group by 해서 포함되지 않는 열만 return하도록 했습니다!
 ## ✅ 변경로직 <!-- 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
  -
