### PR TITLE
[GGBE4-86--ItemStroreResponseDto-TestCode] 유저별 아이템 보관함 조회 테스트 코드 삭제

### DIFF
--- a/src/test/java/com/gg/server/domain/item/controller/ItemStoreListControllerTest.java
+++ b/src/test/java/com/gg/server/domain/item/controller/ItemStoreListControllerTest.java
@@ -16,6 +16,8 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.boot.test.mock.mockito.MockBean;
+
+import static com.gg.server.domain.item.type.ItemType.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import javax.transaction.Transactional;
 import java.util.Arrays;
@@ -54,9 +56,9 @@ class ItemStoreListControllerTest {
 
         //given
         List<ItemStoreResponseDto> testItems = Arrays.asList(
-                new ItemStoreResponseDto(1L, "itemName 1", "mainContent 1","subContent 1", "MEGAPHONE", "ImageUrl 1", 1000, 10, 900),
-                new ItemStoreResponseDto(2L, "itemName 2", "mainContent 2","subContent 2", "PROFILE_IMAGE", "ImageUrl 2", 2000, 20, 1800),
-                new ItemStoreResponseDto(3L, "itemName 3", "mainContent 2","subContent 2", "TEXT_COLOR", "ImageUrl 3", 3000, 30, 2700)
+                new ItemStoreResponseDto(1L, "itemName 1", "mainContent 1","subContent 1", MEGAPHONE, "ImageUrl 1", 1000, 10, 900),
+                new ItemStoreResponseDto(2L, "itemName 2", "mainContent 2","subContent 2", PROFILE_IMAGE, "ImageUrl 2", 2000, 20, 1800),
+                new ItemStoreResponseDto(3L, "itemName 3", "mainContent 2","subContent 2", TEXT_COLOR, "ImageUrl 3", 3000, 30, 2700)
         );
         ItemStoreListResponseDto testResponse = new ItemStoreListResponseDto(testItems);
         when(itemService.getAllItems()).thenReturn(testResponse);


### PR DESCRIPTION

 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 유저별 아이템 보관함 조회 테스트 코드 수정
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - 유저별 아이템 보관함 조회에서 toString() 부분을 삭제하고 ENUM 그대로 받았음
  - 이에 따라 테스트 코드도 동일하게 수정
  - deploy 돌리던 중 에러 발견함
 ## ✅ 변경로직 <!-- 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
  -
