### PR TITLE
✨ [Feature] 토너먼트 유저 조회 API 추가

### DIFF
--- a/src/main/java/com/gg/server/admin/tournament/controller/TournamentAdminController.java
+++ b/src/main/java/com/gg/server/admin/tournament/controller/TournamentAdminController.java
@@ -5,19 +5,15 @@ import com.gg.server.admin.tournament.dto.TournamentAdminAddUserResponseDto;
 import com.gg.server.admin.tournament.dto.TournamentAdminUpdateRequestDto;
 import com.gg.server.admin.tournament.service.TournamentAdminService;
 import javax.validation.Valid;
+
+import com.gg.server.domain.tournament.dto.TournamentUserListResponseDto;
 import lombok.AllArgsConstructor;
 import org.checkerframework.checker.index.qual.Positive;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.*;
 import com.gg.server.admin.tournament.dto.TournamentAdminCreateRequestDto;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @AllArgsConstructor
@@ -76,5 +72,18 @@ public class TournamentAdminController {
         TournamentAdminAddUserResponseDto responseDto = tournamentAdminService.addTournamentUser(tournamentId, tournamentAdminUserAddRequestDto);
 
         return new ResponseEntity<TournamentAdminAddUserResponseDto>(responseDto, HttpStatus.CREATED);
+    }
+
+    /**
+     * <p>토너먼트 유저 조회</p>
+     * @param tournamentId 유저를 조회할 토너먼트 id
+     * @param isJoined 참여중인 유저만 조회할지 여부
+     * @return TournamentUserListResponseDto
+     */
+    @GetMapping("/{tournamentId}/users")
+    public ResponseEntity<TournamentUserListResponseDto> getTournamentUserList(@PathVariable @Positive Long tournamentId,
+                                                                               @RequestParam(required = false) Boolean isJoined) {
+        TournamentUserListResponseDto responseDto = tournamentAdminService.getTournamentUserList(tournamentId, isJoined);
+        return new ResponseEntity<>(responseDto, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/gg/server/admin/tournament/service/TournamentAdminService.java
+++ b/src/main/java/com/gg/server/admin/tournament/service/TournamentAdminService.java
@@ -11,6 +11,7 @@ import com.gg.server.domain.tournament.data.Tournament;
 import com.gg.server.domain.tournament.data.TournamentRepository;
 import com.gg.server.domain.tournament.data.TournamentUser;
 import com.gg.server.domain.tournament.data.TournamentUserRepository;
+import com.gg.server.domain.tournament.dto.TournamentUserListResponseDto;
 import com.gg.server.domain.tournament.exception.TournamentConflictException;
 import com.gg.server.domain.tournament.exception.TournamentNotFoundException;
 import com.gg.server.domain.tournament.exception.TournamentUpdateException;
@@ -231,5 +232,22 @@ public class TournamentAdminService {
                 a -> {
                     throw new TournamentTitleConflictException();
                 });
+    }
+
+    /**
+     * <p>토너먼트 유저 리스트 조회</p>
+     * @param tournamentId 토너먼트 id
+     * @param isJoined     참가자인지 대기자인지 여부
+     * @return TournamentUserListResponseDto
+     * @throws TournamentNotFoundException 토너먼트가 존재하지 않을 때
+     */
+    public TournamentUserListResponseDto getTournamentUserList(Long tournamentId, Boolean isJoined) {
+        Tournament tournament = tournamentRepository.findById(tournamentId).
+                orElseThrow(() -> new TournamentNotFoundException(ErrorCode.TOURNAMENT_NOT_FOUND.getMessage(), ErrorCode.TOURNAMENT_NOT_FOUND));
+        if (isJoined == null){
+            return new TournamentUserListResponseDto(tournamentUserRepository.findAllByTournament(tournament));
+        } else {
+            return new TournamentUserListResponseDto(tournamentUserRepository.findAllByTournamentAndIsJoined(tournament, isJoined));
+        }
     }
 }

--- a/src/main/java/com/gg/server/domain/tournament/data/TournamentUserRepository.java
+++ b/src/main/java/com/gg/server/domain/tournament/data/TournamentUserRepository.java
@@ -1,12 +1,16 @@
 package com.gg.server.domain.tournament.data;
 
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
 
 public interface TournamentUserRepository extends JpaRepository<TournamentUser, Long> {
 
     int countByTournamentAndIsJoined(Tournament tournament, boolean isJoined);
 
-    int countByTournament(Tournament tournament);
+    List<TournamentUser> findAllByTournament(Tournament tournament);
+
+    List<TournamentUser> findAllByTournamentAndIsJoined(Tournament tournament, boolean isJoined);
+
     List<TournamentUser> findAllByTournamentId(Long tournamentId);
 }

