### PR TITLE
[GGBE4-83-UserAlreadyAttendanceException-to-DuplicationException] UserAlreadyAttendanceException 의 상속을 DuplicationException 으로 변경

### DIFF
--- a/src/main/java/com/gg/server/domain/user/exception/UserAlreadyAttendanceException.java
+++ b/src/main/java/com/gg/server/domain/user/exception/UserAlreadyAttendanceException.java
@@ -1,9 +1,9 @@
 package com.gg.server.domain.user.exception;
 
 import com.gg.server.global.exception.ErrorCode;
-import com.gg.server.global.exception.custom.InvalidParameterException;
+import com.gg.server.global.exception.custom.DuplicationException;
 
-public class UserAlreadyAttendanceException extends InvalidParameterException {
+public class UserAlreadyAttendanceException extends DuplicationException {
     public UserAlreadyAttendanceException() {
         super("이미 출석한 유저입니다.", ErrorCode.USER_ALREADY_ATTENDANCE);
     }


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - UserAlreadyAttendanceException 의 상속을 DuplicationException 으로 변경
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  -
 ## ✅ 변경로직 <!-- 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
  -
