### PR TITLE
:bug: [Fix]  tournament 관련 테이블의 varchar 길이 수정

### DIFF
--- a/src/main/resources/db/migration/V3__migration_42gg_5th.sql
+++ b/src/main/resources/db/migration/V3__migration_42gg_5th.sql
@@ -1,7 +1,7 @@
 ### Tournament ###
 CREATE TABLE tournament (
     id                  BIGINT NOT NULL AUTO_INCREMENT,
-    title               VARCHAR(20) NOT NULL,
+    title               VARCHAR(30) NOT NULL,
     contents            VARCHAR(1000) NOT NULL,
     start_time          DATETIME NOT NULL,
     end_time            DATETIME NOT NULL,

--- a/src/main/resources/db/migration/V3__migration_42gg_5th.sql
+++ b/src/main/resources/db/migration/V3__migration_42gg_5th.sql
@@ -33,7 +33,7 @@ CREATE TABLE tournament_game (
     id                  BIGINT NOT NULL AUTO_INCREMENT,
     tournament_id       BIGINT NOT NULL,
     game_id             BIGINT,
-    round               VARCHAR(10) NOT NULL,
+    round               VARCHAR(20) NOT NULL,
     created_at          DATETIME NOT NULL,
     modified_at          DATETIME NOT NULL,
     PRIMARY KEY (id),


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - tournament 관련 테이블의 `VARCHAR` column 길이 수정
  
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - `tournament_game` 데이터가 생성될 때 enum 길이가 길어서 저장이 안 되는 문제가 발생
    - `round` 컬럼을 `VARCHAR(10)` -> `VARCHAR(20)`으로 수정
  - `tournament`의 `title` column도 `VARCHAR(20)` -> `VARCHAR(30)`으로 수정했습니다.
  