--- a/src/main/java/com/gg/server/domain/tournament/dto/TournamentUserListResponseDto.java
+++ b/src/main/java/com/gg/server/domain/tournament/dto/TournamentUserListResponseDto.java
@@ -1,0 +1,24 @@
+package com.gg.server.domain.tournament.dto;
+
+import com.gg.server.domain.tournament.data.TournamentUser;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+@Getter
+public class TournamentUserListResponseDto {
+    List<TournamentUserResponseDto> users;
+
+    public TournamentUserListResponseDto(List<TournamentUser> tournamentUsers){
+        users = new ArrayList<>();
+        for (TournamentUser tournamentUser : tournamentUsers) {
+            users.add(new TournamentUserResponseDto(tournamentUser));
+        }
+        users.sort(Comparator.comparing(TournamentUserResponseDto::getIsJoined).reversed().
+                thenComparing(TournamentUserResponseDto::getRegisteredDate));
+    }
+}

--- a/src/main/java/com/gg/server/domain/tournament/dto/TournamentUserListResponseDto.java
+++ b/src/main/java/com/gg/server/domain/tournament/dto/TournamentUserListResponseDto.java
@@ -11,7 +11,7 @@ import java.util.List;
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 @Getter
 public class TournamentUserListResponseDto {
-    List<TournamentUserResponseDto> users;
+    private List<TournamentUserResponseDto> users;
 
     public TournamentUserListResponseDto(List<TournamentUser> tournamentUsers){
         users = new ArrayList<>();

--- a/src/main/java/com/gg/server/domain/tournament/dto/TournamentUserResponseDto.java
+++ b/src/main/java/com/gg/server/domain/tournament/dto/TournamentUserResponseDto.java
@@ -1,0 +1,25 @@
+package com.gg.server.domain.tournament.dto;
+
+import com.gg.server.domain.tournament.data.TournamentUser;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@AllArgsConstructor
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+@Getter
+public class TournamentUserResponseDto {
+    private Long userId;
+    private String intraId;
+    private Boolean isJoined;
+    private LocalDateTime registeredDate;
+
+    public TournamentUserResponseDto(TournamentUser tournamentUser) {
+        this.userId = tournamentUser.getUser().getId();
+        this.intraId = tournamentUser.getUser().getIntraId();
+        this.isJoined = tournamentUser.isJoined();
+        this.registeredDate = tournamentUser.getRegisterTime();
+    }
+}

--- a/src/test/java/com/gg/server/admin/tournament/controller/TournamentAdminUserControllerTest.java
+++ b/src/test/java/com/gg/server/admin/tournament/controller/TournamentAdminUserControllerTest.java
@@ -1,0 +1,101 @@
+package com.gg.server.admin.tournament.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gg.server.domain.tournament.data.Tournament;
+import com.gg.server.domain.tournament.dto.TournamentUserListResponseDto;
+import com.gg.server.domain.user.data.User;
+import com.gg.server.domain.user.type.RacketType;
+import com.gg.server.domain.user.type.RoleType;
+import com.gg.server.domain.user.type.SnsType;
+import com.gg.server.global.security.jwt.utils.AuthTokenProvider;
+import com.gg.server.utils.TestDataUtils;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.http.HttpHeaders;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@Slf4j
+public class TournamentAdminUserControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+    @Autowired
+    TestDataUtils testDataUtils;
+    @Autowired
+    ObjectMapper objectMapper;
+    @Autowired
+    AuthTokenProvider tokenProvider;
+
+    String accessToken;
+    int joinUserCnt = 8;
+    int notJoinUserCnt = 4;
+    String testName = "42_gg_tester_";
+    Tournament tournament;
+    String adminUrl = "/pingpong/admin/tournaments/";
+    @BeforeEach
+    void beforeEach() {
+        User tester = testDataUtils.createNewUser("findControllerTester", "findControllerTester", RacketType.DUAL, SnsType.SLACK, RoleType.ADMIN);
+        accessToken = tokenProvider.createToken(tester.getId());
+        tournament = testDataUtils.createTournamentWithUser(joinUserCnt, notJoinUserCnt, testName);
+    }
+
+    @Nested
+    @DisplayName("/pingpong/admin/tournaments")
+    class FindTournamentUser {
+
+        @Test
+        @DisplayName("[Get] /{tournamentId}/users")
+        void getAllTournamentUser() throws Exception {
+            // given
+
+            String url = adminUrl + tournament.getId() + "/users";
+
+            // when
+            String contentAsString = mockMvc.perform(get(url).header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                    .andExpect(status().isOk())
+                    .andReturn().getResponse().getContentAsString();
+            TournamentUserListResponseDto resp = objectMapper.readValue(contentAsString, TournamentUserListResponseDto.class);
+
+            // then
+            assertThat(resp.getUsers().size()).isEqualTo(joinUserCnt+ notJoinUserCnt);
+            for (int i = 0; i < joinUserCnt + notJoinUserCnt; i++) {
+                assertThat(resp.getUsers().get(i).getIntraId()).isEqualTo(testName + i);
+            }
+        }
+
+        @Test
+        @DisplayName("[Get] /{tournamentId}/users?isJoined=true")
+        void getAllTournamentUserByIsJoined() throws Exception {
+
+            // given
+            String url = adminUrl + tournament.getId() + "/users" + "?isJoined=true";
+
+            // when
+            String contentAsString = mockMvc.perform(get(url).header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                    .andExpect(status().isOk())
+                    .andReturn().getResponse().getContentAsString();
+            TournamentUserListResponseDto resp = objectMapper.readValue(contentAsString, TournamentUserListResponseDto.class);
+
+            // then
+            assertThat(resp.getUsers().size()).isEqualTo(joinUserCnt);
+            for (int i = 0; i < joinUserCnt; i++) {
+                assertThat(resp.getUsers().get(i).getIntraId()).isEqualTo(testName + i);
+                assertThat(resp.getUsers().get(i).getIsJoined()).isEqualTo(true);
+            }
+        }
+    }
+}

--- a/src/test/java/com/gg/server/admin/tournament/controller/TournamentAdminUserControllerTest.java
+++ b/src/test/java/com/gg/server/admin/tournament/controller/TournamentAdminUserControllerTest.java
@@ -41,8 +41,8 @@ public class TournamentAdminUserControllerTest {
     AuthTokenProvider tokenProvider;
 
     String accessToken;
-    int joinUserCnt = 8;
-    int notJoinUserCnt = 4;
+    final int joinUserCnt = 8;
+    final int notJoinUserCnt = 4;
     String testName = "42_gg_tester_";
     Tournament tournament;
     String adminUrl = "/pingpong/admin/tournaments/";

--- a/src/test/java/com/gg/server/utils/TestDataUtils.java
+++ b/src/test/java/com/gg/server/utils/TestDataUtils.java
@@ -347,7 +347,7 @@ public class TestDataUtils {
      */
     public Tournament createTournamentByEnum(TournamentType tournamentType, TournamentStatus tournamentStatus) {
         Tournament tournament = Tournament.builder()
-            .title("title")
+            .title("testTournament")
             .contents("contents")
             .startTime(LocalDateTime.now())
             .endTime(LocalDateTime.now().plusDays(1))
@@ -435,4 +435,25 @@ public class TestDataUtils {
         }
         return tournamentResponseDtos;
     }
+
+    public Tournament createTournamentWithUser(int joinUserCnt, int notJoinUserCnt, String testName) {
+        Tournament tournament = createTournamentByEnum(TournamentType.ROOKIE, TournamentStatus.BEFORE);
+        tournamentRepository.save(tournament);
+        for (int i = 0; i < joinUserCnt + notJoinUserCnt; i++) {
+            User newUser = createNewUser(testName + i, "tester" + i + "@gmail.com", RacketType.PENHOLDER, SnsType.NONE, RoleType.USER);
+            userRepository.save(newUser);
+        }
+        for (int j = 0; j < joinUserCnt; j++) {
+            TournamentUser tournamentUser = new TournamentUser(userRepository.findByIntraId(testName + j).get(), tournament, true, LocalDateTime.now());
+            tournamentUserRepository.save(tournamentUser);
+            tournament.getTournamentUsers().add(tournamentUser);
+        }
+        for (int j = joinUserCnt; j < joinUserCnt + notJoinUserCnt; j++) {
+            TournamentUser tournamentUser = new TournamentUser(userRepository.findByIntraId(testName + j).get(), tournament, false, LocalDateTime.now());
+            tournamentUserRepository.save(tournamentUser);
+            tournament.getTournamentUsers().add(tournamentUser);
+        }
+        return tournament;
+    }
+
 }


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 토너먼트에 참가된 유저들을 조회하는 API 추가
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - `TournamentAdminController` && `TournamentAdminService` : 토너먼트 유저 조회 API 추가
  - `TournamentUserRepository` findAllByTournament, findAllByTournamentAndIsJoined 추가
  - `TestDataUtils` : TournamentUser 데이터 추가하는 로직 추가
  -  TournamentAdminUserControllerTest 테스트 코드 추가
 ## 💡Issue 번호 <!-- issue number을 link 시켜주세요 (ex. "- close #4242") -->
 -  close #332