### PR TITLE
:hammer: [Refactor] 토너먼트, 토너먼트 게임 테이블 수정

### DIFF
--- a/src/main/java/com/gg/server/domain/tournament/data/Tournament.java
+++ b/src/main/java/com/gg/server/domain/tournament/data/Tournament.java
@@ -2,9 +2,11 @@ package com.gg.server.domain.tournament.data;
 
 import com.gg.server.domain.tournament.type.TournamentStatus;
 import com.gg.server.domain.tournament.type.TournamentType;
+import com.gg.server.domain.user.data.User;
 import com.gg.server.global.utils.BaseTimeEntity;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
 
@@ -43,6 +45,16 @@ public class Tournament extends BaseTimeEntity {
     @Column(name = "status")
     @Enumerated(EnumType.STRING)
     private TournamentStatus status;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "winner_id")
+    private User winner;
+
+    @OneToMany(mappedBy = "tournament")
+    private List<TournamentGame> tournamentGames;
+
+    @OneToMany(mappedBy = "tournament")
+    private List<TournamentUser> tournamentUsers;
 
     @Builder
     public Tournament(String title, String contents, LocalDateTime startTime, LocalDateTime endTime, TournamentType type, TournamentStatus status) {

--- a/src/main/java/com/gg/server/domain/tournament/data/TournamentGame.java
+++ b/src/main/java/com/gg/server/domain/tournament/data/TournamentGame.java
@@ -20,7 +20,6 @@ public class TournamentGame extends BaseTimeEntity {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @NotNull
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "game_id")
     private Game game;

--- a/src/main/resources/db/migration/V3__migration_42gg_5th.sql
+++ b/src/main/resources/db/migration/V3__migration_42gg_5th.sql
@@ -8,8 +8,10 @@ CREATE TABLE tournament (
     type                VARCHAR(15) NOT NULL,
     status              VARCHAR(10) NOT NULL DEFAULT 'BEFORE',
     created_at          DATETIME NOT NULL,
-    modified_at          DATETIME NOT NULL,
-    PRIMARY KEY (id)
+    modified_at         DATETIME NOT NULL,
+    winner_id           BIGINT,
+    PRIMARY KEY (id),
+    FOREIGN KEY (winner_id) REFERENCES user(id)
 );
 
 ### TournamentUser ###
@@ -30,7 +32,7 @@ CREATE TABLE tournament_user (
 CREATE TABLE tournament_game (
     id                  BIGINT NOT NULL AUTO_INCREMENT,
     tournament_id       BIGINT NOT NULL,
-    game_id             BIGINT NOT NULL,
+    game_id             BIGINT,
     round               VARCHAR(10) NOT NULL,
     created_at          DATETIME NOT NULL,
     modified_at          DATETIME NOT NULL,


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 토너먼트, 토너먼트 게임 테이블 수정
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
### `Tournament` 테이블 수정
  - 토너먼트 테이블 `winner_id` 추가(nullable user_id fk)
    - 토너먼트 조회할 때 기존에 winner를 찾기 위해서 너무 많은 join이 필요하고 depth가 깊어지는 문제점을 해결하기 위해 nullable한 `winner_id` 컬럼을 추가하기로 결정되었습니다.
### `TournamentGame` 테이블 수정
  - 토너먼트 게임 테이블 `game_id` (fk) nullable하게 수정
    -  Response Dto에서 다음 경기에 대한 정보가 필요해서, `tournament_game_id` 값을 사용하기로 결정되었습니다.
    - 이에 따라 tournament 생성 시점에 touranment_game도 함께 생성되어야 하고 game은 생성되지 않을 수 있으므로 `game_id`를 nullable하게 수정했습니다.
 ## 💡Issue 번호 <!-- issue number을 link 시켜주세요 (ex. "- close #4242") -->
 - close #312