### PR TITLE
✨ [Feature] tournament 단일 조회 API 추가

### DIFF
--- a/src/main/java/com/gg/server/domain/tournament/controller/TournamentController.java
+++ b/src/main/java/com/gg/server/domain/tournament/controller/TournamentController.java
@@ -2,14 +2,14 @@ package com.gg.server.domain.tournament.controller;
 
 import com.gg.server.domain.tournament.dto.TournamentFilterRequestDto;
 import com.gg.server.domain.tournament.dto.TournamentListResponseDto;
+import com.gg.server.domain.tournament.dto.TournamentResponseDto;
 import com.gg.server.domain.tournament.service.TournamentService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 
@@ -30,5 +30,16 @@ public class TournamentController {
         Pageable pageRequest = PageRequest.of(tournamentFilterRequestDto.getPage() - 1, tournamentFilterRequestDto.getSize());
 
         return tournamentService.getAllTournamentList(pageRequest, tournamentFilterRequestDto.getType(), tournamentFilterRequestDto.getStatus());
+    }
+
+    /**
+     * 토너먼트 단일 조회
+     * @param tournamentId 토너먼트 id
+     * @return 토너먼트
+     */
+    @GetMapping("/{tournamentId}")
+    public ResponseEntity<TournamentResponseDto> getTournnament(@PathVariable Long tournamentId) {
+        TournamentResponseDto tournamentResponseDto = tournamentService.getTournament(tournamentId);
+            return ResponseEntity.status(HttpStatus.OK).body(tournamentResponseDto);
     }
 }

--- a/src/main/java/com/gg/server/domain/tournament/service/TournamentService.java
+++ b/src/main/java/com/gg/server/domain/tournament/service/TournamentService.java
@@ -6,16 +6,21 @@ import com.gg.server.domain.tournament.data.TournamentUser;
 import com.gg.server.domain.tournament.data.TournamentUserRepository;
 import com.gg.server.domain.tournament.dto.TournamentListResponseDto;
 import com.gg.server.domain.tournament.dto.TournamentResponseDto;
+import com.gg.server.domain.tournament.exception.TournamentNotFoundException;
 import com.gg.server.domain.tournament.type.TournamentStatus;
 import com.gg.server.domain.tournament.type.TournamentType;
 import com.gg.server.domain.user.data.User;
 import com.gg.server.domain.user.dto.UserImageDto;
+import com.gg.server.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+
+import javax.persistence.EntityNotFoundException;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -70,5 +75,16 @@ public class TournamentService {
      */
     private int findJoinedPlayerCnt(Tournament tournament) {
         return tournamentUserRepository.countByTournamentAndIsJoined(tournament, true);
+    }
+
+    /**
+     * 토너먼트 단일 조회
+     * @param tournamentId
+     * @return 토너먼트
+     */
+    public TournamentResponseDto getTournament(long tournamentId) {
+        Tournament tournament = tournamentRepository.findById(tournamentId)
+                .orElseThrow(() -> new TournamentNotFoundException("Tournament no found with ID: " + tournamentId, ErrorCode.TOURNAMENT_NOT_FOUND));
+        return (new TournamentResponseDto(tournament, findTournamentWinner(tournament), findJoinedPlayerCnt(tournament)));
     }
 }

--- a/src/test/java/com/gg/server/domain/tournament/controller/TournamentFindControllerTest.java
+++ b/src/test/java/com/gg/server/domain/tournament/controller/TournamentFindControllerTest.java
@@ -1,7 +1,7 @@
 package com.gg.server.domain.tournament.controller;
 
-
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gg.server.domain.tournament.data.Tournament;
 import com.gg.server.domain.tournament.dto.TournamentListResponseDto;
 import com.gg.server.domain.tournament.dto.TournamentResponseDto;
 import com.gg.server.domain.tournament.type.TournamentStatus;
