### PR TITLE
✨ [Feature] Tournament 수정 API 추가

### DIFF
--- a/src/main/java/com/gg/server/admin/tournament/controller/TournamentAdminController.java
+++ b/src/main/java/com/gg/server/admin/tournament/controller/TournamentAdminController.java
@@ -1,0 +1,36 @@
+package com.gg.server.admin.tournament.controller;
+
+import com.gg.server.admin.tournament.dto.TournamentAdminUpdateRequestDto;
+import com.gg.server.admin.tournament.service.TournamentAdminService;
+import javax.validation.Valid;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@AllArgsConstructor
+@RequestMapping("pingpong/admin")
+@Validated
+public class TournamentAdminController {
+    private final TournamentAdminService tournamentAdminService;
+
+    /**
+     * 토너먼트 정보 수정
+     * @param tournamentId 업데이트 하고자 하는 토너먼트 id
+     * @param tournamentAdminUpdateRequestDto 요청 데이터
+     * @return
+     */
+    @PatchMapping("/tournament/{tournamentId}")
+    public ResponseEntity updateTournamentInfo(@PathVariable Long tournamentId,
+        @Valid @RequestBody TournamentAdminUpdateRequestDto tournamentAdminUpdateRequestDto) {
+        tournamentAdminService.updateTournamentInfo(tournamentId, tournamentAdminUpdateRequestDto);
+
+        return new ResponseEntity(HttpStatus.NO_CONTENT);
+    }
+}

