### PR TITLE
:sparkles: [Feature] 토너먼트 관리자 삭제 API 추가

### DIFF
--- a/src/main/java/com/gg/server/admin/tournament/controller/TournamentAdminController.java
+++ b/src/main/java/com/gg/server/admin/tournament/controller/TournamentAdminController.java
@@ -8,6 +8,7 @@ import org.checkerframework.checker.index.qual.Positive;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -25,7 +26,6 @@ public class TournamentAdminController {
      * 토너먼트 정보 수정
      * @param tournamentId 업데이트 하고자 하는 토너먼트 id
      * @param tournamentAdminUpdateRequestDto 요청 데이터
-     * @return
      */
     @PatchMapping("/{tournamentId}")
     public ResponseEntity<Void> updateTournamentInfo(@PathVariable @Positive Long tournamentId,
@@ -35,4 +35,14 @@ public class TournamentAdminController {
         return new ResponseEntity<Void>(HttpStatus.NO_CONTENT);
     }
 
+    /**
+     * 토너먼트 정보 삭제
+     * @param tournamentId 삭제 하고자 하는 토너먼트 id
+     */
+    @DeleteMapping("/{tournamentId}")
+    public ResponseEntity<Void> deleteTournamentInfo(@PathVariable @Positive Long tournamentId) {
+        tournamentAdminService.deleteTournamentInfo(tournamentId);
+
+        return new ResponseEntity<Void>(HttpStatus.NO_CONTENT);
+    }
 }

--- a/src/main/java/com/gg/server/admin/tournament/controller/TournamentAdminController.java
+++ b/src/main/java/com/gg/server/admin/tournament/controller/TournamentAdminController.java
@@ -24,7 +24,7 @@ public class TournamentAdminController {
 
     /**
      * 토너먼트 정보 수정
-     * @param tournamentId 업데이트 하고자 하는 토너먼트 id
+     * @param tournamentId 업데이트하고자 하는 토너먼트 id
      * @param tournamentAdminUpdateRequestDto 요청 데이터
      */
     @PatchMapping("/{tournamentId}")
@@ -37,7 +37,7 @@ public class TournamentAdminController {
 
     /**
      * 토너먼트 정보 삭제
-     * @param tournamentId 삭제 하고자 하는 토너먼트 id
+     * @param tournamentId 삭제하고자 하는 토너먼트 id
      */
     @DeleteMapping("/{tournamentId}")
     public ResponseEntity<Void> deleteTournamentInfo(@PathVariable @Positive Long tournamentId) {

--- a/src/main/java/com/gg/server/admin/tournament/dto/TournamentAdminUpdateRequestDto.java
+++ b/src/main/java/com/gg/server/admin/tournament/dto/TournamentAdminUpdateRequestDto.java
@@ -5,13 +5,16 @@ import java.time.LocalDateTime;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.validation.constraints.NotNull;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.format.annotation.DateTimeFormat.ISO;
 
 @Getter
 @AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TournamentAdminUpdateRequestDto {
     @NotNull(message = "제목이 필요합니다.")
     private String title;

--- a/src/main/java/com/gg/server/admin/tournament/service/TournamentAdminService.java
+++ b/src/main/java/com/gg/server/admin/tournament/service/TournamentAdminService.java
@@ -104,7 +104,7 @@ public class TournamentAdminService {
                 (startTime.isBefore(tournament.getStartTime()) && endTime.isAfter(tournament.getEndTime())) ||
                 startTime.isEqual(tournament.getStartTime()) || startTime.isEqual(tournament.getEndTime()) ||
                 endTime.isEqual(tournament.getEndTime()) || endTime.isEqual(tournament.getStartTime())) {
-                throw new TournamentConflictException("tournament conflicted", ErrorCode.TOURNAMENT_TIME_CONFLICT);
+                throw new TournamentConflictException("tournament conflicted", ErrorCode.TOURNAMENT_CONFLICT);
             }
         }
     }

--- a/src/main/java/com/gg/server/admin/tournament/service/TournamentAdminService.java
+++ b/src/main/java/com/gg/server/admin/tournament/service/TournamentAdminService.java
@@ -79,7 +79,6 @@ public class TournamentAdminService {
      * @throws InvalidParameterException 토너먼트 시간으로 부적합 할 때
      */
     private void checkValidTournamentTime(LocalDateTime startTime, LocalDateTime endTime) {
-
         if (startTime.isAfter(endTime) || startTime.isEqual(endTime) ||
             startTime.isBefore(LocalDateTime.now().plusDays(ALLOWED_MINIMAL_START_DAYS)) ||
             startTime.plusHours(MINIMUM_TOURNAMENT_DURATION).isAfter(endTime)) {
@@ -95,7 +94,7 @@ public class TournamentAdminService {
      * @throws TournamentConflictException 업데이트 하고자 하는 토너먼트의 시간이 겹칠 때
      */
     private void checkConflictedTournament(Long targetTournamentId, LocalDateTime startTime, LocalDateTime endTime) {
-        List<Tournament> tournamentList = tournamentRepository.findAllByStatus(TournamentStatus.BEFORE);
+        List<Tournament> tournamentList = tournamentRepository.findAllByStatusBeforeAndLive();
         for (Tournament tournament : tournamentList) {
             if (targetTournamentId.equals(tournament.getId())) {
                 continue;

--- a/src/main/java/com/gg/server/admin/tournament/service/TournamentAdminService.java
+++ b/src/main/java/com/gg/server/admin/tournament/service/TournamentAdminService.java
@@ -52,7 +52,8 @@ public class TournamentAdminService {
     }
 
     /**
-     * 토너먼트 삭제 매서드
+     * 토너먼트 삭제 매서드:
+     * 토너먼트는 BEFORE 인 경우에만 삭제 가능하다.
      * @param tournamentId 타겟 토너먼트 id
      * @throws TournamentNotFoundException 찾을 수 없는 토너먼트 일 때
      * @throws TournamentUpdateException 업데이트 할 수 없는 토너먼트 일 때
@@ -94,7 +95,7 @@ public class TournamentAdminService {
      * @throws TournamentConflictException 업데이트 하고자 하는 토너먼트의 시간이 겹칠 때
      */
     private void checkConflictedTournament(Long targetTournamentId, LocalDateTime startTime, LocalDateTime endTime) {
-        List<Tournament> tournamentList = tournamentRepository.findAllByStatusBeforeAndLive();
+        List<Tournament> tournamentList = tournamentRepository.findAllByStatusIsNot(TournamentStatus.END);
         for (Tournament tournament : tournamentList) {
             if (targetTournamentId.equals(tournament.getId())) {
                 continue;

--- a/src/main/java/com/gg/server/admin/tournament/service/TournamentAdminService.java
+++ b/src/main/java/com/gg/server/admin/tournament/service/TournamentAdminService.java
@@ -25,6 +25,7 @@ public class TournamentAdminService {
     private static final long ALLOWED_MINIMAL_START_DAYS = 2;
     // 토너먼트 최소 진행 시간 (n시간)
     private static final long MINIMUM_TOURNAMENT_DURATION = 2;
+
     /**
      * 토너먼트 업데이트 Method
      * @param tournamentId  업데이트할 토너먼트 id

--- a/src/main/java/com/gg/server/domain/tournament/data/Tournament.java
+++ b/src/main/java/com/gg/server/domain/tournament/data/Tournament.java
@@ -98,5 +98,4 @@ public class Tournament extends BaseTimeEntity {
         this.type = type;
         this.status = status;
     }
-
 }

--- a/src/main/java/com/gg/server/domain/tournament/data/Tournament.java
+++ b/src/main/java/com/gg/server/domain/tournament/data/Tournament.java
@@ -6,6 +6,7 @@ import com.gg.server.domain.user.data.User;
 import com.gg.server.global.utils.BaseTimeEntity;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
@@ -52,10 +53,10 @@ public class Tournament extends BaseTimeEntity {
     private User winner;
 
     @OneToMany(mappedBy = "tournament")
-    private List<TournamentGame> tournamentGames;
+    private List<TournamentGame> tournamentGames = new ArrayList<>();
 
     @OneToMany(mappedBy = "tournament")
-    private List<TournamentUser> tournamentUsers;
+    private List<TournamentUser> tournamentUsers = new ArrayList<>();
 
     @Builder
     public Tournament(String title, String contents, LocalDateTime startTime, LocalDateTime endTime, TournamentType type, TournamentStatus status) {

--- a/src/main/java/com/gg/server/domain/tournament/data/TournamentGame.java
+++ b/src/main/java/com/gg/server/domain/tournament/data/TournamentGame.java
@@ -30,7 +30,14 @@ public class TournamentGame extends BaseTimeEntity {
     private Tournament tournament;
 
     @NotNull
-    @Column(name = "round")
+    @Column(name = "round", length = 30)
     @Enumerated(EnumType.STRING)
     private TournamentRound tournamentRound;
+
+
+    public TournamentGame(Game game, Tournament tournament, TournamentRound tournamentRound) {
+        this.game = game;
+        this.tournament = tournament;
+        this.tournamentRound = tournamentRound;
+    }
 }

--- a/src/main/java/com/gg/server/domain/tournament/data/TournamentGame.java
+++ b/src/main/java/com/gg/server/domain/tournament/data/TournamentGame.java
@@ -35,6 +35,12 @@ public class TournamentGame extends BaseTimeEntity {
     private TournamentRound tournamentRound;
 
 
+    /**
+     * id 값 제외한 생성자
+     * @param game
+     * @param tournament
+     * @param tournamentRound
+     */
     public TournamentGame(Game game, Tournament tournament, TournamentRound tournamentRound) {
         this.game = game;
         this.tournament = tournament;

--- a/src/main/java/com/gg/server/domain/tournament/data/TournamentGameRepository.java
+++ b/src/main/java/com/gg/server/domain/tournament/data/TournamentGameRepository.java
@@ -1,6 +1,8 @@
 package com.gg.server.domain.tournament.data;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TournamentGameRepository extends JpaRepository<TournamentGame, Long> {
+    List<TournamentGame> findAllByTournamentId(Long tournamentId);
 }

--- a/src/main/java/com/gg/server/domain/tournament/data/TournamentGameRepository.java
+++ b/src/main/java/com/gg/server/domain/tournament/data/TournamentGameRepository.java
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TournamentGameRepository extends JpaRepository<TournamentGame, Long> {
     List<TournamentGame> findAllByTournamentId(Long tournamentId);
+
 }

--- a/src/main/java/com/gg/server/domain/tournament/data/TournamentRepository.java
+++ b/src/main/java/com/gg/server/domain/tournament/data/TournamentRepository.java
@@ -3,7 +3,11 @@ package com.gg.server.domain.tournament.data;
 import com.gg.server.domain.tournament.type.TournamentStatus;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface TournamentRepository extends JpaRepository<Tournament, Long> {
     List<Tournament> findAllByStatus(TournamentStatus status);
+
+    @Query(value = "select t from Tournament t where  t.status='before' or t.status='live'")
+    List<Tournament> findAllByStatusBeforeAndLive();
 }

--- a/src/main/java/com/gg/server/domain/tournament/data/TournamentRepository.java
+++ b/src/main/java/com/gg/server/domain/tournament/data/TournamentRepository.java
@@ -8,6 +8,5 @@ import org.springframework.data.jpa.repository.Query;
 public interface TournamentRepository extends JpaRepository<Tournament, Long> {
     List<Tournament> findAllByStatus(TournamentStatus status);
 
-    @Query(value = "select t from Tournament t where  t.status='before' or t.status='live'")
-    List<Tournament> findAllByStatusBeforeAndLive();
+    List<Tournament> findAllByStatusIsNot(TournamentStatus status);
 }

--- a/src/main/java/com/gg/server/global/exception/ErrorCode.java
+++ b/src/main/java/com/gg/server/global/exception/ErrorCode.java
@@ -117,7 +117,7 @@ public enum ErrorCode {
 
     // Tournament
     TOURNAMENT_NOT_FOUND(404, "TN001", "tournament not found"),
-    TOURNAMENT_TIME_CONFLICT(409, "TN002", "tournament time conflicted"),
+    TOURNAMENT_TIME_CONFLICT(409, "TN002", "tournament conflicted"),
     TOURNAMENT_NOT_BEFORE(400, "TN003", "tournament status is not before")
     ;
     private int status;

--- a/src/main/java/com/gg/server/global/exception/ErrorCode.java
+++ b/src/main/java/com/gg/server/global/exception/ErrorCode.java
@@ -117,7 +117,7 @@ public enum ErrorCode {
 
     // Tournament
     TOURNAMENT_NOT_FOUND(404, "TN001", "tournament not found"),
-    TOURNAMENT_TIME_CONFLICT(409, "TN002", "tournament conflicted"),
+    TOURNAMENT_CONFLICT(409, "TN002", "tournament conflicted"),
     TOURNAMENT_NOT_BEFORE(400, "TN003", "tournament status is not before")
     ;
     private int status;

--- a/src/test/java/com/gg/server/admin/tournament/controller/TournamentAdminControllerTest.java
+++ b/src/test/java/com/gg/server/admin/tournament/controller/TournamentAdminControllerTest.java
@@ -1,5 +1,6 @@
 package com.gg.server.admin.tournament.controller;
 
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -7,11 +8,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.gg.server.admin.tournament.dto.TournamentAdminUpdateRequestDto;
 import com.gg.server.admin.tournament.service.TournamentAdminService;
 import com.gg.server.domain.tournament.data.Tournament;
+import com.gg.server.domain.tournament.data.TournamentGame;
 import com.gg.server.domain.tournament.type.TournamentStatus;
 import com.gg.server.domain.tournament.type.TournamentType;
 import com.gg.server.global.security.jwt.utils.AuthTokenProvider;
 import com.gg.server.utils.TestDataUtils;
 import java.time.LocalDateTime;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.apache.http.HttpHeaders;
 import org.junit.jupiter.api.DisplayName;
@@ -71,9 +74,15 @@ class TournamentAdminControllerTest {
 
             // when, then
             String contentAsString = mockMvc.perform(patch(url)
+<<<<<<< HEAD
                     .content(content)
                     .contentType(MediaType.APPLICATION_JSON)
                     .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+=======
+                .content(content)
+                .contentType(MediaType.APPLICATION_JSON)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+>>>>>>> 8786b173 (:green_heart: chore: Add tmp commit for rebase)
                 .andExpect(status().isNoContent())
                 .andReturn().getResponse().getContentAsString();
 
@@ -97,9 +106,9 @@ class TournamentAdminControllerTest {
             String content = objectMapper.writeValueAsString(updateDto);
             // when, then
             String contentAsString = mockMvc.perform(patch(url)
-                    .content(content)
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .content(content)
+                .contentType(MediaType.APPLICATION_JSON)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
                 .andExpect(status().isNotFound())
                 .andReturn().getResponse().getContentAsString();
 
@@ -135,9 +144,9 @@ class TournamentAdminControllerTest {
 
             // when, then
             String contentAsString = mockMvc.perform(patch(url)
-                    .content(content)
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .content(content)
+                .contentType(MediaType.APPLICATION_JSON)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
                 .andExpect(status().isConflict())
                 .andReturn().getResponse().getContentAsString();
 
@@ -172,9 +181,9 @@ class TournamentAdminControllerTest {
 
             // when live tournament test, then
             String contentAsString = mockMvc.perform(patch(url)
-                    .content(content)
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .content(content)
+                .contentType(MediaType.APPLICATION_JSON)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
                 .andExpect(status().isBadRequest())
                 .andReturn().getResponse().getContentAsString();
 
@@ -266,6 +275,95 @@ class TournamentAdminControllerTest {
                     .content(content)
                     .contentType(MediaType.APPLICATION_JSON)
                     .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isBadRequest())
+                .andReturn().getResponse().getContentAsString();
+
+            System.out.println(contentAsString);
+        }
+    }
+
+    @Nested
+    @DisplayName("토너먼트 관리 삭제 컨트롤러 테스트")
+    class TournamentAdminControllerDeleteTest {
+        @Test
+        @DisplayName("토너먼트_삭제_성공")
+        void success() throws Exception {
+            // given
+            String accessToken = testDataUtils.getAdminLoginAccessToken();
+            tokenProvider.getUserIdFromAccessToken(accessToken);
+
+            Tournament tournament = testDataUtils.createTournament(
+                LocalDateTime.now().plusDays(2).plusHours(1),
+                LocalDateTime.now().plusDays(2).plusHours(3),
+                TournamentStatus.BEFORE);
+
+            List<TournamentGame> tournamentGameList = testDataUtils.createTournamentGameList(tournament, 7);
+
+            String url = "/pingpong/admin/tournament/" + tournament.getId();
+
+            // when, then
+            String contentAsString = mockMvc.perform(delete(url)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isNoContent())
+                .andReturn().getResponse().getContentAsString();
+
+            System.out.println(contentAsString);
+        }
+
+        @Test
+        @DisplayName("토너먼트_없는_경우")
+        void tournamentNotFound() throws Exception {
+            // given
+            String accessToken = testDataUtils.getAdminLoginAccessToken();
+            tokenProvider.getUserIdFromAccessToken(accessToken);
+
+            String url = "/pingpong/admin/tournament/" + 1111;
+
+            // when, then
+            String contentAsString = mockMvc.perform(delete(url)
+                .contentType(MediaType.APPLICATION_JSON)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isNotFound())
+                .andReturn().getResponse().getContentAsString();
+
+            System.out.println(contentAsString);
+        }
+
+        @Test
+        @DisplayName("이미_시작했거나_종료된_토너먼트_수정")
+        void canNotDelete() throws Exception {
+            // given
+            String accessToken = testDataUtils.getAdminLoginAccessToken();
+            tokenProvider.getUserIdFromAccessToken(accessToken);
+
+            Tournament liveTournament = testDataUtils.createTournament(
+                LocalDateTime.now().minusHours(1),
+                LocalDateTime.now().plusHours(2),
+                TournamentStatus.LIVE);
+
+            Tournament endedTournament = testDataUtils.createTournament(
+                LocalDateTime.now().minusHours(3),
+                LocalDateTime.now().minusHours(1),
+                TournamentStatus.END);
+
+            String url = "/pingpong/admin/tournament/" + liveTournament.getId();
+
+            // when live tournament test, then
+            String contentAsString = mockMvc.perform(delete(url)
+                .contentType(MediaType.APPLICATION_JSON)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isBadRequest())
+                .andReturn().getResponse().getContentAsString();
+
+            System.out.println(contentAsString);
+
+            url = "/pingpong/admin/tournament/" + endedTournament.getId();
+
+            // when ended tournament test, then
+            contentAsString = mockMvc.perform(delete(url)
+                .contentType(MediaType.APPLICATION_JSON)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
                 .andExpect(status().isBadRequest())
                 .andReturn().getResponse().getContentAsString();
 

--- a/src/test/java/com/gg/server/admin/tournament/controller/TournamentAdminControllerTest.java
+++ b/src/test/java/com/gg/server/admin/tournament/controller/TournamentAdminControllerTest.java
@@ -74,15 +74,9 @@ class TournamentAdminControllerTest {
 
             // when, then
             String contentAsString = mockMvc.perform(patch(url)
-<<<<<<< HEAD
-                    .content(content)
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
-=======
                 .content(content)
                 .contentType(MediaType.APPLICATION_JSON)
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
->>>>>>> 8786b173 (:green_heart: chore: Add tmp commit for rebase)
                 .andExpect(status().isNoContent())
                 .andReturn().getResponse().getContentAsString();
 
@@ -193,9 +187,9 @@ class TournamentAdminControllerTest {
 
             // when ended tournament test, then
             contentAsString = mockMvc.perform(patch(url)
-                    .content(content)
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .content(content)
+                .contentType(MediaType.APPLICATION_JSON)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
                 .andExpect(status().isBadRequest())
                 .andReturn().getResponse().getContentAsString();
 
@@ -229,9 +223,9 @@ class TournamentAdminControllerTest {
             String content = objectMapper.writeValueAsString(updateDto1);
 
             String contentAsString = mockMvc.perform(patch(url)
-                    .content(content)
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .content(content)
+                .contentType(MediaType.APPLICATION_JSON)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
                 .andExpect(status().isBadRequest())
                 .andReturn().getResponse().getContentAsString();
 
@@ -272,9 +266,9 @@ class TournamentAdminControllerTest {
             String content = objectMapper.writeValueAsString(updateDto1);
 
             String contentAsString = mockMvc.perform(patch(url)
-                    .content(content)
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .content(content)
+                .contentType(MediaType.APPLICATION_JSON)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
                 .andExpect(status().isBadRequest())
                 .andReturn().getResponse().getContentAsString();
 
@@ -303,8 +297,8 @@ class TournamentAdminControllerTest {
 
             // when, then
             String contentAsString = mockMvc.perform(delete(url)
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .contentType(MediaType.APPLICATION_JSON)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
                 .andExpect(status().isNoContent())
                 .andReturn().getResponse().getContentAsString();
 

--- a/src/test/java/com/gg/server/admin/tournament/service/TournamentAdminServiceTest.java
+++ b/src/test/java/com/gg/server/admin/tournament/service/TournamentAdminServiceTest.java
@@ -50,7 +50,7 @@ class TournamentAdminServiceTest {
             TournamentAdminUpdateRequestDto updateRequestDto = makeTournamentAdminUpdateRequestDto(
                 getTargetTime(3, 1), getTargetTime(3, 3));
             given(tournamentRepository.findById(1L)).willReturn(Optional.of(tournament));
-            given(tournamentRepository.findAllByStatus(TournamentStatus.BEFORE)).willReturn(tournamentList);
+            given(tournamentRepository.findAllByStatusIsNot(TournamentStatus.END)).willReturn(tournamentList);
             given(tournamentRepository.save(any(Tournament.class))).willReturn(tournament);
             // when
             Tournament changedTournament = tournamentAdminService.updateTournamentInfo(1L, updateRequestDto);
@@ -130,7 +130,7 @@ class TournamentAdminServiceTest {
             TournamentAdminUpdateRequestDto updateRequestDto = makeTournamentAdminUpdateRequestDto(
                 LocalDateTime.now().plusDays(2).plusHours(3), LocalDateTime.now().plusDays(2).plusHours(5));
             given(tournamentRepository.findById(1L)).willReturn(Optional.of(tournament));
-            given(tournamentRepository.findAllByStatus(TournamentStatus.BEFORE)).willReturn(tournamentList);
+            given(tournamentRepository.findAllByStatusIsNot(TournamentStatus.END)).willReturn(tournamentList);
             // when, then
             assertThatThrownBy(() -> tournamentAdminService.updateTournamentInfo(tournament.getId(), updateRequestDto))
                 .isInstanceOf(TournamentConflictException.class);

--- a/src/test/java/com/gg/server/admin/tournament/service/TournamentAdminServiceTest.java
+++ b/src/test/java/com/gg/server/admin/tournament/service/TournamentAdminServiceTest.java
@@ -7,10 +7,13 @@ import static org.mockito.BDDMockito.given;
 
 import com.gg.server.admin.tournament.dto.TournamentAdminUpdateRequestDto;
 import com.gg.server.domain.tournament.data.Tournament;
+import com.gg.server.domain.tournament.data.TournamentGame;
+import com.gg.server.domain.tournament.data.TournamentGameRepository;
 import com.gg.server.domain.tournament.data.TournamentRepository;
 import com.gg.server.domain.tournament.exception.TournamentConflictException;
 import com.gg.server.domain.tournament.exception.TournamentNotFoundException;
 import com.gg.server.domain.tournament.exception.TournamentUpdateException;
+import com.gg.server.domain.tournament.type.TournamentRound;
 import com.gg.server.domain.tournament.type.TournamentStatus;
 import com.gg.server.domain.tournament.type.TournamentType;
 import com.gg.server.global.exception.custom.InvalidParameterException;
@@ -30,11 +33,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class TournamentAdminServiceTest {
     @Mock
     TournamentRepository tournamentRepository;
+    @Mock
+    TournamentGameRepository tournamentGameRepository;
     @InjectMocks
     TournamentAdminService tournamentAdminService;
 
-
-    // 토너먼트 수정 서비스 테스트
     @Nested
     @DisplayName("토너먼트 관리자 서비스 수정 테스트")
     class TournamentAdminServiceUpdateTest {
@@ -134,6 +137,53 @@ class TournamentAdminServiceTest {
         }
     }
 
+    // 토너먼트 삭제 서비스 테스트
+    @Nested
+    @DisplayName("토너먼트 관리자 서비스 삭제 테스트")
+    class TournamentAdminServiceDeleteTest {
+        @Test
+        @DisplayName("토너먼트_삭제_성공")
+        void success() {
+            // given
+            long tournamentGameCnt = 7;
+            Tournament tournament = makeTournament(1L, TournamentStatus.BEFORE,
+                getTargetTime(2, 1), getTargetTime(2, 3));
+            List<TournamentGame> tournamentGameList = makeTournamentGames(1L, tournament, tournamentGameCnt);
+            given(tournamentRepository.findById(1L)).willReturn(Optional.of(tournament));
+            given(tournamentGameRepository.findAllByTournamentId(tournament.getId())).willReturn(tournamentGameList);
+            // when, then
+            tournamentAdminService.deleteTournamentInfo(tournament.getId());
+        }
+        @Test
+        @DisplayName("타겟_토너먼트_없음")
+        public void tournamentNotFound() {
+            // given
+            Tournament tournament = makeTournament(1L, TournamentStatus.BEFORE,
+                getTargetTime(2, 1), getTargetTime(2, 3));
+            given(tournamentRepository.findById(1L)).willReturn(Optional.empty());
+            // when, then
+            assertThatThrownBy(() -> tournamentAdminService.deleteTournamentInfo(tournament.getId()))
+                .isInstanceOf(TournamentNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("토너먼트_삭제_불가_상태")
+        public void canNotDelete() {
+            // given
+            Tournament liveTournament = makeTournament(1L, TournamentStatus.LIVE,
+                getTargetTime(0, -1), getTargetTime(0, 1));
+            Tournament endTournament = makeTournament(1L, TournamentStatus.END,
+                getTargetTime(-2, 5), getTargetTime(-2, 7));
+            given(tournamentRepository.findById(liveTournament.getId())).willReturn(Optional.of(liveTournament));
+            given(tournamentRepository.findById(endTournament.getId())).willReturn(Optional.of(endTournament));
+            // when, then
+            assertThatThrownBy(() -> tournamentAdminService.deleteTournamentInfo(liveTournament.getId()))
+                .isInstanceOf(TournamentUpdateException.class);
+            assertThatThrownBy(() -> tournamentAdminService.deleteTournamentInfo(endTournament.getId()))
+                .isInstanceOf(TournamentUpdateException.class);
+        }
+
+    }
 
     /**
      * 현재 시간에서 days hours, 만큼 차이나는 시간을 구한다.
@@ -199,5 +249,30 @@ class TournamentAdminServiceTest {
             endTime,
             TournamentType.ROOKIE
         );
+    }
+
+    /**
+     * 토너먼트 게임 생성(테스트에 상관없는 부분들은 임의의 값)
+     * @param id 토너먼트 게임 id
+     * @param tournament 해당 토너먼트
+     * @return
+     */
+    private TournamentGame makeTournamentGame(Long id, Tournament tournament) {
+        return new TournamentGame(id, null, tournament, TournamentRound.THE_FINAL);
+    }
+
+    /**
+     * cnt 사이즈의 토너먼트 게임 리스트 생성
+     * @param id 토너먼트 게임 id
+     * @param tournament 해당 토너먼트
+     * @param cnt 토너먼트 게임 수
+     * @return
+     */
+    private List<TournamentGame> makeTournamentGames(Long id, Tournament tournament, long cnt) {
+        List<TournamentGame> tournamentGameList = new ArrayList<>();
+        for (long i=0; i<cnt; i++) {
+            tournamentGameList.add(makeTournamentGame(id++, tournament));
+        }
+        return tournamentGameList;
     }
 }

--- a/src/test/java/com/gg/server/admin/tournament/service/TournamentAdminServiceTest.java
+++ b/src/test/java/com/gg/server/admin/tournament/service/TournamentAdminServiceTest.java
@@ -145,7 +145,7 @@ class TournamentAdminServiceTest {
         @DisplayName("토너먼트_삭제_성공")
         void success() {
             // given
-            long tournamentGameCnt = 7;
+            int tournamentGameCnt = 7;
             Tournament tournament = makeTournament(1L, TournamentStatus.BEFORE,
                 getTargetTime(2, 1), getTargetTime(2, 3));
             List<TournamentGame> tournamentGameList = makeTournamentGames(1L, tournament, tournamentGameCnt);
@@ -252,26 +252,17 @@ class TournamentAdminServiceTest {
     }
 
     /**
-     * 토너먼트 게임 생성(테스트에 상관없는 부분들은 임의의 값)
-     * @param id 토너먼트 게임 id
-     * @param tournament 해당 토너먼트
-     * @return
-     */
-    private TournamentGame makeTournamentGame(Long id, Tournament tournament) {
-        return new TournamentGame(id, null, tournament, TournamentRound.THE_FINAL);
-    }
-
-    /**
      * cnt 사이즈의 토너먼트 게임 리스트 생성
      * @param id 토너먼트 게임 id
      * @param tournament 해당 토너먼트
      * @param cnt 토너먼트 게임 수
      * @return
      */
-    private List<TournamentGame> makeTournamentGames(Long id, Tournament tournament, long cnt) {
+    private List<TournamentGame> makeTournamentGames(Long id, Tournament tournament, int cnt) {
         List<TournamentGame> tournamentGameList = new ArrayList<>();
-        for (long i=0; i<cnt; i++) {
-            tournamentGameList.add(makeTournamentGame(id++, tournament));
+        TournamentRound [] values = TournamentRound.values();
+        while (--cnt >= 0) {
+            tournamentGameList.add(new TournamentGame(id, null, tournament, values[cnt]));
         }
         return tournamentGameList;
     }

--- a/src/test/java/com/gg/server/utils/TestDataUtils.java
+++ b/src/test/java/com/gg/server/utils/TestDataUtils.java
@@ -23,6 +23,10 @@ import com.gg.server.domain.tier.data.Tier;
 import com.gg.server.domain.tier.data.TierRepository;
 import com.gg.server.domain.tournament.data.Tournament;
 import com.gg.server.domain.tournament.data.TournamentRepository;
+import com.gg.server.domain.tournament.data.TournamentGame;
+import com.gg.server.domain.tournament.data.TournamentGameRepository;
+import com.gg.server.domain.tournament.data.TournamentRepository;
+import com.gg.server.domain.tournament.type.TournamentRound;
 import com.gg.server.domain.tournament.type.TournamentStatus;
 import com.gg.server.domain.tournament.type.TournamentType;
 import com.gg.server.domain.user.data.User;
@@ -34,6 +38,8 @@ import com.gg.server.domain.user.type.SnsType;
 import com.gg.server.global.security.jwt.utils.AuthTokenProvider;
 import com.gg.server.domain.game.type.Mode;
 import com.gg.server.domain.game.type.StatusType;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -55,6 +61,7 @@ public class TestDataUtils {
     private final RankRepository rankRepository;
     private final TierRepository tierRepository;
     private final TournamentRepository tournamentRepository;
+    private final TournamentGameRepository tournamentGameRepository;
 
     public String getLoginAccessToken() {
         User user = User.builder()
@@ -261,6 +268,13 @@ public class TestDataUtils {
         pChangeRepository.save(pChange2);
     }
 
+    /**
+     * 테스트용 토너먼트 반환. 매개변수 값들만 초기화
+     * @param startTime
+     * @param endTime
+     * @param status
+     * @return
+     */
     public Tournament createTournament(LocalDateTime startTime, LocalDateTime endTime, TournamentStatus status) {
         Tournament tournament = Tournament.builder()
             .title("title")
@@ -269,10 +283,16 @@ public class TestDataUtils {
             .endTime(endTime)
             .type(TournamentType.ROOKIE)
             .status(status).build();
-        tournamentRepository.save(tournament);
-        return  tournament;
+        return  tournamentRepository.save(tournament);
     }
 
+    /**
+     * 테스트용 토너먼트 RequestDto 반환. 매개변수 값들만 초기화
+     * @param startTime
+     * @param endTime
+     * @param type
+     * @return
+     */
     public TournamentAdminUpdateRequestDto createUpdateRequestDto(LocalDateTime startTime, LocalDateTime endTime, TournamentType type) {
         return new TournamentAdminUpdateRequestDto(
             "title",
@@ -280,5 +300,21 @@ public class TestDataUtils {
             startTime,
             endTime,
             type);
+    }
+
+    /**
+     * 테스트용 토너먼트 게임 리스트 반환. 매개변수 값들만 초기화
+     * @param tournament
+     * @param cnt
+     * @return
+     */
+    public List<TournamentGame> createTournamentGameList(Tournament tournament, int cnt) {
+        List<TournamentGame> tournamentGameList = new ArrayList<>();
+        TournamentRound [] values = TournamentRound.values();
+
+        while (--cnt >= 0) {
+            tournamentGameList.add(new TournamentGame(null, tournament, values[cnt]));
+        }
+        return tournamentGameRepository.saveAll(tournamentGameList);
     }
 }


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 토너먼트 관리자 삭제 API 추가 
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - `TournamentAdminController`
    - delete 맵핑 + 매서드 추가
  - `TournamentAdminService`
    -  삭제 매서드 추가
  - `TournamentGame`
    - `id를 제외한 파라미터 생성자 추가` + round 길이 30 제한
  - `TournamentGameRepository`
    - `토너먼트 id`로 탐색하는 매서드 추가
  - `TestDataUtils`
    - TournamentGame 리스트 반환 매서드 추가
  - `TournamentAdminControllerTest`
    - 통합테스트
    - `성공`, `타겟 토너먼트 없음`, `삭제 불가` 토너먼트 검사
  - `TournamentAdminServiceTest`
    - 서비스 계층 단위 테스트
    - makeTournamentGames: 토너먼트 게임 리스트 반환 매서드 추가
    - `성공`, `타겟 토너먼트 없음`, `삭제 불가` 토너먼트 검사
## ✅ 변경로직 <!-- 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
  - `TournamentAdminService`
    - `checkConflictedTournament` 매서드 중복 검사 조건 변경, before -> before & live 둘다 체크
  - `Tournament`
    -   tournamentGames & tournamentUsers 에 `new ArrayList<>()`로 할당
  - `TournamentGameRepository`
    - `findAllByStatusBeforeAndLive`: before & live 상태 토너먼트 다 찾아주는 매서드 
  - `ErrorCode`
    - TOURNAMENT_TIME_CONFLICT =>  TOURNAMENT_CONFLICT 변경
 ## 💡Issue 번호 <!-- issue number을 link 시켜주세요 (ex. "- close #4242") -->
 - close #303 