### PR TITLE
[fix] #232 점수 수정 시 승패 수정 안되는 문제 수정

### DIFF
--- a/src/main/java/com/gg/server/admin/game/service/GameAdminService.java
+++ b/src/main/java/com/gg/server/admin/game/service/GameAdminService.java
@@ -6,6 +6,7 @@ import com.gg.server.admin.game.data.GameAdminRepository;
 import com.gg.server.admin.game.dto.RankGamePPPModifyReqDto;
 import com.gg.server.admin.game.exception.NotRecentlyGameException;
 import com.gg.server.admin.pchange.data.PChangeAdminRepository;
+import com.gg.server.admin.pchange.exception.PChangeNotExistException;
 import com.gg.server.admin.season.data.SeasonAdminRepository;
 import com.gg.server.admin.team.data.TeamUserAdminRepository;
 import com.gg.server.admin.user.data.UserAdminRepository;
@@ -111,6 +112,9 @@ public class GameAdminService {
         for (TeamUser teamUser :
                 teamUsers) {
             List<PChange> pChanges = pChangeAdminRepository.findByTeamUser(teamUser.getUser().getId());
+            if (!pChanges.get(0).getGame().getId().equals(gameId)) {
+                throw new PChangeNotExistException();
+            }
             rollbackGameResult(reqDto, season, teamUser, pChanges);
             pChangeAdminRepository.delete(pChanges.get(0));
         }
@@ -123,17 +127,17 @@ public class GameAdminService {
         // rank zset 도 update
         // 이전 ppp, exp 되돌리기
         // rank data 에 있는 ppp 되돌리기
-        if (teamUser.getTeam().getId().equals(reqDto.getTeam1Id())) {
-            teamUser.getTeam().updateScore(reqDto.getTeam1Score(), reqDto.getTeam1Score() > reqDto.getTeam2Score());
-        } else if (teamUser.getTeam().getId().equals(reqDto.getTeam2Id())) {
-            teamUser.getTeam().updateScore(reqDto.getTeam2Score(), reqDto.getTeam2Score() > reqDto.getTeam1Score());
-        }
         if (pChanges.size() == 1) {
             rankRedisService.rollbackRank(teamUser, season.getStartPpp(), season.getId());
             teamUser.getUser().updateExp(0);
         } else {
             rankRedisService.rollbackRank(teamUser, pChanges.get(1).getPppResult(), season.getId());
             teamUser.getUser().updateExp(pChanges.get(1).getExp());
+        }
+        if (teamUser.getTeam().getId().equals(reqDto.getTeam1Id())) {
+            teamUser.getTeam().updateScore(reqDto.getTeam1Score(), reqDto.getTeam1Score() > reqDto.getTeam2Score());
+        } else if (teamUser.getTeam().getId().equals(reqDto.getTeam2Id())) {
+            teamUser.getTeam().updateScore(reqDto.getTeam2Score(), reqDto.getTeam2Score() > reqDto.getTeam1Score());
         }
     }
 

--- a/src/main/java/com/gg/server/global/exception/ErrorCode.java
+++ b/src/main/java/com/gg/server/global/exception/ErrorCode.java
@@ -74,7 +74,6 @@ public enum ErrorCode {
      **/
     PCHANGE_NOT_FOUND(404, "PC100", "PChange 가 존재하지 않습니다."),
 
-
     AWS_S3_ERR(500, "CL001", "AWS S3 Error"),
     AWS_SERVER_ERR(500, "CL002", "AWS Error"),
 


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - admin 페이지에서 게임 점수 입력이 잘못되었을 때 관리자가 수정할 수 있는 기능입니다.
  - 승패가 바뀌는 경우, 승패 횟수가 바뀌지 않는 문제를 수정했습니다.
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - 이전 게임 결과를 바탕으로 승패 횟수 및 pchange 를 되돌린 후, teamUser 에 저장된 win 값을 변경하도록 수정했습니다.