@@ -25,6 +25,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
@@ -61,7 +62,7 @@ public class TournamentFindControllerTest {
 
     @Nested
     @DisplayName("토너먼트_리스트_조회")
-    class findTournamentTest {
+    class findTournamentListTest {
 
         @Test
         @DisplayName("전체_조회")
@@ -192,6 +193,65 @@ public class TournamentFindControllerTest {
 
             // then
             log.info(contentAsString);
+        }
+    }
+
+    @Nested
+    @DisplayName("토너먼트_단일_조회")
+    class findTournamentTest {
+        @Test
+        @DisplayName("조회_성공")
+        public void success() throws Exception {
+            //given
+            Tournament tournament = testDataUtils.createTournament("string1", "string",
+                    LocalDateTime.now().plusDays(2).plusHours(1), LocalDateTime.now().plusDays(2).plusHours(3),
+                    TournamentType.ROOKIE, TournamentStatus.BEFORE);
+            User user = testDataUtils.createNewUser("test");
+            testDataUtils.createTournamentUser(user, tournament, true);
+            tournament.update_winner(user);
+
+            Long tournamentId = tournament.getId();
+            String url = "/pingpong/tournaments/" + tournamentId;
+
+            //when
+            String contentAsString = mockMvc.perform(get(url)
+                            .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                    .andExpect(status().isOk())
+                    .andReturn().getResponse().getContentAsString();
+
+            TournamentResponseDto responseDto = objectMapper.readValue(contentAsString, TournamentResponseDto.class);
+
+            //then
+            assertThat(tournament.getTitle()).isEqualTo(responseDto.getTitle());
+            assertThat(tournament.getContents()).isEqualTo(responseDto.getContents());
+            assertThat(tournament.getType()).isEqualTo(responseDto.getType());
+            assertThat(tournament.getStatus()).isEqualTo(responseDto.getStatus());
+            if (tournament.getWinner() == null) {
+                assertThat(responseDto.getWinnerIntraId()).isEqualTo(null);
+                assertThat(responseDto.getWinnerImageUrl()).isEqualTo(null);
+            }
+            else {
+                assertThat(tournament.getWinner().getIntraId()).isEqualTo(responseDto.getWinnerIntraId());
+                assertThat(tournament.getWinner().getImageUri()).isEqualTo(responseDto.getWinnerImageUrl());
+            }
+            assertThat(tournament.getTournamentUsers().size()).isEqualTo(responseDto.getPlayer_cnt());
+        }
+
+        @Test
+        @DisplayName("잘못된_토너먼트_ID")
+        public void tournamentNotExist() throws Exception {
+            //given
+            Long tournamentId = 1L;
+            String url = "/pingpong/tournaments/" + tournamentId;
+
+            //when
+            String contentAsString = mockMvc.perform(get(url)
+                            .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                    .andExpect(status().isNotFound())
+                    .andReturn().getResponse().getContentAsString();
+
+            //then
+            System.out.println(contentAsString);
         }
     }
 }

--- a/src/test/java/com/gg/server/utils/TestDataUtils.java
+++ b/src/test/java/com/gg/server/utils/TestDataUtils.java
@@ -324,6 +324,26 @@ public class TestDataUtils {
     }
 
     /**
+     * 테스트용 토너먼트 반환.
+     * @param title 제목
+     * @param contents 내용
+     * @param startTime 시작 시간
+     * @param endTime 종료 시간
+     * @param type 타입
+     * @param status 상태
+     * @return 테스트용 토너먼트
+     */
+    public Tournament createTournament(String title, String contents, LocalDateTime startTime, LocalDateTime endTime, TournamentType type, TournamentStatus status) {
+        Tournament tournament = Tournament.builder()
+                .title(title)
+                .contents(contents)
+                .startTime(startTime)
+                .endTime(endTime)
+                .type(type)
+                .status(status).build();
+        return  tournamentRepository.save(tournament);
+    }
+    /**
      * 테스트용 토너먼트 생성 RequestDto 반환.
      * @param startTime
      * @param endTime


### PR DESCRIPTION
 ## 📌 개요
  - tournament 단일 조회 API

 ## 💻 작업사항
  - TournamentController
    - 토너먼트 단일조회 컨트롤러 구현
    - `getTournnament`: 토너먼트 단일 조회 메소드
    - `ResponseEntity.status(HttpStatus.OK).body(tournamentResponseDto)`으로 HTTP 상태 코드와 응답 dto 모두 반환
  - TournamentService
    - 토너먼트 단일 조회 서비스 구현
    - 토너먼트 ID가 유효하지 않을 경우, `TournamentNotFoundException` 발생
  - TournamentControllerTest
    - 토너먼트 단일 조회 컨트롤러 테스트 코드 구현
    - 조회 성공 테스트 구현 (우승자 존재 유무에 따른 `assertThat` 조건문 존재)
    - 잘못된 토너먼트 ID 테스트 구현
  - TestDataUtils
    - `createTournament`: 테스트용 토너먼트 반환 메소드

 ## ✅ 변경로직

 ## 💡Issue 번호
 - close #328 