### PR TITLE
[GGBE4-70-fix-season_outcode]현재 시즌 수정시 204가 아닌 403반환 수정

### DIFF
--- a/src/main/java/com/gg/server/admin/season/service/SeasonAdminService.java
+++ b/src/main/java/com/gg/server/admin/season/service/SeasonAdminService.java
@@ -83,6 +83,9 @@ public class SeasonAdminService {
         Season season = seasonAdminRepository.findById(seasonId)
                 .orElseThrow(() -> new SeasonNotFoundException());
 
+        if (LocalDateTime.now().isAfter(season.getStartTime()))
+            throw new SeasonForbiddenException();
+
         if (LocalDateTime.now().isBefore(season.getStartTime())) {
             detach(season);
             season.setSeasonName(updateDto.getSeasonName());

--- a/src/test/java/com/gg/server/admin/season/SeasonAdminControllerTest.java
+++ b/src/test/java/com/gg/server/admin/season/SeasonAdminControllerTest.java
@@ -200,4 +200,28 @@ class SeasonAdminControllerTest {
         assertThat(seasonAdminRepository.findById(dbSeasonId).get().getSeasonName())
                 .isEqualTo(seasonUpdateRequestDto.getSeasonName());
     }
+
+    @Test
+    @DisplayName("Fail[Put]/pingpong/admin/seasons/{seasonId}")
+    void failUpdateSeasons() throws Exception {//현재 시즌을 변경할 때 400번대 상태코드 반환
+        String accessToken = testDataUtils.getAdminLoginAccessToken();
+        Long userId = tokenProvider.getUserIdFromAccessToken(accessToken);
+
+        Long nowSeasonId = seasonAdminRepository.findCurrentSeason(LocalDateTime.now()).get().getId();
+        SeasonUpdateRequestDto seasonUpdateRequestDto = new SeasonUpdateRequestDto(
+                "putSeasonTestName",
+                LocalDateTime.now().plusHours(25),
+                1000,
+                500);
+
+        String content = objectMapper.writeValueAsString(seasonUpdateRequestDto);
+
+        String contentAsString = mockMvc.perform(MockMvcRequestBuilders.put("/pingpong/admin/seasons/" + nowSeasonId)
+                        .content(content)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().is4xxClientError())//403반환
+                .andReturn().getResponse().getContentAsString();
+
+    }
 }


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 이전 기수에서 현재시즌에 대한 수정 요청시 수정 없이 204 반환(사유: 관리자 실수가 없을 것이라 가정 및 판단)
  - 이번 기수에서 400번 반환으로 수정 요청(원래 이게 맞는 것이긴 함, 과거의 나는 대체....)
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - 수정 작업 요청시 변동되는 시즌의 시작시간이 과거이면 403 반환
  - 시즌 생성 및 삭제는 체크 함수에서 이미 걸러냄, 수정만 if문 안에서  체크해 미래 시즌인지 확인하는 과정에서 예외처리를 하지 않음
