### PR TITLE
[GGBE4-77--admin-update-coin-api] 관리자 코인 수정 api 구현

### DIFF
--- a/src/main/java/com/gg/server/admin/coin/controller/CoinAdminController.java
+++ b/src/main/java/com/gg/server/admin/coin/controller/CoinAdminController.java
@@ -1,0 +1,21 @@
+package com.gg.server.admin.coin.controller;
+
+import com.gg.server.admin.coin.dto.CoinUpdateRequestDto;
+import com.gg.server.admin.coin.service.CoinAdminService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("pingpong/admin/coin")
+public class CoinAdminController {
+    private final CoinAdminService coinAdminService;
+
+    @PutMapping(value = "")
+    public ResponseEntity updateUserCoin(@RequestBody CoinUpdateRequestDto coinUpdateRequestDto) {
+        coinAdminService.updateUserCoin(coinUpdateRequestDto);
+        return new ResponseEntity(HttpStatus.NO_CONTENT);
+    }
+}

--- a/src/main/java/com/gg/server/admin/coin/controller/CoinAdminController.java
+++ b/src/main/java/com/gg/server/admin/coin/controller/CoinAdminController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.*;
 public class CoinAdminController {
     private final CoinAdminService coinAdminService;
 
-    @PutMapping(value = "")
+    @PutMapping()
     public ResponseEntity updateUserCoin(@RequestBody CoinUpdateRequestDto coinUpdateRequestDto) {
         coinAdminService.updateUserCoin(coinUpdateRequestDto);
         return new ResponseEntity(HttpStatus.NO_CONTENT);

--- a/src/main/java/com/gg/server/admin/coin/dto/CoinUpdateRequestDto.java
+++ b/src/main/java/com/gg/server/admin/coin/dto/CoinUpdateRequestDto.java
@@ -1,0 +1,19 @@
+package com.gg.server.admin.coin.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class CoinUpdateRequestDto {
+    @NotNull(message = "intraId는 null이 될 수 없습니다.")
+    private String intraId;
+    @NotNull(message = "change는 null이 될 수 없습니다.")
+    private int change;
+    @NotNull(message = "content는 null이 될 수 없습니다.")
+    private String content;
+}

--- a/src/main/java/com/gg/server/admin/coin/service/CoinAdminService.java
+++ b/src/main/java/com/gg/server/admin/coin/service/CoinAdminService.java
@@ -1,0 +1,25 @@
+package com.gg.server.admin.coin.service;
+
+import com.gg.server.admin.coin.dto.CoinUpdateRequestDto;
+import com.gg.server.domain.coin.data.CoinHistory;
+import com.gg.server.domain.coin.service.CoinHistoryService;
+import com.gg.server.domain.user.data.User;
+import com.gg.server.domain.user.data.UserRepository;
+import com.gg.server.domain.user.exception.UserNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CoinAdminService {
+    private final UserRepository userRepository;
+    private final CoinHistoryService coinHistoryService;
+
+    @Transactional
+    public void updateUserCoin(CoinUpdateRequestDto coinUpdateRequestDto) {
+        User user = userRepository.findByIntraId(coinUpdateRequestDto.getIntraId()).orElseThrow(() -> new UserNotFoundException());
+        user.addGgCoin(coinUpdateRequestDto.getChange());
+        coinHistoryService.addCoinHistory(new CoinHistory(user, coinUpdateRequestDto.getContent(), coinUpdateRequestDto.getChange()));
+    }
+}

--- a/src/main/java/com/gg/server/domain/coin/service/CoinHistoryService.java
+++ b/src/main/java/com/gg/server/domain/coin/service/CoinHistoryService.java
@@ -26,29 +26,29 @@ public class CoinHistoryService {
 
     @Transactional
     public void addPurchaseItemCoinHistory(User user, Item item, Integer price) {
-        addCoinHistory(new CoinHistory(user, item.getName()+ " 구매", price*(-1)));
+        addCoinHistory(new CoinHistory(user, item.getName() + " 구매", price * (-1)));
     }
 
     @Transactional
     public void addGiftItemCoinHistory(User user, User giftTarget, Item item, Integer price) {
-        addCoinHistory(new CoinHistory(user, giftTarget.getIntraId() + "에게 " + item.getName()+ " 선물", price*(-1)));
+        addCoinHistory(new CoinHistory(user, giftTarget.getIntraId() + "에게 " + item.getName() + " 선물", price * (-1)));
     }
 
     @Transactional
-    public void addNormalCoin(User user){
+    public void addNormalCoin(User user) {
         int amount = coinPolicyRepository.findTopByOrderByCreatedAtDesc().getNormal();
         addCoinHistory(new CoinHistory(user, HistoryType.NORMAL.getHistory(), amount));
     }
 
     @Transactional
-    public int addRankWinCoin(User user){
+    public int addRankWinCoin(User user) {
         int amount = coinPolicyRepository.findTopByOrderByCreatedAtDesc().getRankWin();
         addCoinHistory(new CoinHistory(user, HistoryType.RANKWIN.getHistory(), amount));
         return amount;
     }
 
     @Transactional
-    public int addRankLoseCoin(User user){
+    public int addRankLoseCoin(User user) {
         int amount = coinPolicyRepository.findTopByOrderByCreatedAtDesc().getRankLose();
         if (amount == 0)
             return amount;
@@ -64,7 +64,7 @@ public class CoinHistoryService {
                 user, HistoryType.ATTENDANCECOIN.getHistory(), startOfDay, endOfDay);
     }
 
-    private void addCoinHistory(CoinHistory coinHistory){
+    public void addCoinHistory(CoinHistory coinHistory) {
         coinHistoryRepository.save(coinHistory);
     }
 

--- a/src/test/java/com/gg/server/admin/coin/controller/CoinAdminControllerTest.java
+++ b/src/test/java/com/gg/server/admin/coin/controller/CoinAdminControllerTest.java
@@ -1,0 +1,58 @@
+package com.gg.server.admin.coin.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gg.server.admin.coin.dto.CoinUpdateRequestDto;
+import com.gg.server.domain.user.data.UserRepository;
+import com.gg.server.global.security.jwt.utils.AuthTokenProvider;
+import com.gg.server.utils.TestDataUtils;
+import lombok.RequiredArgsConstructor;
+import org.apache.http.HttpHeaders;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@RequiredArgsConstructor
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class CoinAdminControllerTest {
+    @Autowired
+    TestDataUtils testDataUtils;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Autowired
+    AuthTokenProvider tokenProvider;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Test
+    @DisplayName("PUT /pingpong/admin/coin")
+    public void updateCoinTest() throws Exception {
+        String accessToken = testDataUtils.getAdminLoginAccessToken();
+        Long userId = tokenProvider.getUserIdFromAccessToken(accessToken);
+        String creatorId = userRepository.getById(userId).getIntraId();
+        int beforeCoin = userRepository.getById(userId).getGgCoin();
+        int changeCoin = 10;
+        CoinUpdateRequestDto coinUpdateRequestDto = new CoinUpdateRequestDto(creatorId, changeCoin, "관리자 코인 지급 테스트");
+        mockMvc.perform(put("/pingpong/admin/coin").header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(coinUpdateRequestDto)))
+                .andExpect(status().isNoContent());
+        Assertions.assertThat(userRepository.getById(userId).getGgCoin()).isEqualTo(beforeCoin + changeCoin);
+    }
+}


### PR DESCRIPTION

 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 관리자 코인 수정 api 구현
  - 코인 내역에 저장
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - 관리자가 유저의 코인양을 수정할 수 있어야 한다는 프론트 측의 요청으로 추가하였습니다.
  - 수정 내역은 관리자가 입력한 그대로 유저에게 노출됩니다.
  - 추후 패널티 등을 고려하여 음수 막지 않았습니다.