### PR TITLE
✨  [Feature] 토너먼트 전체 리스트 조회 Api 추가

### DIFF
--- a/src/main/java/com/gg/server/domain/tournament/controller/TournamentController.java
+++ b/src/main/java/com/gg/server/domain/tournament/controller/TournamentController.java
@@ -9,6 +9,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -23,14 +24,12 @@ public class TournamentController {
 
     /**
      * 토너먼트 리스트 조회
-     * @param pageRequestDto 페이지 정보
-     * @param tournamentFilterRequestDto Enum 필터 정보
+     * @param tournamentFilterRequestDto Enum 필터 정보 (page, size, type, status)
      * @return 토너먼트 리스트
      */
     @GetMapping
-    TournamentListResponseDto getAllTournamentList(@Valid PageRequestDto pageRequestDto,
-                                                   @Valid TournamentFilterRequestDto tournamentFilterRequestDto){
-        Pageable pageRequest = PageRequest.of(pageRequestDto.getPage() - 1, pageRequestDto.getSize());
+    TournamentListResponseDto getAllTournamentList(@ModelAttribute @Valid TournamentFilterRequestDto tournamentFilterRequestDto){
+        Pageable pageRequest = PageRequest.of(tournamentFilterRequestDto.getPage() - 1, tournamentFilterRequestDto.getSize());
 
         return tournamentService.getAllTournamentList(pageRequest, tournamentFilterRequestDto.getType(), tournamentFilterRequestDto.getStatus());
     }

--- a/src/main/java/com/gg/server/domain/tournament/controller/TournamentController.java
+++ b/src/main/java/com/gg/server/domain/tournament/controller/TournamentController.java
@@ -20,6 +20,12 @@ public class TournamentController {
 
     private final TournamentService tournamentService;
 
+    /**
+     * 토너먼트 리스트 조회
+     * @param pageRequestDto 페이지 정보
+     * @param tournamentFilterRequestDto Enum 필터 정보
+     * @return 토너먼트 리스트
+     */
     @GetMapping
     TournamentListResponseDto getAllTournamentList(@Valid PageRequestDto pageRequestDto,
                                                    @Valid TournamentFilterRequestDto tournamentFilterRequestDto){

--- a/src/main/java/com/gg/server/domain/tournament/controller/TournamentController.java
+++ b/src/main/java/com/gg/server/domain/tournament/controller/TournamentController.java
@@ -7,6 +7,7 @@ import com.gg.server.global.dto.PageRequestDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -29,7 +30,7 @@ public class TournamentController {
     @GetMapping
     TournamentListResponseDto getAllTournamentList(@Valid PageRequestDto pageRequestDto,
                                                    @Valid TournamentFilterRequestDto tournamentFilterRequestDto){
-        PageRequest pageRequest = PageRequest.of(pageRequestDto.getPage() - 1, pageRequestDto.getSize());
+        Pageable pageRequest = PageRequest.of(pageRequestDto.getPage() - 1, pageRequestDto.getSize());
 
         return tournamentService.getAllTournamentList(pageRequest, tournamentFilterRequestDto.getType(), tournamentFilterRequestDto.getStatus());
     }

--- a/src/main/java/com/gg/server/domain/tournament/controller/TournamentController.java
+++ b/src/main/java/com/gg/server/domain/tournament/controller/TournamentController.java
@@ -1,11 +1,30 @@
 package com.gg.server.domain.tournament.controller;
 
+import com.gg.server.domain.tournament.dto.TournamentFilterRequestDto;
+import com.gg.server.domain.tournament.dto.TournamentListResponseDto;
+import com.gg.server.domain.tournament.service.TournamentService;
+import com.gg.server.global.dto.PageRequestDto;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/pingpong/tournament")
 public class TournamentController {
+
+    private final TournamentService tournamentService;
+
+    @GetMapping
+    TournamentListResponseDto getAllTournamentList(@Valid PageRequestDto pageRequestDto,
+                                                   @Valid TournamentFilterRequestDto tournamentFilterRequestDto){
+        PageRequest pageRequest = PageRequest.of(pageRequestDto.getPage() - 1, pageRequestDto.getSize());
+
+        return tournamentService.getAllTournamentList(pageRequest, tournamentFilterRequestDto.getType(), tournamentFilterRequestDto.getStatus());
+    }
 }

--- a/src/main/java/com/gg/server/domain/tournament/data/Tournament.java
+++ b/src/main/java/com/gg/server/domain/tournament/data/Tournament.java
@@ -99,4 +99,9 @@ public class Tournament extends BaseTimeEntity {
         this.type = type;
         this.status = status;
     }
+
+    public void update_winner(User winner) {
+        this.winner = winner;
+    }
+
 }

--- a/src/main/java/com/gg/server/domain/tournament/data/TournamentRepository.java
+++ b/src/main/java/com/gg/server/domain/tournament/data/TournamentRepository.java
@@ -1,12 +1,22 @@
 package com.gg.server.domain.tournament.data;
 
 import com.gg.server.domain.tournament.type.TournamentStatus;
-import java.util.List;
+import com.gg.server.domain.tournament.type.TournamentType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
+
+import javax.validation.constraints.NotNull;
+import java.util.List;
 
 public interface TournamentRepository extends JpaRepository<Tournament, Long> {
     List<Tournament> findAllByStatus(TournamentStatus status);
 
     List<Tournament> findAllByStatusIsNot(TournamentStatus status);
+
+    Page<Tournament> findAllByTypeAndStatus(@NotNull TournamentType type, @NotNull TournamentStatus status, Pageable pageable);
+
+    Page<Tournament> findAllByStatus(@NotNull TournamentStatus status, Pageable pageable);
+
+    Page<Tournament> findAllByType(@NotNull TournamentType type, Pageable pageable);
 }

--- a/src/main/java/com/gg/server/domain/tournament/data/TournamentUser.java
+++ b/src/main/java/com/gg/server/domain/tournament/data/TournamentUser.java
@@ -42,4 +42,11 @@ public class TournamentUser extends BaseTimeEntity {
     @NotNull
     @Column(name = "register_time")
     private LocalDateTime registerTime;
+
+    public TournamentUser(User user, Tournament tournament, boolean isJoined, LocalDateTime registerTime) {
+        this.user = user;
+        this.tournament = tournament;
+        this.isJoined = isJoined;
+        this.registerTime = registerTime;
+    }
 }

--- a/src/main/java/com/gg/server/domain/tournament/data/TournamentUserRepository.java
+++ b/src/main/java/com/gg/server/domain/tournament/data/TournamentUserRepository.java
@@ -3,4 +3,8 @@ package com.gg.server.domain.tournament.data;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TournamentUserRepository extends JpaRepository<TournamentUser, Long> {
+
+    int countByTournamentAndIsJoined(Tournament tournament, boolean isJoined);
+
+    int countByTournament(Tournament tournament);
 }

--- a/src/main/java/com/gg/server/domain/tournament/dto/TournamentFilterRequestDto.java
+++ b/src/main/java/com/gg/server/domain/tournament/dto/TournamentFilterRequestDto.java
@@ -1,0 +1,23 @@
+package com.gg.server.domain.tournament.dto;
+
+import com.gg.server.domain.tournament.type.TournamentStatus;
+import com.gg.server.domain.tournament.type.TournamentType;
+import com.gg.server.domain.tournament.validation.EnumValue;
+import lombok.Getter;
+
+import javax.annotation.Nullable;
+
+@Getter
+public class TournamentFilterRequestDto {
+
+    @EnumValue(enumClass = TournamentType.class, message = "plz. check tournamentType")
+    private String type;
+
+    @EnumValue(enumClass = TournamentStatus.class, message = "plz. check tournamentStatus")
+    private String status;
+
+    public TournamentFilterRequestDto(@Nullable String type, @Nullable String status) {
+        this.type = type;
+        this.status = status;
+    }
+}

--- a/src/main/java/com/gg/server/domain/tournament/dto/TournamentFilterRequestDto.java
+++ b/src/main/java/com/gg/server/domain/tournament/dto/TournamentFilterRequestDto.java
@@ -3,12 +3,13 @@ package com.gg.server.domain.tournament.dto;
 import com.gg.server.domain.tournament.type.TournamentStatus;
 import com.gg.server.domain.tournament.type.TournamentType;
 import com.gg.server.domain.tournament.validation.EnumValue;
+import com.gg.server.global.dto.PageRequestDto;
 import lombok.Getter;
 
 import javax.annotation.Nullable;
 
 @Getter
-public class TournamentFilterRequestDto {
+public class TournamentFilterRequestDto extends PageRequestDto {
 
     @EnumValue(enumClass = TournamentType.class, message = "plz. check tournamentType")
     private String type;
@@ -16,7 +17,8 @@ public class TournamentFilterRequestDto {
     @EnumValue(enumClass = TournamentStatus.class, message = "plz. check tournamentStatus")
     private String status;
 
-    public TournamentFilterRequestDto(@Nullable String type, @Nullable String status) {
+    public TournamentFilterRequestDto(Integer page, Integer size, @Nullable String type, @Nullable String status) {
+        super(page, size);
         this.type = type;
         this.status = status;
     }

--- a/src/main/java/com/gg/server/domain/tournament/dto/TournamentListResponseDto.java
+++ b/src/main/java/com/gg/server/domain/tournament/dto/TournamentListResponseDto.java
@@ -1,0 +1,17 @@
+package com.gg.server.domain.tournament.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@AllArgsConstructor
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+@Getter
+public class TournamentListResponseDto {
+
+    private List<TournamentResponseDto> tournaments;
+    private int totalPage;
+}

--- a/src/main/java/com/gg/server/domain/tournament/dto/TournamentResponseDto.java
+++ b/src/main/java/com/gg/server/domain/tournament/dto/TournamentResponseDto.java
@@ -1,0 +1,47 @@
+package com.gg.server.domain.tournament.dto;
+
+
+import com.gg.server.domain.tournament.data.Tournament;
+import com.gg.server.domain.tournament.type.TournamentStatus;
+import com.gg.server.domain.tournament.type.TournamentType;
+import com.gg.server.domain.user.dto.UserImageDto;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+@AllArgsConstructor
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+@Getter
+public class TournamentResponseDto {
+
+    private Long tournamentId;
+    private String title;
+    private String contents;
+    private LocalDateTime startTime;
+    private LocalDateTime endTime;
+    private TournamentType type;
+    private TournamentStatus status;
+    private String winnerIntraId;
+    private String winnerImageUrl;
+    private int player_cnt;
+
+    public TournamentResponseDto (Tournament tournament, UserImageDto winner, int player_cnt) {
+        this.tournamentId = tournament.getId();
+        this.title = tournament.getTitle();
+        this.contents = tournament.getContents();
+        this.startTime = tournament.getStartTime();
+        this.endTime = tournament.getEndTime();
+        this.type = tournament.getType();
+        this.status = tournament.getStatus();
+        this.winnerIntraId = winner.getIntraId();
+        this.winnerImageUrl = winner.getImageUri();
+        this.player_cnt = player_cnt;
+    }
+
+    public void update_player_cnt(int player_cnt) {
+        this.player_cnt = player_cnt;
+    }
+}

--- a/src/main/java/com/gg/server/domain/tournament/service/TournamentService.java
+++ b/src/main/java/com/gg/server/domain/tournament/service/TournamentService.java
@@ -20,6 +20,13 @@ import org.springframework.stereotype.Service;
 public class TournamentService {
     private final TournamentRepository tournamentRepository;
 
+    /**
+     * 토너먼트 리스트 조회
+     * @param pageRequest 페이지 정보
+     * @param type 토너먼트 타입
+     * @param status 토너먼트 상태
+     * @return 토너먼트 리스트
+     */
     public TournamentListResponseDto getAllTournamentList(PageRequest pageRequest, String type, String status) {
 
         Page<TournamentResponseDto> tournaments;
@@ -43,11 +50,21 @@ public class TournamentService {
         return new TournamentListResponseDto(tournaments.getContent(), tournaments.getTotalPages());
     }
 
+    /**
+     * 토너먼트 우승자 조회
+     * @param tournament 토너먼트
+     * @return 토너먼트 우승자 정보
+     */
     private UserImageDto findTournamentWinner(Tournament tournament) {
         User winner = tournament.getWinner();
         return new UserImageDto(winner);
     }
 
+    /**
+     * 토너먼트 참가자 수 조회
+     * @param tournament 토너먼트
+     * @return 토너먼트 참가자 수
+     */
     private int findPlayerCnt(Tournament tournament) {
         int player_cnt = 0;
         for (TournamentUser tournamentUser : tournament.getTournamentUsers()) {

--- a/src/main/java/com/gg/server/domain/tournament/service/TournamentService.java
+++ b/src/main/java/com/gg/server/domain/tournament/service/TournamentService.java
@@ -1,9 +1,60 @@
 package com.gg.server.domain.tournament.service;
 
+import com.gg.server.domain.tournament.data.Tournament;
+import com.gg.server.domain.tournament.data.TournamentRepository;
+import com.gg.server.domain.tournament.data.TournamentUser;
+import com.gg.server.domain.tournament.dto.TournamentListResponseDto;
+import com.gg.server.domain.tournament.dto.TournamentResponseDto;
+import com.gg.server.domain.tournament.type.TournamentStatus;
+import com.gg.server.domain.tournament.type.TournamentType;
+import com.gg.server.domain.user.data.User;
+import com.gg.server.domain.user.dto.UserImageDto;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class TournamentService {
+    private final TournamentRepository tournamentRepository;
+
+    public TournamentListResponseDto getAllTournamentList(PageRequest pageRequest, String type, String status) {
+
+        Page<TournamentResponseDto> tournaments;
+
+        TournamentType tournamentType = TournamentType.getEnumFromValue(type);
+        TournamentStatus tournamentStatus = TournamentStatus.getEnumFromValue(status);
+
+        if (type == null && status == null) {
+            tournaments = tournamentRepository.findAll(pageRequest).
+                    map(o-> new TournamentResponseDto(o, findTournamentWinner(o), findPlayerCnt(o)));
+        } else if (type == null){
+            tournaments = tournamentRepository.findAllByStatus(tournamentStatus, pageRequest).
+                    map(o-> new TournamentResponseDto(o, findTournamentWinner(o), findPlayerCnt(o)));
+        } else if (status == null) {
+            tournaments = tournamentRepository.findAllByType(tournamentType, pageRequest).
+                    map(o-> new TournamentResponseDto(o, findTournamentWinner(o), findPlayerCnt(o)));
+        } else {
+            tournaments = tournamentRepository.findAllByTypeAndStatus(tournamentType, tournamentStatus, pageRequest).
+                    map(o-> new TournamentResponseDto(o, findTournamentWinner(o), findPlayerCnt(o)));
+        }
+        return new TournamentListResponseDto(tournaments.getContent(), tournaments.getTotalPages());
+    }
+
+    private UserImageDto findTournamentWinner(Tournament tournament) {
+        User winner = tournament.getWinner();
+        return new UserImageDto(winner);
+    }
+
+    private int findPlayerCnt(Tournament tournament) {
+        int player_cnt = 0;
+        for (TournamentUser tournamentUser : tournament.getTournamentUsers()) {
+            if (tournamentUser.isJoined()){
+                player_cnt++;
+            }
+        }
+        return player_cnt;
+    }
 }

--- a/src/main/java/com/gg/server/domain/tournament/type/TournamentStatus.java
+++ b/src/main/java/com/gg/server/domain/tournament/type/TournamentStatus.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 public enum TournamentStatus {
     BEFORE("before", "토너먼트 시작 전"),
     LIVE("live", "토너먼트 진행 중"),
+    READY("ready", "토너먼트 준비 중"),
     END("end", "토너먼트 종료");
 
     private final String code;

--- a/src/main/java/com/gg/server/domain/tournament/type/TournamentStatus.java
+++ b/src/main/java/com/gg/server/domain/tournament/type/TournamentStatus.java
@@ -18,6 +18,7 @@ public enum TournamentStatus {
 
     @JsonCreator
     public static TournamentStatus getEnumFromValue(String value) {
+        if (value == null) return null;
         for(TournamentStatus e : values()) {
             if (e.name().equals(value)) {
                 return e;

--- a/src/main/java/com/gg/server/domain/tournament/type/TournamentType.java
+++ b/src/main/java/com/gg/server/domain/tournament/type/TournamentType.java
@@ -16,6 +16,7 @@ public enum TournamentType {
 
     @JsonCreator
     public static TournamentType getEnumFromValue(String value) {
+        if (value == null) return null;
         for(TournamentType e : values()) {
             if (e.name().equals(value)) {
                 return e;

--- a/src/main/java/com/gg/server/domain/tournament/validation/EnumValue.java
+++ b/src/main/java/com/gg/server/domain/tournament/validation/EnumValue.java
@@ -1,0 +1,22 @@
+package com.gg.server.domain.tournament.validation;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Documented
+@Constraint(validatedBy = ValueOfEnumValidator.class)
+public @interface EnumValue {
+    Class<? extends Enum<?>> enumClass();
+
+    String message() default "";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+    boolean ignoreCase() default true;
+}

--- a/src/main/java/com/gg/server/domain/tournament/validation/ValueOfEnumValidator.java
+++ b/src/main/java/com/gg/server/domain/tournament/validation/ValueOfEnumValidator.java
@@ -1,0 +1,32 @@
+package com.gg.server.domain.tournament.validation;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class ValueOfEnumValidator implements ConstraintValidator<EnumValue, String> {
+
+    private EnumValue enumValue;
+    @Override
+    public void initialize(EnumValue constraintAnnotation) {
+        this.enumValue = constraintAnnotation;
+    }
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        boolean result = false;
+        if (value == null) {
+            return true;
+        }
+        Enum<?>[] enumValues = this.enumValue.enumClass().getEnumConstants();
+        if (enumValues != null) {
+            for (Object enumValue : enumValues) {
+                if (value.equals(enumValue.toString())
+                        || this.enumValue.ignoreCase() && value.equalsIgnoreCase(enumValue.toString())) {
+                    result = true;
+                    break;
+                }
+            }
+        }
+        return result;
+    }
+}

--- a/src/main/java/com/gg/server/domain/user/dto/UserImageDto.java
+++ b/src/main/java/com/gg/server/domain/user/dto/UserImageDto.java
@@ -13,10 +13,10 @@ import java.time.LocalDateTime;
 @Getter
 @NoArgsConstructor
 public class UserImageDto {
-    String intraId;
-    String imageUri;
-    EdgeType edge;
-    String tierImage;
+    private String intraId;
+    private String imageUri;
+    private EdgeType edge;
+    private String tierImage;
 
     public UserImageDto(String intraId, String imageUri, EdgeType edge, String tierImage) {
         this.intraId = intraId;

--- a/src/main/java/com/gg/server/domain/user/dto/UserImageDto.java
+++ b/src/main/java/com/gg/server/domain/user/dto/UserImageDto.java
@@ -1,5 +1,6 @@
 package com.gg.server.domain.user.dto;
 
+import com.gg.server.domain.user.data.User;
 import com.gg.server.domain.user.type.EdgeType;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -22,5 +23,10 @@ public class UserImageDto {
         this.imageUri = imageUri;
         this.edge = edge;
         this.tierImage = tierImage;
+    }
+
+    public UserImageDto(User user){
+        this.intraId = (user == null)? null : user.getIntraId();
+        this.imageUri = (user == null)? null : user.getImageUri();
     }
 }

--- a/src/main/java/com/gg/server/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/gg/server/global/exception/GlobalExceptionHandler.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
@@ -50,7 +51,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler({DuplicationException.class})
     public ResponseEntity<ErrorResponse> duplicatedException(DuplicationException ex) {
-        log.error("Duplicated", ex.getStackTrace());
+        log.error("Duplicated", ex);
         return new ResponseEntity<>(new ErrorResponse(ex.getErrorCode()), HttpStatus.CONFLICT);
     }
 
@@ -105,6 +106,11 @@ public class GlobalExceptionHandler {
         log.error("!!!!!! SERVER ERROR !!!!!!", ex.getMessage());
         ErrorResponse response = new ErrorResponse(ErrorCode.INTERNAL_SERVER_ERR);
         return new ResponseEntity<>(response, HttpStatus.valueOf(response.getStatus()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    protected ResponseEntity handleException(MethodArgumentNotValidException e) {
+        return ResponseEntity.badRequest().body(e.getFieldError().getDefaultMessage());
     }
 
 }

--- a/src/test/java/com/gg/server/domain/tournament/controller/TournamentFindControllerTest.java
+++ b/src/test/java/com/gg/server/domain/tournament/controller/TournamentFindControllerTest.java
@@ -1,0 +1,197 @@
+package com.gg.server.domain.tournament.controller;
+
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gg.server.domain.tournament.dto.TournamentListResponseDto;
+import com.gg.server.domain.tournament.dto.TournamentResponseDto;
+import com.gg.server.domain.tournament.type.TournamentStatus;
+import com.gg.server.domain.tournament.type.TournamentType;
+import com.gg.server.domain.user.data.User;
+import com.gg.server.domain.user.type.RacketType;
+import com.gg.server.domain.user.type.RoleType;
+import com.gg.server.domain.user.type.SnsType;
+import com.gg.server.global.security.jwt.utils.AuthTokenProvider;
+import com.gg.server.utils.TestDataUtils;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.http.HttpHeaders;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@RequiredArgsConstructor
+@Slf4j
+public class TournamentFindControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+    @Autowired
+    TestDataUtils testDataUtils;
+    @Autowired
+    ObjectMapper objectMapper;
+    @Autowired
+    AuthTokenProvider tokenProvider;
+
+    List<TournamentResponseDto> tournamentList;
+    String accessToken;
+
+    User tester;
+
+    @BeforeEach
+    void beforeEach() {
+        tester = testDataUtils.createNewUser("findControllerTester", "findControllerTester", RacketType.DUAL, SnsType.SLACK, RoleType.ADMIN);
+        accessToken = tokenProvider.createToken(tester.getId());
+        tournamentList = testDataUtils.makeTournamentList();
+    }
+
+    @Nested
+    @DisplayName("토너먼트_리스트_조회")
+    class findTournamentTest {
+
+        @Test
+        @DisplayName("전체_조회")
+        public void getTournamentList() throws Exception {
+            // given
+            int page = 2;
+            int size = 20;
+            String url = "/pingpong/tournament/?page=" + page + "&size=" + size;
+
+            // when
+            String contentAsString = mockMvc.perform(get(url).header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                    .andExpect(status().isOk())
+                    .andReturn().getResponse().getContentAsString();
+            TournamentListResponseDto resp = objectMapper.readValue(contentAsString, TournamentListResponseDto.class);
+
+            // then
+            List<TournamentResponseDto> tournamentInfoList = resp.getTournaments();
+            for (int i = 0; i < tournamentInfoList.size(); i++) {
+                Long tournamentId = tournamentInfoList.get(i).getTournamentId();
+                TournamentResponseDto tournamentResponseDto = tournamentList.stream().filter(t -> t.getTournamentId().equals(tournamentId)).findFirst().orElse(null);
+                if (tournamentResponseDto != null) {
+                    assertThat(tournamentInfoList.get(i).getTitle()).isEqualTo(tournamentResponseDto.getTitle());
+                    assertThat(tournamentInfoList.get(i).getContents()).isEqualTo(tournamentResponseDto.getContents());
+                    assertThat(tournamentInfoList.get(i).getType()).isEqualTo(tournamentResponseDto.getType());
+                    assertThat(tournamentInfoList.get(i).getStatus()).isEqualTo(tournamentResponseDto.getStatus());
+                    assertThat(tournamentInfoList.get(i).getWinnerIntraId()).isEqualTo(tournamentResponseDto.getWinnerIntraId());
+                    assertThat(tournamentInfoList.get(i).getWinnerImageUrl()).isEqualTo(tournamentResponseDto.getWinnerImageUrl());
+                    assertThat(tournamentInfoList.get(i).getPlayer_cnt()).isEqualTo(tournamentResponseDto.getPlayer_cnt());
+                }
+            }
+        }
+
+        @Test
+        @DisplayName("status별_조회")
+        public void getTournamentListByStatus() throws Exception {
+
+            // given
+            int page = 1;
+            int size = 10;
+            String url = "/pingpong/tournament/?page=" + page + "&size=" + size + "&status=" + TournamentStatus.BEFORE.getCode();
+
+            // when
+            String contentAsString = mockMvc.perform(get(url).header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                    .andExpect(status().isOk())
+                    .andReturn().getResponse().getContentAsString();
+            TournamentListResponseDto resp = objectMapper.readValue(contentAsString, TournamentListResponseDto.class);
+
+            // then
+            List<TournamentResponseDto> tournamentInfoList = resp.getTournaments();
+            for (TournamentResponseDto responseDto : tournamentInfoList) {
+                assertThat(responseDto.getStatus()).isEqualTo(TournamentStatus.BEFORE);
+            }
+        }
+
+        @Test
+        @DisplayName("type별_조회")
+        public void getTournamentListByType() throws Exception {
+
+            // given
+            int page = 1;
+            int size = 10;
+            String url = "/pingpong/tournament/?page=" + page + "&size=" + size + "&type=" + TournamentType.ROOKIE.getCode();
+
+            // when
+            String contentAsString = mockMvc.perform(get(url).header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                    .andExpect(status().isOk())
+                    .andReturn().getResponse().getContentAsString();
+            TournamentListResponseDto resp = objectMapper.readValue(contentAsString, TournamentListResponseDto.class);
+
+            // then
+            List<TournamentResponseDto> tournamentInfoList = resp.getTournaments();
+            for (TournamentResponseDto responseDto : tournamentInfoList) {
+                assertThat(responseDto.getType()).isEqualTo(TournamentType.ROOKIE);
+            }
+        }
+
+        @Test
+        @DisplayName("type과 status 별 조회")
+        public void getTournamentListByTypeAndStatus() throws Exception {
+            // given
+            int page = 1;
+            int size = 10;
+            String url = "/pingpong/tournament/?page=" + page + "&size=" + size + "&type=" + TournamentType.ROOKIE.getCode() + "&status=" + TournamentStatus.BEFORE.getCode();
+
+            // when
+            String contentAsString = mockMvc.perform(get(url).header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                    .andExpect(status().isOk())
+                    .andReturn().getResponse().getContentAsString();
+            TournamentListResponseDto resp = objectMapper.readValue(contentAsString, TournamentListResponseDto.class);
+
+            // then
+            List<TournamentResponseDto> tournamentInfoList = resp.getTournaments();
+            for (TournamentResponseDto responseDto : tournamentInfoList) {
+                assertThat(responseDto.getType()).isEqualTo(TournamentType.ROOKIE);
+                assertThat(responseDto.getStatus()).isEqualTo(TournamentStatus.BEFORE);
+            }
+        }
+
+        @Test
+        @DisplayName("잘못된 type")
+        public void wrongType() throws Exception {
+            // given
+            int page = 1;
+            int size = 10;
+            String url = "/pingpong/tournament/?page=" + page + "&size=" + size + "&type=" + "rookie123" + "&status=" + TournamentStatus.BEFORE.getCode();
+
+            // when
+            String contentAsString = mockMvc.perform(get(url).header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                    .andExpect(status().isBadRequest())
+                    .andReturn().getResponse().getContentAsString();
+
+            // then
+            log.info(contentAsString);
+        }
+
+        @Test
+        @DisplayName("잘못된 status")
+        public void wrongStatus() throws Exception {
+            // given
+            int page = 1;
+            int size = 10;
+            String url = "/pingpong/tournament/?page=" + page + "&size=" + size + "&type=" + TournamentType.ROOKIE.getCode() + "&status=" + "wrongStatus";
+
+            // when
+            String contentAsString = mockMvc.perform(get(url).header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                    .andExpect(status().isBadRequest())
+                    .andReturn().getResponse().getContentAsString();
+
+            // then
+            log.info(contentAsString);
+        }
+    }
+}


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - Tournament 리스트 조회 Api 작성
  - Tournament list 조회를 위한 Repository, Dto 추가
  - Tournament Type, Status Dto의 Valid 추가
  - Tournament 전체 리스트 조회 테스트 코드 추가
  
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - `TournamentController` (Pageable) 
      - param -> pagenation에 필요한 `page`, `size` 그리고 검색 조건에 사용되는 `TournamentFilterRequestDto`
      -   `TournamentFilterRequestDto` : `TournamentStatus`, `TournamentType`이 담겨있는 Dto
  - Tournament data 에 `updateWinner()` 함수 추가
  - `TournamentResponseDto` : 검색된 토너먼트 정보들
  - `TournamentListResponseDto` : `TournamentResponseDto와` `totalPage` 정보가 포함된 dto
 ### Enum 검사를 위한 annotation 생성
  - `EnumValue` : `String` type을 EnumValue로 검사하기 위해 사용되는 **`@Enumvalue` 어노테이션**
  - `ValueOfEnumValidator` : `@EnumValue` 에서 valid 검사를 위한 validator

 ## 💡Issue 번호 <!-- issue number을 link 시켜주세요 (ex. "- close #4242") -->
 - close #302 
 - close #321 