### PR TITLE
[GGBE4-81--FIX-ItemStoreResponseDto-enum-toString] Dto 생성자 및 바디 수정

### DIFF
--- a/src/main/java/com/gg/server/domain/item/dto/ItemStoreResponseDto.java
+++ b/src/main/java/com/gg/server/domain/item/dto/ItemStoreResponseDto.java
@@ -1,6 +1,7 @@
 package com.gg.server.domain.item.dto;
 
 import com.gg.server.domain.item.data.Item;
+import com.gg.server.domain.item.type.ItemType;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,7 +14,7 @@ public class ItemStoreResponseDto {
     private String itemName;
     private String mainContent;
     private String subContent;
-    private String itemType;
+    private ItemType itemType;
     private String imageUri;
     private Integer originalPrice;
     private Integer discount;
@@ -24,7 +25,7 @@ public class ItemStoreResponseDto {
         this.itemName = item.getName();
         this.mainContent = item.getMainContent();
         this.subContent = item.getSubContent();
-        this.itemType = item.getType().toString();
+        this.itemType = item.getType();
         this.imageUri = item.getImageUri();
         this.originalPrice = item.getPrice();
         this.discount = item.getDiscount();


### PR DESCRIPTION

 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - DTO 생성자 및 바디 수정
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - this.itemType = item.getType().toString() 대신 item.getType() 으로 수정
  - 컨트롤러에서 반환하는 객체(DTO 등)는 HTTP 응답으로 변환되기 전에 내부적으로 Jackson 라이브러리를 통해 JSON형식으로 변환되고, Enum타입 필드는 문자열 값으로 변환됨
 ## ✅ 변경로직 <!-- 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
  -
