### PR TITLE
✨ [Feature] tournament 테이블 초기화 SQL 추가

### DIFF
--- a/src/main/java/com/gg/server/domain/tournament/data/Tournament.java
+++ b/src/main/java/com/gg/server/domain/tournament/data/Tournament.java
@@ -3,12 +3,9 @@ package com.gg.server.domain.tournament.data;
 import com.gg.server.domain.tournament.type.TournamentStatus;
 import com.gg.server.domain.tournament.type.TournamentType;
 import com.gg.server.global.utils.BaseTimeEntity;
+
 import java.time.LocalDateTime;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
+import javax.persistence.*;
 import javax.validation.constraints.NotNull;
 
 import lombok.*;
@@ -38,11 +35,13 @@ public class Tournament extends BaseTimeEntity {
     private LocalDateTime endTime;
 
     @NotNull
+    @Enumerated(EnumType.STRING)
     @Column(name = "type")
     private TournamentType type;
 
     @NotNull
     @Column(name = "status")
+    @Enumerated(EnumType.STRING)
     private TournamentStatus status;
 
     @Builder

--- a/src/main/java/com/gg/server/domain/tournament/data/TournamentGame.java
+++ b/src/main/java/com/gg/server/domain/tournament/data/TournamentGame.java
@@ -3,14 +3,8 @@ package com.gg.server.domain.tournament.data;
 import com.gg.server.domain.game.data.Game;
 import com.gg.server.domain.tournament.type.TournamentRound;
 import com.gg.server.global.utils.BaseTimeEntity;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.OneToOne;
+
+import javax.persistence.*;
 import javax.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -23,8 +17,7 @@ import lombok.NoArgsConstructor;
 @Entity
 public class TournamentGame extends BaseTimeEntity {
 
-    @Id @GeneratedValue
-    @Column(name = "tournament_game_id")
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @NotNull
@@ -39,5 +32,6 @@ public class TournamentGame extends BaseTimeEntity {
 
     @NotNull
     @Column(name = "round")
+    @Enumerated(EnumType.STRING)
     private TournamentRound tournamentRound;
 }

--- a/src/main/resources/db/migration/V3__migration_42gg_5th.sql
+++ b/src/main/resources/db/migration/V3__migration_42gg_5th.sql
@@ -1,0 +1,48 @@
+### Tournament ###
+CREATE TABLE tournament (
+    id                  BIGINT NOT NULL AUTO_INCREMENT,
+    title               VARCHAR(20) NOT NULL,
+    contents            VARCHAR(1000) NOT NULL,
+    start_time          DATETIME NOT NULL,
+    end_time            DATETIME NOT NULL,
+    type                VARCHAR(15) NOT NULL,
+    status              VARCHAR(10) NOT NULL DEFAULT 'BEFORE',
+    created_at          DATETIME NOT NULL,
+    modified_at          DATETIME NOT NULL,
+    PRIMARY KEY (id)
+);
+
+### TournamentUser ###
+CREATE TABLE tournament_user (
+    id              BIGINT NOT NULL AUTO_INCREMENT,
+    user_id         BIGINT NOT NULL,
+    tournament_id   BIGINT NOT NULL,
+    is_joined       BOOLEAN NOT NULL DEFAULT FALSE,
+    register_time   DATETIME NOT NULL,
+    created_at      DATETIME NOT NULL,
+    modified_at      DATETIME NOT NULL,
+    PRIMARY KEY (id),
+    FOREIGN KEY (tournament_id) REFERENCES tournament(id)
+        ON UPDATE CASCADE
+        ON DELETE CASCADE ,
+    FOREIGN KEY (user_id) REFERENCES user(id)
+        ON UPDATE CASCADE
+        ON DELETE CASCADE
+);
+
+### TournamentGame ###
+CREATE TABLE tournament_game (
+    id                  BIGINT NOT NULL AUTO_INCREMENT,
+    tournament_id       BIGINT NOT NULL,
+    game_id             BIGINT NOT NULL,
+    round               VARCHAR(10) NOT NULL,
+    created_at          DATETIME NOT NULL,
+    modified_at          DATETIME NOT NULL,
+    PRIMARY KEY (id),
+    FOREIGN KEY (tournament_id) REFERENCES tournament(id)
+        ON UPDATE CASCADE
+        ON DELETE CASCADE,
+    FOREIGN KEY (game_id) REFERENCES game(id)
+        ON UPDATE CASCADE
+        ON DELETE CASCADE
+);


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 토너먼트 테이블 초기화하는 v3 파일 추가

 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
### `Tournament`, `TournamentGame` Entity 수정
  - `TournamentGame` Entity에서 id `@Column` annotation 삭제 (컬럼명 잘못됨)
  - enum type을 사용하는 필드에 `@Enumerated` annotation 추가
### `tournament`, `tournament_game`, `tournament_user` 테이블 초기화하는 sql v3 추가
  - `tournamet_user`의 `is_joined` 컬럼을 `BIT(1)` 대신 `BOOLEAN`으로 설정했습니다.
      MySQL 내부적으로 `TINYINT(1)`로 저장되며 이를 권장한다고 합니다.
      <img width="596" alt="스크린샷 2023-11-09 오후 12 59 45" src="https://github.com/42organization/42gg.server.dev.v2/assets/33301153/a86b9b60-0653-4ba8-bfc6-f08012d5821d">
    - [Mysql 공식문서](https://dev.mysql.com/doc/refman/8.0/en/numeric-type-syntax.html)
    - [Stack Overflow](https://stackoverflow.com/questions/290223/what-is-the-difference-between-bit-and-tinyint-in-mysql)

 ## 💡Issue 번호 <!-- issue number을 link 시켜주세요 (ex. "- close #4242") -->
 - close #299 