--- a/src/main/java/com/gg/server/admin/tournament/controller/TournamentAdminController.java
+++ b/src/main/java/com/gg/server/admin/tournament/controller/TournamentAdminController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @AllArgsConstructor
-@RequestMapping("pingpong/admin")
+@RequestMapping("/pingpong/admin")
 @Validated
 public class TournamentAdminController {
     private final TournamentAdminService tournamentAdminService;

--- a/src/main/java/com/gg/server/admin/tournament/controller/TournamentAdminController.java
+++ b/src/main/java/com/gg/server/admin/tournament/controller/TournamentAdminController.java
@@ -4,6 +4,7 @@ import com.gg.server.admin.tournament.dto.TournamentAdminUpdateRequestDto;
 import com.gg.server.admin.tournament.service.TournamentAdminService;
 import javax.validation.Valid;
 import lombok.AllArgsConstructor;
+import org.checkerframework.checker.index.qual.Positive;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -15,7 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @AllArgsConstructor
-@RequestMapping("/pingpong/admin")
+@RequestMapping("/pingpong/admin/tournament")
 @Validated
 public class TournamentAdminController {
     private final TournamentAdminService tournamentAdminService;
@@ -26,11 +27,11 @@ public class TournamentAdminController {
      * @param tournamentAdminUpdateRequestDto 요청 데이터
      * @return
      */
-    @PatchMapping("/tournament/{tournamentId}")
-    public ResponseEntity updateTournamentInfo(@PathVariable Long tournamentId,
+    @PatchMapping("/{tournamentId}")
+    public ResponseEntity<TournamentAdminUpdateRequestDto> updateTournamentInfo(@PathVariable @Positive Long tournamentId,
         @Valid @RequestBody TournamentAdminUpdateRequestDto tournamentAdminUpdateRequestDto) {
         tournamentAdminService.updateTournamentInfo(tournamentId, tournamentAdminUpdateRequestDto);
 
-        return new ResponseEntity(HttpStatus.NO_CONTENT);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 }

--- a/src/main/java/com/gg/server/admin/tournament/controller/TournamentAdminController.java
+++ b/src/main/java/com/gg/server/admin/tournament/controller/TournamentAdminController.java
@@ -28,10 +28,11 @@ public class TournamentAdminController {
      * @return
      */
     @PatchMapping("/{tournamentId}")
-    public ResponseEntity<TournamentAdminUpdateRequestDto> updateTournamentInfo(@PathVariable @Positive Long tournamentId,
+    public ResponseEntity<Void> updateTournamentInfo(@PathVariable @Positive Long tournamentId,
         @Valid @RequestBody TournamentAdminUpdateRequestDto tournamentAdminUpdateRequestDto) {
         tournamentAdminService.updateTournamentInfo(tournamentId, tournamentAdminUpdateRequestDto);
 
-        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+        return new ResponseEntity<Void>(HttpStatus.NO_CONTENT);
     }
+
 }

--- a/src/main/java/com/gg/server/admin/tournament/dto/TournamentAdminUpdateRequestDto.java
+++ b/src/main/java/com/gg/server/admin/tournament/dto/TournamentAdminUpdateRequestDto.java
@@ -1,0 +1,33 @@
+package com.gg.server.admin.tournament.dto;
+
+import com.gg.server.domain.tournament.type.TournamentType;
+import java.time.LocalDateTime;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.format.annotation.DateTimeFormat.ISO;
+
+@Getter
+@AllArgsConstructor
+public class TournamentAdminUpdateRequestDto {
+    @NotNull(message = "제목이 필요합니다.")
+    private String title;
+
+    @NotNull(message = "내용이 필요합니다.")
+    private String contents;
+
+    @NotNull(message = "시작 시간이 필요합니다.")
+    @DateTimeFormat(iso = ISO.DATE_TIME)
+    private LocalDateTime startTime;
+
+    @NotNull(message = "종료 시간이 필요합니다.")
+    @DateTimeFormat(iso = ISO.DATE_TIME)
+    private LocalDateTime endTime;
+
+    @NotNull(message = "토너먼트 종류가 필요합니다.")
+    @Enumerated(EnumType.STRING)
+    private TournamentType type;
+}

--- a/src/main/java/com/gg/server/admin/tournament/service/TournamentAdminService.java
+++ b/src/main/java/com/gg/server/admin/tournament/service/TournamentAdminService.java
@@ -11,14 +11,14 @@ import com.gg.server.global.exception.ErrorCode;
 import com.gg.server.global.exception.custom.InvalidParameterException;
 import java.time.LocalDateTime;
 import java.util.List;
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
-@AllArgsConstructor
+@RequiredArgsConstructor
 public class TournamentAdminService {
     private final TournamentRepository tournamentRepository;
-
+    public static final long ALLOWED_MINIMAL_START_TIME = 2;
     /**
      * 토너먼트 업데이트 Method
      * @param tournamentId  업데이트할 토너먼트 id
@@ -53,8 +53,10 @@ public class TournamentAdminService {
      * @param endTime 업데이트할 토너먼트 종료 시간
      * @throws InvalidParameterException 토너먼트 시간으로 부적합 할 때
      */
-    public void checkValidTournamentTime(LocalDateTime startTime, LocalDateTime endTime) {
-        if (startTime.isAfter(endTime) || startTime.isEqual(endTime) || startTime.isBefore(LocalDateTime.now().plusDays(2))) {
+    private void checkValidTournamentTime(LocalDateTime startTime, LocalDateTime endTime) {
+
+        if (startTime.isAfter(endTime) || startTime.isEqual(endTime) ||
+            startTime.isBefore(LocalDateTime.now().plusDays(ALLOWED_MINIMAL_START_TIME))) {
             throw new InvalidParameterException("invalid tournament time", ErrorCode.VALID_FAILED);
         }
     }
@@ -66,7 +68,7 @@ public class TournamentAdminService {
      * @param endTime 업데이트할 토너먼트 종료 시간
      * @throws TournamentConflictException 업데이트 하고자 하는 토너먼트의 시간이 겹칠 때
      */
-    public void checkConflictedTournament(Long targetTournamentId, LocalDateTime startTime, LocalDateTime endTime) {
+    private void checkConflictedTournament(Long targetTournamentId, LocalDateTime startTime, LocalDateTime endTime) {
         List<Tournament> tournamentList = tournamentRepository.findAllByStatus(TournamentStatus.BEFORE);
         for (Tournament tournament : tournamentList) {
             if (targetTournamentId.equals(tournament.getId())) {

--- a/src/main/java/com/gg/server/admin/tournament/service/TournamentAdminService.java
+++ b/src/main/java/com/gg/server/admin/tournament/service/TournamentAdminService.java
@@ -19,6 +19,7 @@ import org.springframework.stereotype.Service;
 public class TournamentAdminService {
     private final TournamentRepository tournamentRepository;
     public static final long ALLOWED_MINIMAL_START_TIME = 2;
+    public static final long MINIMUM_TOURNAMENT_DURATION = 2;
     /**
      * 토너먼트 업데이트 Method
      * @param tournamentId  업데이트할 토너먼트 id
@@ -49,6 +50,7 @@ public class TournamentAdminService {
      * [ 현재 시간 + 최소 2일 ],
      * [ 현재시간 보다 미래 ],
      * [ 시작 시간이 종료시간보다 현재시에 가까움 ]
+     * [ 진행 시간 최소 2시간 ]
      * @param startTime 업데이트할 토너먼트 시작 시간
      * @param endTime 업데이트할 토너먼트 종료 시간
      * @throws InvalidParameterException 토너먼트 시간으로 부적합 할 때
@@ -56,7 +58,8 @@ public class TournamentAdminService {
     private void checkValidTournamentTime(LocalDateTime startTime, LocalDateTime endTime) {
 
         if (startTime.isAfter(endTime) || startTime.isEqual(endTime) ||
-            startTime.isBefore(LocalDateTime.now().plusDays(ALLOWED_MINIMAL_START_TIME))) {
+            startTime.isBefore(LocalDateTime.now().plusDays(ALLOWED_MINIMAL_START_TIME)) ||
+            startTime.plusHours(MINIMUM_TOURNAMENT_DURATION).isAfter(endTime)) {
             throw new InvalidParameterException("invalid tournament time", ErrorCode.VALID_FAILED);
         }
     }

--- a/src/main/java/com/gg/server/admin/tournament/service/TournamentAdminService.java
+++ b/src/main/java/com/gg/server/admin/tournament/service/TournamentAdminService.java
@@ -1,0 +1,84 @@
+package com.gg.server.admin.tournament.service;
+
+import com.gg.server.admin.tournament.dto.TournamentAdminUpdateRequestDto;
+import com.gg.server.domain.tournament.data.Tournament;
+import com.gg.server.domain.tournament.data.TournamentRepository;
+import com.gg.server.domain.tournament.exception.TournamentConflictException;
+import com.gg.server.domain.tournament.exception.TournamentNotFoundException;
+import com.gg.server.domain.tournament.exception.TournamentUpdateException;
+import com.gg.server.domain.tournament.type.TournamentStatus;
+import com.gg.server.global.exception.ErrorCode;
+import com.gg.server.global.exception.custom.InvalidParameterException;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@AllArgsConstructor
+public class TournamentAdminService {
+    private final TournamentRepository tournamentRepository;
+
+    /**
+     * 토너먼트 업데이트 Method
+     * @param tournamentId  업데이트할 토너먼트 id
+     * @param requestDto 요청한 Dto
+     * @throws TournamentNotFoundException 찾을 수 없는 토너먼트 일 때
+     * @throws TournamentUpdateException 업데이트 할 수 없는 토너먼트 일 때
+     */
+    public Tournament updateTournamentInfo(Long tournamentId, TournamentAdminUpdateRequestDto requestDto) {
+        Tournament targetTournament = tournamentRepository.findById(tournamentId)
+            .orElseThrow(() -> new TournamentNotFoundException("target tournament not found", ErrorCode.TOURNAMENT_NOT_FOUND));
+        if (targetTournament.getStatus() != TournamentStatus.BEFORE) {
+            throw new TournamentUpdateException("already started or ended", ErrorCode.TOURNAMENT_NOT_BEFORE);
+        }
+        checkValidTournamentTime(requestDto.getStartTime(), requestDto.getEndTime());
+        checkConflictedTournament(targetTournament.getId(), requestDto.getStartTime(), requestDto.getEndTime());
+        targetTournament.update(
+            requestDto.getTitle(),
+            requestDto.getContents(),
+            requestDto.getStartTime(),
+            requestDto.getEndTime(),
+            requestDto.getType(),
+            TournamentStatus.BEFORE);
+        return targetTournament;
+    }
+
+    /**
+     * 토너먼트 시간 체크 :
+     * [ 현재 시간 + 최소 2일 ],
+     * [ 현재시간 보다 미래 ],
+     * [ 시작 시간이 종료시간보다 현재시에 가까움 ]
+     * @param startTime 업데이트할 토너먼트 시작 시간
+     * @param endTime 업데이트할 토너먼트 종료 시간
+     * @throws InvalidParameterException 토너먼트 시간으로 부적합 할 때
+     */
+    public void checkValidTournamentTime(LocalDateTime startTime, LocalDateTime endTime) {
+        if (startTime.isAfter(endTime) || startTime.isEqual(endTime) || startTime.isBefore(LocalDateTime.now().plusDays(2))) {
+            throw new InvalidParameterException("invalid tournament time", ErrorCode.VALID_FAILED);
+        }
+    }
+
+    /**
+     * tournamentList 에서 targetTournament을 제외한 토너먼트 중 겹치는 시간대 존재 유무 확인
+     * @param targetTournamentId 업데이트할 토너먼트 id
+     * @param startTime 업데이트할 토너먼트 시작 시간
+     * @param endTime 업데이트할 토너먼트 종료 시간
+     * @throws TournamentConflictException 업데이트 하고자 하는 토너먼트의 시간이 겹칠 때
+     */
+    public void checkConflictedTournament(Long targetTournamentId, LocalDateTime startTime, LocalDateTime endTime) {
+        List<Tournament> tournamentList = tournamentRepository.findAllByStatus(TournamentStatus.BEFORE);
+        for (Tournament tournament : tournamentList) {
+            if (targetTournamentId.equals(tournament.getId())) {
+                continue;
+            }
+            if ((startTime.isAfter(tournament.getStartTime()) && startTime.isBefore(tournament.getEndTime())) ||
+                (endTime.isAfter(tournament.getStartTime()) && endTime.isBefore(tournament.getEndTime())) ||
+                (startTime.isBefore(tournament.getStartTime()) && endTime.isAfter(tournament.getEndTime())) ||
+                startTime.isEqual(tournament.getStartTime()) || startTime.isEqual(tournament.getEndTime()) ||
+                endTime.isEqual(tournament.getEndTime()) || endTime.isEqual(tournament.getStartTime())) {
+                throw new TournamentConflictException("tournament conflicted", ErrorCode.TOURNAMENT_TIME_CONFLICT);
+            }
+        }
+    }
+}

--- a/src/main/java/com/gg/server/admin/tournament/service/TournamentAdminService.java
+++ b/src/main/java/com/gg/server/admin/tournament/service/TournamentAdminService.java
@@ -18,8 +18,10 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class TournamentAdminService {
     private final TournamentRepository tournamentRepository;
-    public static final long ALLOWED_MINIMAL_START_TIME = 2;
-    public static final long MINIMUM_TOURNAMENT_DURATION = 2;
+    // 토너먼트 최소 시작 날짜 (n일 후)
+    private static final long ALLOWED_MINIMAL_START_DAYS = 2;
+    // 토너먼트 최소 진행 시간 (n시간)
+    private static final long MINIMUM_TOURNAMENT_DURATION = 2;
     /**
      * 토너먼트 업데이트 Method
      * @param tournamentId  업데이트할 토너먼트 id
@@ -58,7 +60,7 @@ public class TournamentAdminService {
     private void checkValidTournamentTime(LocalDateTime startTime, LocalDateTime endTime) {
 
         if (startTime.isAfter(endTime) || startTime.isEqual(endTime) ||
-            startTime.isBefore(LocalDateTime.now().plusDays(ALLOWED_MINIMAL_START_TIME)) ||
+            startTime.isBefore(LocalDateTime.now().plusDays(ALLOWED_MINIMAL_START_DAYS)) ||
             startTime.plusHours(MINIMUM_TOURNAMENT_DURATION).isAfter(endTime)) {
             throw new InvalidParameterException("invalid tournament time", ErrorCode.VALID_FAILED);
         }

--- a/src/main/java/com/gg/server/admin/tournament/service/TournamentAdminService.java
+++ b/src/main/java/com/gg/server/admin/tournament/service/TournamentAdminService.java
@@ -41,7 +41,7 @@ public class TournamentAdminService {
             requestDto.getEndTime(),
             requestDto.getType(),
             TournamentStatus.BEFORE);
-        return targetTournament;
+        return tournamentRepository.save(targetTournament);
     }
 
     /**

--- a/src/main/java/com/gg/server/domain/tournament/data/Tournament.java
+++ b/src/main/java/com/gg/server/domain/tournament/data/Tournament.java
@@ -88,4 +88,25 @@ public class Tournament extends BaseTimeEntity {
 //                .status(tournamentDto.getStatus())
 //                .build();
 //    }
+
+    public void update(String title, String contents, LocalDateTime startTime, LocalDateTime endTime, TournamentType type, TournamentStatus status) {
+        this.title = title;
+        this.contents = contents;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.type = type;
+        this.status = status;
+    }
+
+    public String toString() {
+        return "Tournament{" +
+            "id=" + id +
+            ", title=" + title +
+            ", contents=" + contents +
+            ", startTime=" + startTime +
+            ", endTime=" + endTime +
+            ", type=" + type +
+            ", status=" + status +
+            '}';
+    }
 }

--- a/src/main/java/com/gg/server/domain/tournament/data/Tournament.java
+++ b/src/main/java/com/gg/server/domain/tournament/data/Tournament.java
@@ -16,6 +16,7 @@ import lombok.*;
 @AllArgsConstructor
 @Getter
 @Entity
+@ToString
 public class Tournament extends BaseTimeEntity {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -98,15 +99,4 @@ public class Tournament extends BaseTimeEntity {
         this.status = status;
     }
 
-    public String toString() {
-        return "Tournament{" +
-            "id=" + id +
-            ", title=" + title +
-            ", contents=" + contents +
-            ", startTime=" + startTime +
-            ", endTime=" + endTime +
-            ", type=" + type +
-            ", status=" + status +
-            '}';
-    }
 }

--- a/src/main/java/com/gg/server/domain/tournament/data/TournamentRepository.java
+++ b/src/main/java/com/gg/server/domain/tournament/data/TournamentRepository.java
@@ -1,6 +1,9 @@
 package com.gg.server.domain.tournament.data;
 
+import com.gg.server.domain.tournament.type.TournamentStatus;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TournamentRepository extends JpaRepository<Tournament, Long> {
+    List<Tournament> findAllByStatus(TournamentStatus status);
 }

--- a/src/test/java/com/gg/server/admin/tournament/controller/TournamentAdminControllerTest.java
+++ b/src/test/java/com/gg/server/admin/tournament/controller/TournamentAdminControllerTest.java
@@ -1,0 +1,268 @@
+package com.gg.server.admin.tournament.controller;
+
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gg.server.admin.tournament.dto.TournamentAdminUpdateRequestDto;
+import com.gg.server.admin.tournament.service.TournamentAdminService;
+import com.gg.server.domain.tournament.data.Tournament;
+import com.gg.server.domain.tournament.type.TournamentStatus;
+import com.gg.server.domain.tournament.type.TournamentType;
+import com.gg.server.global.security.jwt.utils.AuthTokenProvider;
+import com.gg.server.utils.TestDataUtils;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.apache.http.HttpHeaders;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@RequiredArgsConstructor
+@Transactional
+class TournamentAdminControllerTest {
+
+    @Autowired
+    TestDataUtils testDataUtils;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Autowired
+    AuthTokenProvider tokenProvider;
+
+    @Autowired
+    TournamentAdminService tournamentAdminService;
+
+    @Test
+    @DisplayName("[Patch] /pingpong/admin/tournament/{tournamentId}")
+    void 토너먼트_업데이트_성공() throws Exception {
+        // given
+        String accessToken = testDataUtils.getAdminLoginAccessToken();
+        tokenProvider.getUserIdFromAccessToken(accessToken);
+
+        Tournament tournament = testDataUtils.createTournament(
+            LocalDateTime.now().plusDays(2).plusHours(1),
+            LocalDateTime.now().plusDays(2).plusHours(3),
+            TournamentStatus.BEFORE);
+
+        TournamentAdminUpdateRequestDto updateDto = testDataUtils.createUpdateRequestDto (
+            LocalDateTime.now().plusDays(2).plusHours(2),
+            LocalDateTime.now().plusDays(2).plusHours(4),
+            TournamentType.MASTER);
+
+        String url = "/pingpong/admin/tournament/" + tournament.getId();
+
+        String content = objectMapper.writeValueAsString(updateDto);
+
+        // when, then
+        String contentAsString = mockMvc.perform(patch(url)
+            .content(content)
+            .contentType(MediaType.APPLICATION_JSON)
+            .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+            .andExpect(status().isNoContent())
+            .andReturn().getResponse().getContentAsString();
+
+        System.out.println(contentAsString);
+    }
+
+    @Test
+    void 토너먼트_없는_경우() throws Exception {
+        // given
+        String accessToken = testDataUtils.getAdminLoginAccessToken();
+        tokenProvider.getUserIdFromAccessToken(accessToken);
+
+        TournamentAdminUpdateRequestDto updateDto = testDataUtils.createUpdateRequestDto(
+            LocalDateTime.now().plusDays(2).plusHours(2),
+            LocalDateTime.now().plusDays(2).plusHours(4),
+            TournamentType.MASTER);
+
+        String url = "/pingpong/admin/tournament/" + 1111;
+
+        String content = objectMapper.writeValueAsString(updateDto);
+        // when, then
+        String contentAsString = mockMvc.perform(patch(url)
+            .content(content)
+            .contentType(MediaType.APPLICATION_JSON)
+            .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+            .andExpect(status().isNotFound())
+            .andReturn().getResponse().getContentAsString();
+
+        System.out.println(contentAsString);
+    }
+
+    @Test
+    void 토너먼트_업데이트_기간_겹치는_경우() throws Exception {
+        // given
+        String accessToken = testDataUtils.getAdminLoginAccessToken();
+        tokenProvider.getUserIdFromAccessToken(accessToken);
+
+        Tournament tournamentAlreadyExist = testDataUtils.createTournament(
+            LocalDateTime.now().plusDays(2).plusHours(2),
+            LocalDateTime.now().plusDays(2).plusHours(4),
+            TournamentStatus.BEFORE);
+
+        Tournament tournamentToChange = testDataUtils.createTournament(
+            LocalDateTime.now().plusDays(2).plusHours(5),
+            LocalDateTime.now().plusDays(2).plusHours(7),
+            TournamentStatus.BEFORE);
+
+        // 겹치는 시간 조절
+        TournamentAdminUpdateRequestDto updateDto = testDataUtils.createUpdateRequestDto(
+            tournamentAlreadyExist.getStartTime().plusMinutes(1),
+            tournamentAlreadyExist.getEndTime().plusMinutes(2),
+            TournamentType.MASTER);
+
+        String url = "/pingpong/admin/tournament/" + tournamentToChange.getId();
+
+        String content = objectMapper.writeValueAsString(updateDto);
+
+        // when, then
+        String contentAsString = mockMvc.perform(patch(url)
+            .content(content)
+            .contentType(MediaType.APPLICATION_JSON)
+            .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+            .andExpect(status().isConflict())
+            .andReturn().getResponse().getContentAsString();
+
+        System.out.println(contentAsString);
+    }
+
+    @Test
+    void 이미_시작했거나_종료된_토너먼트_수정() throws Exception {
+        // given
+        String accessToken = testDataUtils.getAdminLoginAccessToken();
+        tokenProvider.getUserIdFromAccessToken(accessToken);
+
+        Tournament liveTournament = testDataUtils.createTournament(
+            LocalDateTime.now().minusHours(1),
+            LocalDateTime.now().plusHours(2),
+            TournamentStatus.LIVE);
+
+        Tournament endedTournament = testDataUtils.createTournament(
+            LocalDateTime.now().minusHours(3),
+            LocalDateTime.now().minusHours(1),
+            TournamentStatus.END);
+
+        TournamentAdminUpdateRequestDto updateTournamentDto = testDataUtils.createUpdateRequestDto(
+            LocalDateTime.now().plusDays(2).plusHours(1),
+            LocalDateTime.now().plusDays(2).plusHours(3),
+            TournamentType.MASTER);
+
+        String url = "/pingpong/admin/tournament/" + liveTournament.getId();
+
+        String content = objectMapper.writeValueAsString(updateTournamentDto);
+
+        // when live tournament test, then
+        String contentAsString = mockMvc.perform(patch(url)
+            .content(content)
+            .contentType(MediaType.APPLICATION_JSON)
+            .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+            .andExpect(status().isBadRequest())
+            .andReturn().getResponse().getContentAsString();
+
+        System.out.println(contentAsString);
+
+        url = "/pingpong/admin/tournament/" + endedTournament.getId();
+
+        // when ended tournament test, then
+        contentAsString = mockMvc.perform(patch(url)
+                .content(content)
+                .contentType(MediaType.APPLICATION_JSON)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+            .andExpect(status().isBadRequest())
+            .andReturn().getResponse().getContentAsString();
+
+        System.out.println(contentAsString);
+    }
+
+    @Test
+    void 토너먼트_잘못된_기간() throws Exception {
+        // given
+        String accessToken = testDataUtils.getAdminLoginAccessToken();
+        tokenProvider.getUserIdFromAccessToken(accessToken);
+
+        Tournament tournamentToChange = testDataUtils.createTournament(
+            LocalDateTime.now().plusDays(2).plusHours(1),
+            LocalDateTime.now().plusDays(2).plusHours(3),
+            TournamentStatus.BEFORE);
+
+        TournamentAdminUpdateRequestDto updateDto1 = testDataUtils.createUpdateRequestDto(
+            tournamentToChange.getStartTime(),
+            tournamentToChange.getStartTime(),
+            TournamentType.MASTER);
+
+        TournamentAdminUpdateRequestDto updateDto2 = testDataUtils.createUpdateRequestDto(
+            tournamentToChange.getEndTime(),
+            tournamentToChange.getStartTime(),
+            TournamentType.MASTER);
+
+        String url = "/pingpong/admin/tournament/" + tournamentToChange.getId();
+        // when startTime == endTime, then
+        String content = objectMapper.writeValueAsString(updateDto1);
+
+        String contentAsString = mockMvc.perform(patch(url)
+            .content(content)
+            .contentType(MediaType.APPLICATION_JSON)
+            .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+            .andExpect(status().isBadRequest())
+            .andReturn().getResponse().getContentAsString();
+
+        System.out.println(contentAsString);
+
+        // when startTime > endTime test, then
+        content = objectMapper.writeValueAsString(updateDto2);
+
+        contentAsString = mockMvc.perform(patch(url)
+            .content(content)
+            .contentType(MediaType.APPLICATION_JSON)
+            .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+            .andExpect(status().isBadRequest())
+            .andReturn().getResponse().getContentAsString();
+
+        System.out.println(contentAsString);
+    }
+
+    @Test
+    void 잘못된_dto() throws Exception {
+        // given
+        String accessToken = testDataUtils.getAdminLoginAccessToken();
+        tokenProvider.getUserIdFromAccessToken(accessToken);
+
+        Tournament tournamentToChange = testDataUtils.createTournament(
+            LocalDateTime.now().plusDays(2).plusHours(1),
+            LocalDateTime.now().plusDays(2).plusHours(3),
+            TournamentStatus.BEFORE);
+
+        TournamentAdminUpdateRequestDto updateDto1 = testDataUtils.createUpdateRequestDto(
+            tournamentToChange.getStartTime(),
+            tournamentToChange.getStartTime(),
+            null);
+
+        String url = "/pingpong/admin/tournament/" + tournamentToChange.getId();
+        // when startTime == endTime, then
+        String content = objectMapper.writeValueAsString(updateDto1);
+
+        String contentAsString = mockMvc.perform(patch(url)
+                .content(content)
+                .contentType(MediaType.APPLICATION_JSON)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+            .andExpect(status().isBadRequest())
+            .andReturn().getResponse().getContentAsString();
+
+        System.out.println(contentAsString);
+    }
+
+
+
+}

--- a/src/test/java/com/gg/server/admin/tournament/controller/TournamentAdminControllerTest.java
+++ b/src/test/java/com/gg/server/admin/tournament/controller/TournamentAdminControllerTest.java
@@ -33,7 +33,7 @@ class TournamentAdminControllerTest {
     TestDataUtils testDataUtils;
 
     @Autowired
-    private MockMvc mockMvc;
+    MockMvc mockMvc;
 
     @Autowired
     ObjectMapper objectMapper;

--- a/src/test/java/com/gg/server/admin/tournament/controller/TournamentAdminControllerTest.java
+++ b/src/test/java/com/gg/server/admin/tournament/controller/TournamentAdminControllerTest.java
@@ -15,6 +15,7 @@ import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.apache.http.HttpHeaders;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -44,225 +45,232 @@ class TournamentAdminControllerTest {
     @Autowired
     TournamentAdminService tournamentAdminService;
 
-    @Test
-    @DisplayName("[Patch] /pingpong/admin/tournament/{tournamentId}")
-    void 토너먼트_업데이트_성공() throws Exception {
-        // given
-        String accessToken = testDataUtils.getAdminLoginAccessToken();
-        tokenProvider.getUserIdFromAccessToken(accessToken);
+    @Nested
+    @DisplayName("토너먼트 관리 수정 컨트롤러 테스트")
+    class TournamentAdminControllerUpdateTest {
+        @Test
+        @DisplayName("토너먼트_업데이트_성공")
+        void success() throws Exception {
+            // given
+            String accessToken = testDataUtils.getAdminLoginAccessToken();
+            tokenProvider.getUserIdFromAccessToken(accessToken);
 
-        Tournament tournament = testDataUtils.createTournament(
-            LocalDateTime.now().plusDays(2).plusHours(1),
-            LocalDateTime.now().plusDays(2).plusHours(3),
-            TournamentStatus.BEFORE);
+            Tournament tournament = testDataUtils.createTournament(
+                LocalDateTime.now().plusDays(2).plusHours(1),
+                LocalDateTime.now().plusDays(2).plusHours(3),
+                TournamentStatus.BEFORE);
 
-        TournamentAdminUpdateRequestDto updateDto = testDataUtils.createUpdateRequestDto (
-            LocalDateTime.now().plusDays(2).plusHours(2),
-            LocalDateTime.now().plusDays(2).plusHours(4),
-            TournamentType.MASTER);
+            TournamentAdminUpdateRequestDto updateDto = testDataUtils.createUpdateRequestDto (
+                LocalDateTime.now().plusDays(2).plusHours(2),
+                LocalDateTime.now().plusDays(2).plusHours(4),
+                TournamentType.MASTER);
 
-        String url = "/pingpong/admin/tournament/" + tournament.getId();
+            String url = "/pingpong/admin/tournament/" + tournament.getId();
 
-        String content = objectMapper.writeValueAsString(updateDto);
+            String content = objectMapper.writeValueAsString(updateDto);
 
-        // when, then
-        String contentAsString = mockMvc.perform(patch(url)
-            .content(content)
-            .contentType(MediaType.APPLICATION_JSON)
-            .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
-            .andExpect(status().isNoContent())
-            .andReturn().getResponse().getContentAsString();
+            // when, then
+            String contentAsString = mockMvc.perform(patch(url)
+                    .content(content)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isNoContent())
+                .andReturn().getResponse().getContentAsString();
 
-        System.out.println(contentAsString);
+            System.out.println(contentAsString);
+        }
+
+        @Test
+        @DisplayName("토너먼트_없는_경우")
+        void tournamentNotFound() throws Exception {
+            // given
+            String accessToken = testDataUtils.getAdminLoginAccessToken();
+            tokenProvider.getUserIdFromAccessToken(accessToken);
+
+            TournamentAdminUpdateRequestDto updateDto = testDataUtils.createUpdateRequestDto(
+                LocalDateTime.now().plusDays(2).plusHours(2),
+                LocalDateTime.now().plusDays(2).plusHours(4),
+                TournamentType.MASTER);
+
+            String url = "/pingpong/admin/tournament/" + 1111;
+
+            String content = objectMapper.writeValueAsString(updateDto);
+            // when, then
+            String contentAsString = mockMvc.perform(patch(url)
+                    .content(content)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isNotFound())
+                .andReturn().getResponse().getContentAsString();
+
+            System.out.println(contentAsString);
+        }
+
+        @Test
+        @DisplayName("토너먼트_업데이트_기간_겹치는_경우")
+        void tournamentConflicted() throws Exception {
+            // given
+            String accessToken = testDataUtils.getAdminLoginAccessToken();
+            tokenProvider.getUserIdFromAccessToken(accessToken);
+
+            Tournament tournamentAlreadyExist = testDataUtils.createTournament(
+                LocalDateTime.now().plusDays(2).plusHours(2),
+                LocalDateTime.now().plusDays(2).plusHours(4),
+                TournamentStatus.BEFORE);
+
+            Tournament tournamentToChange = testDataUtils.createTournament(
+                LocalDateTime.now().plusDays(2).plusHours(5),
+                LocalDateTime.now().plusDays(2).plusHours(7),
+                TournamentStatus.BEFORE);
+
+            // 겹치는 시간 조절
+            TournamentAdminUpdateRequestDto updateDto = testDataUtils.createUpdateRequestDto(
+                tournamentAlreadyExist.getStartTime().plusMinutes(1),
+                tournamentAlreadyExist.getEndTime().plusMinutes(2),
+                TournamentType.MASTER);
+
+            String url = "/pingpong/admin/tournament/" + tournamentToChange.getId();
+
+            String content = objectMapper.writeValueAsString(updateDto);
+
+            // when, then
+            String contentAsString = mockMvc.perform(patch(url)
+                    .content(content)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isConflict())
+                .andReturn().getResponse().getContentAsString();
+
+            System.out.println(contentAsString);
+        }
+
+        @Test
+        @DisplayName("이미_시작했거나_종료된_토너먼트_수정")
+        void canNotUpdate() throws Exception {
+            // given
+            String accessToken = testDataUtils.getAdminLoginAccessToken();
+            tokenProvider.getUserIdFromAccessToken(accessToken);
+
+            Tournament liveTournament = testDataUtils.createTournament(
+                LocalDateTime.now().minusHours(1),
+                LocalDateTime.now().plusHours(2),
+                TournamentStatus.LIVE);
+
+            Tournament endedTournament = testDataUtils.createTournament(
+                LocalDateTime.now().minusHours(3),
+                LocalDateTime.now().minusHours(1),
+                TournamentStatus.END);
+
+            TournamentAdminUpdateRequestDto updateTournamentDto = testDataUtils.createUpdateRequestDto(
+                LocalDateTime.now().plusDays(2).plusHours(1),
+                LocalDateTime.now().plusDays(2).plusHours(3),
+                TournamentType.MASTER);
+
+            String url = "/pingpong/admin/tournament/" + liveTournament.getId();
+
+            String content = objectMapper.writeValueAsString(updateTournamentDto);
+
+            // when live tournament test, then
+            String contentAsString = mockMvc.perform(patch(url)
+                    .content(content)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isBadRequest())
+                .andReturn().getResponse().getContentAsString();
+
+            System.out.println(contentAsString);
+
+            url = "/pingpong/admin/tournament/" + endedTournament.getId();
+
+            // when ended tournament test, then
+            contentAsString = mockMvc.perform(patch(url)
+                    .content(content)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isBadRequest())
+                .andReturn().getResponse().getContentAsString();
+
+            System.out.println(contentAsString);
+        }
+
+        @Test
+        @DisplayName("토너먼트_잘못된_기간")
+        void wrongTournamentTime() throws Exception {
+            // given
+            String accessToken = testDataUtils.getAdminLoginAccessToken();
+            tokenProvider.getUserIdFromAccessToken(accessToken);
+
+            Tournament tournamentToChange = testDataUtils.createTournament(
+                LocalDateTime.now().plusDays(2).plusHours(1),
+                LocalDateTime.now().plusDays(2).plusHours(3),
+                TournamentStatus.BEFORE);
+
+            TournamentAdminUpdateRequestDto updateDto1 = testDataUtils.createUpdateRequestDto(
+                tournamentToChange.getStartTime(),
+                tournamentToChange.getStartTime(),
+                TournamentType.MASTER);
+
+            TournamentAdminUpdateRequestDto updateDto2 = testDataUtils.createUpdateRequestDto(
+                tournamentToChange.getEndTime(),
+                tournamentToChange.getStartTime(),
+                TournamentType.MASTER);
+
+            String url = "/pingpong/admin/tournament/" + tournamentToChange.getId();
+            // when startTime == endTime, then
+            String content = objectMapper.writeValueAsString(updateDto1);
+
+            String contentAsString = mockMvc.perform(patch(url)
+                    .content(content)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isBadRequest())
+                .andReturn().getResponse().getContentAsString();
+
+            System.out.println(contentAsString);
+
+            // when startTime > endTime test, then
+            content = objectMapper.writeValueAsString(updateDto2);
+
+            contentAsString = mockMvc.perform(patch(url)
+                    .content(content)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isBadRequest())
+                .andReturn().getResponse().getContentAsString();
+
+            System.out.println(contentAsString);
+        }
+
+        @Test
+        @DisplayName("잘못된_dto")
+        void wrongDto() throws Exception {
+            // given
+            String accessToken = testDataUtils.getAdminLoginAccessToken();
+            tokenProvider.getUserIdFromAccessToken(accessToken);
+
+            Tournament tournamentToChange = testDataUtils.createTournament(
+                LocalDateTime.now().plusDays(2).plusHours(1),
+                LocalDateTime.now().plusDays(2).plusHours(3),
+                TournamentStatus.BEFORE);
+
+            TournamentAdminUpdateRequestDto updateDto1 = testDataUtils.createUpdateRequestDto(
+                tournamentToChange.getStartTime(),
+                tournamentToChange.getStartTime(),
+                null);
+
+            String url = "/pingpong/admin/tournament/" + tournamentToChange.getId();
+            // when startTime == endTime, then
+            String content = objectMapper.writeValueAsString(updateDto1);
+
+            String contentAsString = mockMvc.perform(patch(url)
+                    .content(content)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isBadRequest())
+                .andReturn().getResponse().getContentAsString();
+
+            System.out.println(contentAsString);
+        }
     }
-
-    @Test
-    void 토너먼트_없는_경우() throws Exception {
-        // given
-        String accessToken = testDataUtils.getAdminLoginAccessToken();
-        tokenProvider.getUserIdFromAccessToken(accessToken);
-
-        TournamentAdminUpdateRequestDto updateDto = testDataUtils.createUpdateRequestDto(
-            LocalDateTime.now().plusDays(2).plusHours(2),
-            LocalDateTime.now().plusDays(2).plusHours(4),
-            TournamentType.MASTER);
-
-        String url = "/pingpong/admin/tournament/" + 1111;
-
-        String content = objectMapper.writeValueAsString(updateDto);
-        // when, then
-        String contentAsString = mockMvc.perform(patch(url)
-            .content(content)
-            .contentType(MediaType.APPLICATION_JSON)
-            .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
-            .andExpect(status().isNotFound())
-            .andReturn().getResponse().getContentAsString();
-
-        System.out.println(contentAsString);
-    }
-
-    @Test
-    void 토너먼트_업데이트_기간_겹치는_경우() throws Exception {
-        // given
-        String accessToken = testDataUtils.getAdminLoginAccessToken();
-        tokenProvider.getUserIdFromAccessToken(accessToken);
-
-        Tournament tournamentAlreadyExist = testDataUtils.createTournament(
-            LocalDateTime.now().plusDays(2).plusHours(2),
-            LocalDateTime.now().plusDays(2).plusHours(4),
-            TournamentStatus.BEFORE);
-
-        Tournament tournamentToChange = testDataUtils.createTournament(
-            LocalDateTime.now().plusDays(2).plusHours(5),
-            LocalDateTime.now().plusDays(2).plusHours(7),
-            TournamentStatus.BEFORE);
-
-        // 겹치는 시간 조절
-        TournamentAdminUpdateRequestDto updateDto = testDataUtils.createUpdateRequestDto(
-            tournamentAlreadyExist.getStartTime().plusMinutes(1),
-            tournamentAlreadyExist.getEndTime().plusMinutes(2),
-            TournamentType.MASTER);
-
-        String url = "/pingpong/admin/tournament/" + tournamentToChange.getId();
-
-        String content = objectMapper.writeValueAsString(updateDto);
-
-        // when, then
-        String contentAsString = mockMvc.perform(patch(url)
-            .content(content)
-            .contentType(MediaType.APPLICATION_JSON)
-            .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
-            .andExpect(status().isConflict())
-            .andReturn().getResponse().getContentAsString();
-
-        System.out.println(contentAsString);
-    }
-
-    @Test
-    void 이미_시작했거나_종료된_토너먼트_수정() throws Exception {
-        // given
-        String accessToken = testDataUtils.getAdminLoginAccessToken();
-        tokenProvider.getUserIdFromAccessToken(accessToken);
-
-        Tournament liveTournament = testDataUtils.createTournament(
-            LocalDateTime.now().minusHours(1),
-            LocalDateTime.now().plusHours(2),
-            TournamentStatus.LIVE);
-
-        Tournament endedTournament = testDataUtils.createTournament(
-            LocalDateTime.now().minusHours(3),
-            LocalDateTime.now().minusHours(1),
-            TournamentStatus.END);
-
-        TournamentAdminUpdateRequestDto updateTournamentDto = testDataUtils.createUpdateRequestDto(
-            LocalDateTime.now().plusDays(2).plusHours(1),
-            LocalDateTime.now().plusDays(2).plusHours(3),
-            TournamentType.MASTER);
-
-        String url = "/pingpong/admin/tournament/" + liveTournament.getId();
-
-        String content = objectMapper.writeValueAsString(updateTournamentDto);
-
-        // when live tournament test, then
-        String contentAsString = mockMvc.perform(patch(url)
-            .content(content)
-            .contentType(MediaType.APPLICATION_JSON)
-            .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
-            .andExpect(status().isBadRequest())
-            .andReturn().getResponse().getContentAsString();
-
-        System.out.println(contentAsString);
-
-        url = "/pingpong/admin/tournament/" + endedTournament.getId();
-
-        // when ended tournament test, then
-        contentAsString = mockMvc.perform(patch(url)
-                .content(content)
-                .contentType(MediaType.APPLICATION_JSON)
-                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
-            .andExpect(status().isBadRequest())
-            .andReturn().getResponse().getContentAsString();
-
-        System.out.println(contentAsString);
-    }
-
-    @Test
-    void 토너먼트_잘못된_기간() throws Exception {
-        // given
-        String accessToken = testDataUtils.getAdminLoginAccessToken();
-        tokenProvider.getUserIdFromAccessToken(accessToken);
-
-        Tournament tournamentToChange = testDataUtils.createTournament(
-            LocalDateTime.now().plusDays(2).plusHours(1),
-            LocalDateTime.now().plusDays(2).plusHours(3),
-            TournamentStatus.BEFORE);
-
-        TournamentAdminUpdateRequestDto updateDto1 = testDataUtils.createUpdateRequestDto(
-            tournamentToChange.getStartTime(),
-            tournamentToChange.getStartTime(),
-            TournamentType.MASTER);
-
-        TournamentAdminUpdateRequestDto updateDto2 = testDataUtils.createUpdateRequestDto(
-            tournamentToChange.getEndTime(),
-            tournamentToChange.getStartTime(),
-            TournamentType.MASTER);
-
-        String url = "/pingpong/admin/tournament/" + tournamentToChange.getId();
-        // when startTime == endTime, then
-        String content = objectMapper.writeValueAsString(updateDto1);
-
-        String contentAsString = mockMvc.perform(patch(url)
-            .content(content)
-            .contentType(MediaType.APPLICATION_JSON)
-            .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
-            .andExpect(status().isBadRequest())
-            .andReturn().getResponse().getContentAsString();
-
-        System.out.println(contentAsString);
-
-        // when startTime > endTime test, then
-        content = objectMapper.writeValueAsString(updateDto2);
-
-        contentAsString = mockMvc.perform(patch(url)
-            .content(content)
-            .contentType(MediaType.APPLICATION_JSON)
-            .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
-            .andExpect(status().isBadRequest())
-            .andReturn().getResponse().getContentAsString();
-
-        System.out.println(contentAsString);
-    }
-
-    @Test
-    void 잘못된_dto() throws Exception {
-        // given
-        String accessToken = testDataUtils.getAdminLoginAccessToken();
-        tokenProvider.getUserIdFromAccessToken(accessToken);
-
-        Tournament tournamentToChange = testDataUtils.createTournament(
-            LocalDateTime.now().plusDays(2).plusHours(1),
-            LocalDateTime.now().plusDays(2).plusHours(3),
-            TournamentStatus.BEFORE);
-
-        TournamentAdminUpdateRequestDto updateDto1 = testDataUtils.createUpdateRequestDto(
-            tournamentToChange.getStartTime(),
-            tournamentToChange.getStartTime(),
-            null);
-
-        String url = "/pingpong/admin/tournament/" + tournamentToChange.getId();
-        // when startTime == endTime, then
-        String content = objectMapper.writeValueAsString(updateDto1);
-
-        String contentAsString = mockMvc.perform(patch(url)
-                .content(content)
-                .contentType(MediaType.APPLICATION_JSON)
-                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
-            .andExpect(status().isBadRequest())
-            .andReturn().getResponse().getContentAsString();
-
-        System.out.println(contentAsString);
-    }
-
-
 
 }

--- a/src/test/java/com/gg/server/admin/tournament/service/TournamentAdminServiceTest.java
+++ b/src/test/java/com/gg/server/admin/tournament/service/TournamentAdminServiceTest.java
@@ -2,6 +2,7 @@ package com.gg.server.admin.tournament.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
 import com.gg.server.admin.tournament.dto.TournamentAdminUpdateRequestDto;
@@ -41,6 +42,7 @@ class TournamentAdminServiceTest {
             getTargetTime(3, 1), getTargetTime(3, 3));
         given(tournamentRepository.findById(1L)).willReturn(Optional.of(tournament));
         given(tournamentRepository.findAllByStatus(TournamentStatus.BEFORE)).willReturn(tournamentList);
+        given(tournamentRepository.save(any(Tournament.class))).willReturn(tournament);
         // when
         Tournament changedTournament = tournamentAdminService.updateTournamentInfo(1L, updateRequestDto);
         // then

--- a/src/test/java/com/gg/server/admin/tournament/service/TournamentAdminServiceTest.java
+++ b/src/test/java/com/gg/server/admin/tournament/service/TournamentAdminServiceTest.java
@@ -36,7 +36,7 @@ class TournamentAdminServiceTest {
 
     // 토너먼트 수정 서비스 테스트
     @Nested
-    @DisplayName("[Patch] /pingpong/admin/tournament/{tournamentId}")
+    @DisplayName("토너먼트 관리자 서비스 수정 테스트")
     class TournamentAdminServiceUpdateTest {
         @Test
         @DisplayName("토너먼트_업데이트_성공")

--- a/src/test/java/com/gg/server/admin/tournament/service/TournamentAdminServiceTest.java
+++ b/src/test/java/com/gg/server/admin/tournament/service/TournamentAdminServiceTest.java
@@ -33,6 +33,8 @@ class TournamentAdminServiceTest {
     @InjectMocks
     TournamentAdminService tournamentAdminService;
 
+
+    // 토너먼트 수정 서비스 테스트
     @Nested
     @DisplayName("[Patch] /pingpong/admin/tournament/{tournamentId}")
     class TournamentAdminServiceUpdateTest {
@@ -139,7 +141,7 @@ class TournamentAdminServiceTest {
      * @param hours
      * @return
      */
-    LocalDateTime getTargetTime(long days, long hours) {
+    private LocalDateTime getTargetTime(long days, long hours) {
         return LocalDateTime.now().plusDays(days).plusHours(hours);
     }
 
@@ -151,7 +153,7 @@ class TournamentAdminServiceTest {
      * @param endTime
      * @return
      */
-    Tournament makeTournament(Long id, TournamentStatus status, LocalDateTime startTime, LocalDateTime endTime) {
+    private Tournament makeTournament(Long id, TournamentStatus status, LocalDateTime startTime, LocalDateTime endTime) {
         return new Tournament(
             id,
             id + "st tournament",
@@ -170,7 +172,7 @@ class TournamentAdminServiceTest {
      * @param startTime
      * @return
      */
-    List<Tournament> makeTournaments(Long id, long cnt, LocalDateTime startTime) {
+    private List<Tournament> makeTournaments(Long id, long cnt, LocalDateTime startTime) {
         List<Tournament> tournamentList = new ArrayList<>();
         for (long i=0; i<cnt; i++) {
             tournamentList.add(makeTournament(id++, TournamentStatus.BEFORE,
@@ -185,7 +187,7 @@ class TournamentAdminServiceTest {
      * @param endTime
      * @return
      */
-    TournamentAdminUpdateRequestDto makeTournamentAdminUpdateRequestDto(LocalDateTime startTime, LocalDateTime endTime) {
+    private TournamentAdminUpdateRequestDto makeTournamentAdminUpdateRequestDto(LocalDateTime startTime, LocalDateTime endTime) {
         return new TournamentAdminUpdateRequestDto(
             "tournament changed",
             "changed",

--- a/src/test/java/com/gg/server/admin/tournament/service/TournamentAdminServiceTest.java
+++ b/src/test/java/com/gg/server/admin/tournament/service/TournamentAdminServiceTest.java
@@ -78,7 +78,7 @@ class TournamentAdminServiceTest {
 
         @Test
         @DisplayName("토너먼트_업데이트_불가_상태")
-        public void canNotUpadate() {
+        public void canNotUpdate() {
             // given
             Tournament tournamentLive = makeTournament(1L, TournamentStatus.LIVE,
                 getTargetTime(0, -1), getTargetTime(0, 1));
@@ -161,7 +161,11 @@ class TournamentAdminServiceTest {
             startTime,
             endTime,
             TournamentType.ROOKIE,
-            status);
+            status,
+            null,
+            null,
+            null
+            );
     }
 
     /**

--- a/src/test/java/com/gg/server/admin/tournament/service/TournamentAdminServiceTest.java
+++ b/src/test/java/com/gg/server/admin/tournament/service/TournamentAdminServiceTest.java
@@ -1,0 +1,185 @@
+package com.gg.server.admin.tournament.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import com.gg.server.admin.tournament.dto.TournamentAdminUpdateRequestDto;
+import com.gg.server.domain.tournament.data.Tournament;
+import com.gg.server.domain.tournament.data.TournamentRepository;
+import com.gg.server.domain.tournament.exception.TournamentConflictException;
+import com.gg.server.domain.tournament.exception.TournamentNotFoundException;
+import com.gg.server.domain.tournament.exception.TournamentUpdateException;
+import com.gg.server.domain.tournament.type.TournamentStatus;
+import com.gg.server.domain.tournament.type.TournamentType;
+import com.gg.server.global.exception.custom.InvalidParameterException;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TournamentAdminServiceTest {
+    @Mock
+    TournamentRepository tournamentRepository;
+    @InjectMocks
+    TournamentAdminService tournamentAdminService;
+
+    @Test
+    @DisplayName("[Patch] /pingpong/admin/tournament/{tournamentId}")
+    public void 토너먼트_업데이트_성공() {
+        // given
+        List<Tournament> tournamentList = makeTournaments(1L, 2, getTargetTime(2, 1));
+        Tournament tournament = tournamentList.get(0);
+        TournamentAdminUpdateRequestDto updateRequestDto = makeTournamentAdminUpdateRequestDto(
+            getTargetTime(3, 1), getTargetTime(3, 3));
+        given(tournamentRepository.findById(1L)).willReturn(Optional.of(tournament));
+        given(tournamentRepository.findAllByStatus(TournamentStatus.BEFORE)).willReturn(tournamentList);
+        // when
+        Tournament changedTournament = tournamentAdminService.updateTournamentInfo(1L, updateRequestDto);
+        // then
+        assertThat(changedTournament.getId()).isEqualTo(tournament.getId());
+        assertThat(changedTournament.getTitle()).isEqualTo(updateRequestDto.getTitle());
+        assertThat(changedTournament.getContents()).isEqualTo(updateRequestDto.getContents());
+        assertThat(changedTournament.getStartTime()).isEqualTo(updateRequestDto.getStartTime());
+        assertThat(changedTournament.getEndTime()).isEqualTo(updateRequestDto.getEndTime());
+        assertThat(changedTournament.getType()).isEqualTo(updateRequestDto.getType());
+        assertThat(changedTournament.getStatus()).isEqualTo(tournament.getStatus());
+    }
+
+    @Test
+    public void 업데이트_토너먼트_없음() {
+        // given
+        Tournament tournament = makeTournament(1234L, TournamentStatus.BEFORE,
+            getTargetTime(2, 1), getTargetTime(2, 3));
+        TournamentAdminUpdateRequestDto updateRequestDto = makeTournamentAdminUpdateRequestDto(
+            getTargetTime(2, 1), getTargetTime(2, 3));
+
+        given(tournamentRepository.findById(tournament.getId())).willReturn(Optional.empty());
+        // when, then
+        assertThatThrownBy(() -> tournamentAdminService.updateTournamentInfo(tournament.getId(), updateRequestDto))
+            .isInstanceOf(TournamentNotFoundException.class);
+    }
+
+    @Test
+    public void 토너먼트_업데이트_불가_상태() {
+        // given
+        Tournament tournamentLive = makeTournament(1L, TournamentStatus.LIVE,
+            getTargetTime(0, -1), getTargetTime(0, 1));
+        Tournament tournamentEnd = makeTournament(2L, TournamentStatus.END,
+            getTargetTime(0, -3), getTargetTime(0, -1));
+        TournamentAdminUpdateRequestDto updateRequestDto = makeTournamentAdminUpdateRequestDto(
+            getTargetTime(2, 1), getTargetTime(2, 3));
+        given(tournamentRepository.findById(tournamentLive.getId())).willReturn(Optional.of(tournamentLive));
+        given(tournamentRepository.findById(tournamentEnd.getId())).willReturn(Optional.of(tournamentEnd));
+        // when, then
+        assertThatThrownBy(() -> tournamentAdminService.updateTournamentInfo(tournamentLive.getId(), updateRequestDto))
+            .isInstanceOf(TournamentUpdateException.class);
+        assertThatThrownBy(() -> tournamentAdminService.updateTournamentInfo(tournamentEnd.getId(), updateRequestDto))
+            .isInstanceOf(TournamentUpdateException.class);
+    }
+
+    @Test
+    public void 업데이트_토너먼트_Dto_Invalid_Time() {
+        // given
+        Tournament tournament = makeTournament(1L, TournamentStatus.BEFORE,
+            getTargetTime(2, 1), getTargetTime(2, 3));
+        TournamentAdminUpdateRequestDto invalidRequestDto1 = makeTournamentAdminUpdateRequestDto(
+            getTargetTime(2, 3), getTargetTime(2, 1));
+        TournamentAdminUpdateRequestDto invalidRequestDto2 = makeTournamentAdminUpdateRequestDto(
+            invalidRequestDto1.getStartTime(), invalidRequestDto1.getStartTime());
+        TournamentAdminUpdateRequestDto invalidRequestDto3 = makeTournamentAdminUpdateRequestDto(
+            getTargetTime(2, -1), getTargetTime(2, 1));
+
+        given(tournamentRepository.findById(1L)).willReturn(Optional.of(tournament));
+        // when then
+        assertThatThrownBy(() -> tournamentAdminService.updateTournamentInfo(tournament.getId(), invalidRequestDto1))
+            .isInstanceOf(InvalidParameterException.class);
+        assertThatThrownBy(() -> tournamentAdminService.updateTournamentInfo(tournament.getId(), invalidRequestDto2))
+            .isInstanceOf(InvalidParameterException.class);
+        assertThatThrownBy(() -> tournamentAdminService.updateTournamentInfo(tournament.getId(), invalidRequestDto3))
+            .isInstanceOf(InvalidParameterException.class);
+    }
+
+    @Test
+    public void Dto_기간_토너먼트_기간_겹침() {
+        // given
+        List<Tournament> tournamentList = makeTournaments(1L, 2, getTargetTime(2, 1));
+        Tournament tournament = tournamentList.get(0);
+        TournamentAdminUpdateRequestDto updateRequestDto = makeTournamentAdminUpdateRequestDto(
+            LocalDateTime.now().plusDays(2).plusHours(3), LocalDateTime.now().plusDays(2).plusHours(4));
+        given(tournamentRepository.findById(1L)).willReturn(Optional.of(tournament));
+        given(tournamentRepository.findAllByStatus(TournamentStatus.BEFORE)).willReturn(tournamentList);
+        // when, then
+        assertThatThrownBy(() -> tournamentAdminService.updateTournamentInfo(tournament.getId(), updateRequestDto))
+            .isInstanceOf(TournamentConflictException.class);
+    }
+
+    /**
+     * 현재 시간에서 days hours, 만큼 차이나는 시간을 구한다.
+     * @param days
+     * @param hours
+     * @return
+     */
+    LocalDateTime getTargetTime(long days, long hours) {
+        return LocalDateTime.now().plusDays(days).plusHours(hours);
+    }
+
+    /**
+     * 각 매개변수로 초기화 된 토너먼트를 반환
+     * @param id
+     * @param status
+     * @param startTime
+     * @param endTime
+     * @return
+     */
+    Tournament makeTournament(Long id, TournamentStatus status, LocalDateTime startTime, LocalDateTime endTime) {
+        return new Tournament(
+            id,
+            id + "st tournament",
+            "",
+            startTime,
+            endTime,
+            TournamentType.ROOKIE,
+            status);
+    }
+
+    /**
+     * <div>id 부터 cnt개 만큼의 토너먼트 리스트를 반환해준다.<div/>
+     * 각 토너먼트는 1시간 길이이며, 토너먼트간 1시간의 간격이 있다.
+     * @param id
+     * @param cnt
+     * @param startTime
+     * @return
+     */
+    List<Tournament> makeTournaments(Long id, long cnt, LocalDateTime startTime) {
+        List<Tournament> tournamentList = new ArrayList<>();
+        for (long i=0; i<cnt; i++) {
+            tournamentList.add(makeTournament(id++, TournamentStatus.BEFORE,
+                startTime.plusHours(i*2), startTime.plusHours((i*2+1))));
+        }
+        return tournamentList;
+    }
+
+    /**
+     * 각 매개변수로 초기화된 TournamentAdminUpdateRequestDto를 반환
+     * @param startTime
+     * @param endTime
+     * @return
+     */
+    TournamentAdminUpdateRequestDto makeTournamentAdminUpdateRequestDto(LocalDateTime startTime, LocalDateTime endTime) {
+        return new TournamentAdminUpdateRequestDto(
+            "tournament changed",
+            "changed",
+            startTime,
+            endTime,
+            TournamentType.ROOKIE
+        );
+    }
+}

--- a/src/test/java/com/gg/server/admin/tournament/service/TournamentAdminServiceTest.java
+++ b/src/test/java/com/gg/server/admin/tournament/service/TournamentAdminServiceTest.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -32,96 +33,105 @@ class TournamentAdminServiceTest {
     @InjectMocks
     TournamentAdminService tournamentAdminService;
 
-    @Test
+    @Nested
     @DisplayName("[Patch] /pingpong/admin/tournament/{tournamentId}")
-    public void 토너먼트_업데이트_성공() {
-        // given
-        List<Tournament> tournamentList = makeTournaments(1L, 2, getTargetTime(2, 1));
-        Tournament tournament = tournamentList.get(0);
-        TournamentAdminUpdateRequestDto updateRequestDto = makeTournamentAdminUpdateRequestDto(
-            getTargetTime(3, 1), getTargetTime(3, 3));
-        given(tournamentRepository.findById(1L)).willReturn(Optional.of(tournament));
-        given(tournamentRepository.findAllByStatus(TournamentStatus.BEFORE)).willReturn(tournamentList);
-        given(tournamentRepository.save(any(Tournament.class))).willReturn(tournament);
-        // when
-        Tournament changedTournament = tournamentAdminService.updateTournamentInfo(1L, updateRequestDto);
-        // then
-        assertThat(changedTournament.getId()).isEqualTo(tournament.getId());
-        assertThat(changedTournament.getTitle()).isEqualTo(updateRequestDto.getTitle());
-        assertThat(changedTournament.getContents()).isEqualTo(updateRequestDto.getContents());
-        assertThat(changedTournament.getStartTime()).isEqualTo(updateRequestDto.getStartTime());
-        assertThat(changedTournament.getEndTime()).isEqualTo(updateRequestDto.getEndTime());
-        assertThat(changedTournament.getType()).isEqualTo(updateRequestDto.getType());
-        assertThat(changedTournament.getStatus()).isEqualTo(tournament.getStatus());
+    class TournamentAdminServiceUpdateTest {
+        @Test
+        @DisplayName("토너먼트_업데이트_성공")
+        public void success() {
+            // given
+            List<Tournament> tournamentList = makeTournaments(1L, 2, getTargetTime(2, 1));
+            Tournament tournament = tournamentList.get(0);
+            TournamentAdminUpdateRequestDto updateRequestDto = makeTournamentAdminUpdateRequestDto(
+                getTargetTime(3, 1), getTargetTime(3, 3));
+            given(tournamentRepository.findById(1L)).willReturn(Optional.of(tournament));
+            given(tournamentRepository.findAllByStatus(TournamentStatus.BEFORE)).willReturn(tournamentList);
+            given(tournamentRepository.save(any(Tournament.class))).willReturn(tournament);
+            // when
+            Tournament changedTournament = tournamentAdminService.updateTournamentInfo(1L, updateRequestDto);
+            // then
+            assertThat(changedTournament.getId()).isEqualTo(tournament.getId());
+            assertThat(changedTournament.getTitle()).isEqualTo(updateRequestDto.getTitle());
+            assertThat(changedTournament.getContents()).isEqualTo(updateRequestDto.getContents());
+            assertThat(changedTournament.getStartTime()).isEqualTo(updateRequestDto.getStartTime());
+            assertThat(changedTournament.getEndTime()).isEqualTo(updateRequestDto.getEndTime());
+            assertThat(changedTournament.getType()).isEqualTo(updateRequestDto.getType());
+            assertThat(changedTournament.getStatus()).isEqualTo(tournament.getStatus());
+        }
+
+        @Test
+        @DisplayName("타겟_토너먼트_없음")
+        public void tournamentNotFound() {
+            // given
+            Tournament tournament = makeTournament(1234L, TournamentStatus.BEFORE,
+                getTargetTime(2, 1), getTargetTime(2, 3));
+            TournamentAdminUpdateRequestDto updateRequestDto = makeTournamentAdminUpdateRequestDto(
+                getTargetTime(2, 1), getTargetTime(2, 3));
+
+            given(tournamentRepository.findById(tournament.getId())).willReturn(Optional.empty());
+            // when, then
+            assertThatThrownBy(() -> tournamentAdminService.updateTournamentInfo(tournament.getId(), updateRequestDto))
+                .isInstanceOf(TournamentNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("토너먼트_업데이트_불가_상태")
+        public void canNotUpadate() {
+            // given
+            Tournament tournamentLive = makeTournament(1L, TournamentStatus.LIVE,
+                getTargetTime(0, -1), getTargetTime(0, 1));
+            Tournament tournamentEnd = makeTournament(2L, TournamentStatus.END,
+                getTargetTime(0, -3), getTargetTime(0, -1));
+            TournamentAdminUpdateRequestDto updateRequestDto = makeTournamentAdminUpdateRequestDto(
+                getTargetTime(2, 1), getTargetTime(2, 3));
+            given(tournamentRepository.findById(tournamentLive.getId())).willReturn(Optional.of(tournamentLive));
+            given(tournamentRepository.findById(tournamentEnd.getId())).willReturn(Optional.of(tournamentEnd));
+            // when, then
+            assertThatThrownBy(() -> tournamentAdminService.updateTournamentInfo(tournamentLive.getId(), updateRequestDto))
+                .isInstanceOf(TournamentUpdateException.class);
+            assertThatThrownBy(() -> tournamentAdminService.updateTournamentInfo(tournamentEnd.getId(), updateRequestDto))
+                .isInstanceOf(TournamentUpdateException.class);
+        }
+
+        @Test
+        @DisplayName("업데이트_토너먼트_Dto_Invalid_Time")
+        public void Dto_Invalid_Time() {
+            // given
+            Tournament tournament = makeTournament(1L, TournamentStatus.BEFORE,
+                getTargetTime(2, 1), getTargetTime(2, 3));
+            TournamentAdminUpdateRequestDto invalidRequestDto1 = makeTournamentAdminUpdateRequestDto(
+                getTargetTime(2, 3), getTargetTime(2, 1));
+            TournamentAdminUpdateRequestDto invalidRequestDto2 = makeTournamentAdminUpdateRequestDto(
+                invalidRequestDto1.getStartTime(), invalidRequestDto1.getStartTime());
+            TournamentAdminUpdateRequestDto invalidRequestDto3 = makeTournamentAdminUpdateRequestDto(
+                getTargetTime(2, -1), getTargetTime(2, 1));
+
+            given(tournamentRepository.findById(1L)).willReturn(Optional.of(tournament));
+            // when then
+            assertThatThrownBy(() -> tournamentAdminService.updateTournamentInfo(tournament.getId(), invalidRequestDto1))
+                .isInstanceOf(InvalidParameterException.class);
+            assertThatThrownBy(() -> tournamentAdminService.updateTournamentInfo(tournament.getId(), invalidRequestDto2))
+                .isInstanceOf(InvalidParameterException.class);
+            assertThatThrownBy(() -> tournamentAdminService.updateTournamentInfo(tournament.getId(), invalidRequestDto3))
+                .isInstanceOf(InvalidParameterException.class);
+        }
+
+        @Test
+        @DisplayName("Dto_기간_토너먼트_기간_겹침")
+        public void tournamentTimeConflict() {
+            // given
+            List<Tournament> tournamentList = makeTournaments(1L, 2, getTargetTime(2, 1));
+            Tournament tournament = tournamentList.get(0);
+            TournamentAdminUpdateRequestDto updateRequestDto = makeTournamentAdminUpdateRequestDto(
+                LocalDateTime.now().plusDays(2).plusHours(3), LocalDateTime.now().plusDays(2).plusHours(5));
+            given(tournamentRepository.findById(1L)).willReturn(Optional.of(tournament));
+            given(tournamentRepository.findAllByStatus(TournamentStatus.BEFORE)).willReturn(tournamentList);
+            // when, then
+            assertThatThrownBy(() -> tournamentAdminService.updateTournamentInfo(tournament.getId(), updateRequestDto))
+                .isInstanceOf(TournamentConflictException.class);
+        }
     }
 
-    @Test
-    public void 업데이트_토너먼트_없음() {
-        // given
-        Tournament tournament = makeTournament(1234L, TournamentStatus.BEFORE,
-            getTargetTime(2, 1), getTargetTime(2, 3));
-        TournamentAdminUpdateRequestDto updateRequestDto = makeTournamentAdminUpdateRequestDto(
-            getTargetTime(2, 1), getTargetTime(2, 3));
-
-        given(tournamentRepository.findById(tournament.getId())).willReturn(Optional.empty());
-        // when, then
-        assertThatThrownBy(() -> tournamentAdminService.updateTournamentInfo(tournament.getId(), updateRequestDto))
-            .isInstanceOf(TournamentNotFoundException.class);
-    }
-
-    @Test
-    public void 토너먼트_업데이트_불가_상태() {
-        // given
-        Tournament tournamentLive = makeTournament(1L, TournamentStatus.LIVE,
-            getTargetTime(0, -1), getTargetTime(0, 1));
-        Tournament tournamentEnd = makeTournament(2L, TournamentStatus.END,
-            getTargetTime(0, -3), getTargetTime(0, -1));
-        TournamentAdminUpdateRequestDto updateRequestDto = makeTournamentAdminUpdateRequestDto(
-            getTargetTime(2, 1), getTargetTime(2, 3));
-        given(tournamentRepository.findById(tournamentLive.getId())).willReturn(Optional.of(tournamentLive));
-        given(tournamentRepository.findById(tournamentEnd.getId())).willReturn(Optional.of(tournamentEnd));
-        // when, then
-        assertThatThrownBy(() -> tournamentAdminService.updateTournamentInfo(tournamentLive.getId(), updateRequestDto))
-            .isInstanceOf(TournamentUpdateException.class);
-        assertThatThrownBy(() -> tournamentAdminService.updateTournamentInfo(tournamentEnd.getId(), updateRequestDto))
-            .isInstanceOf(TournamentUpdateException.class);
-    }
-
-    @Test
-    public void 업데이트_토너먼트_Dto_Invalid_Time() {
-        // given
-        Tournament tournament = makeTournament(1L, TournamentStatus.BEFORE,
-            getTargetTime(2, 1), getTargetTime(2, 3));
-        TournamentAdminUpdateRequestDto invalidRequestDto1 = makeTournamentAdminUpdateRequestDto(
-            getTargetTime(2, 3), getTargetTime(2, 1));
-        TournamentAdminUpdateRequestDto invalidRequestDto2 = makeTournamentAdminUpdateRequestDto(
-            invalidRequestDto1.getStartTime(), invalidRequestDto1.getStartTime());
-        TournamentAdminUpdateRequestDto invalidRequestDto3 = makeTournamentAdminUpdateRequestDto(
-            getTargetTime(2, -1), getTargetTime(2, 1));
-
-        given(tournamentRepository.findById(1L)).willReturn(Optional.of(tournament));
-        // when then
-        assertThatThrownBy(() -> tournamentAdminService.updateTournamentInfo(tournament.getId(), invalidRequestDto1))
-            .isInstanceOf(InvalidParameterException.class);
-        assertThatThrownBy(() -> tournamentAdminService.updateTournamentInfo(tournament.getId(), invalidRequestDto2))
-            .isInstanceOf(InvalidParameterException.class);
-        assertThatThrownBy(() -> tournamentAdminService.updateTournamentInfo(tournament.getId(), invalidRequestDto3))
-            .isInstanceOf(InvalidParameterException.class);
-    }
-
-    @Test
-    public void Dto_기간_토너먼트_기간_겹침() {
-        // given
-        List<Tournament> tournamentList = makeTournaments(1L, 2, getTargetTime(2, 1));
-        Tournament tournament = tournamentList.get(0);
-        TournamentAdminUpdateRequestDto updateRequestDto = makeTournamentAdminUpdateRequestDto(
-            LocalDateTime.now().plusDays(2).plusHours(3), LocalDateTime.now().plusDays(2).plusHours(4));
-        given(tournamentRepository.findById(1L)).willReturn(Optional.of(tournament));
-        given(tournamentRepository.findAllByStatus(TournamentStatus.BEFORE)).willReturn(tournamentList);
-        // when, then
-        assertThatThrownBy(() -> tournamentAdminService.updateTournamentInfo(tournament.getId(), updateRequestDto))
-            .isInstanceOf(TournamentConflictException.class);
-    }
 
     /**
      * 현재 시간에서 days hours, 만큼 차이나는 시간을 구한다.

--- a/src/test/java/com/gg/server/utils/TestDataUtils.java
+++ b/src/test/java/com/gg/server/utils/TestDataUtils.java
@@ -1,5 +1,6 @@
 package com.gg.server.utils;
 
+import com.gg.server.admin.tournament.dto.TournamentAdminUpdateRequestDto;
 import com.gg.server.domain.game.data.Game;
 import com.gg.server.domain.game.data.GameRepository;
 import com.gg.server.domain.noti.data.Noti;
@@ -20,6 +21,10 @@ import com.gg.server.domain.team.data.TeamUser;
 import com.gg.server.domain.team.data.TeamUserRepository;
 import com.gg.server.domain.tier.data.Tier;
 import com.gg.server.domain.tier.data.TierRepository;
+import com.gg.server.domain.tournament.data.Tournament;
+import com.gg.server.domain.tournament.data.TournamentRepository;
+import com.gg.server.domain.tournament.type.TournamentStatus;
+import com.gg.server.domain.tournament.type.TournamentType;
 import com.gg.server.domain.user.data.User;
 import com.gg.server.domain.user.data.UserRepository;
 import com.gg.server.domain.user.controller.dto.GameInfoDto;
@@ -49,6 +54,7 @@ public class TestDataUtils {
     private final PChangeRepository pChangeRepository;
     private final RankRepository rankRepository;
     private final TierRepository tierRepository;
+    private final TournamentRepository tournamentRepository;
 
     public String getLoginAccessToken() {
         User user = User.builder()
@@ -253,5 +259,26 @@ public class TestDataUtils {
 
         pChangeRepository.save(pChange1);
         pChangeRepository.save(pChange2);
+    }
+
+    public Tournament createTournament(LocalDateTime startTime, LocalDateTime endTime, TournamentStatus status) {
+        Tournament tournament = Tournament.builder()
+            .title("title")
+            .contents("contents")
+            .startTime(startTime)
+            .endTime(endTime)
+            .type(TournamentType.ROOKIE)
+            .status(status).build();
+        tournamentRepository.save(tournament);
+        return  tournament;
+    }
+
+    public TournamentAdminUpdateRequestDto createUpdateRequestDto(LocalDateTime startTime, LocalDateTime endTime, TournamentType type) {
+        return new TournamentAdminUpdateRequestDto(
+            "title",
+            "contents",
+            startTime,
+            endTime,
+            type);
     }
 }


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 토너먼트 수정 API 구현 및 테스트 코드 추가
  - 토너먼트 수정에 필요한 controller, service, dto 추가
  - 토너먼트 엔티티에 매서드 추가
  - 토너먼트 레포 매서드 추가
  - 테스트 코드 추가
  - 통합 테스트용 매서드 추가
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - `TournamentAdminUpdateRequestDto 추가`
  - `토너먼트 관리자 서비스 수정 매서드 추가`
    - **updateTournamentInfo**: 토너먼트 수정 매서드
    - **checkValidTournamentTime**: 토너먼트 개최 가능 시간 판별 매서드
    - **checkConflictedTournament**: 기존 토너먼트들과 중복하는 기간인지 판별하는 매서드
  - `토너먼트 관리자 수정 컨트롤러 매서드 추가`
  - `TestDataUtils 통합테스트용 유틸 매서드 추가`
    - **createTournament**: 테스트용으로 토너먼트 객체 생성, 매개변수로 받는 값들만 초기화
    - **TournamentAdminUpdateRequestDto**: 테스트용으로 dto 객체 생성, 매개변수로 받는 값들만 초기화
  - `TournamentRepository findAllByStatus 매서드 추가` : 토너먼트 개최 상태에 따른 토너먼트들을 받아오는 매서드
  - `토너먼트 entity update() & toString() 추가`
    - **update**: 토너먼트 entity 수정용 매서드
    - ~~`toString`: 필드값들 확인용으로 추가~~
    - `@ToString` 추가
  - `토너먼트 수정 controller & service 테스트 추가`
    - **controller**: 통합 테스트 
    - **service 계층 단위 테스트 추가**
      - `@Nested` 를 사용해 블록단위로 분리

 ## 💡Issue 번호 <!-- issue number을 link 시켜주세요 (ex. "- close #4242") -->
 - close #301 