### PR TITLE
✨ [Feature] 토너먼트 추가로 인한 Match 로직 수정

### DIFF
--- a/src/main/java/com/gg/server/admin/game/controller/GameAdminController.java
+++ b/src/main/java/com/gg/server/admin/game/controller/GameAdminController.java
@@ -4,11 +4,13 @@ import com.gg.server.admin.game.dto.GameLogListAdminResponseDto;
 import com.gg.server.admin.game.dto.GameUserLogAdminReqDto;
 import com.gg.server.admin.game.dto.RankGamePPPModifyReqDto;
 import com.gg.server.admin.game.service.GameAdminService;
+import com.gg.server.global.dto.PageRequestDto;
 import com.gg.server.global.exception.ErrorCode;
 import com.gg.server.global.exception.custom.InvalidParameterException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -21,6 +23,15 @@ import javax.validation.constraints.Positive;
 @RequestMapping("/pingpong/admin/games")
 public class GameAdminController {
     private final GameAdminService gameAdminService;
+
+    @GetMapping
+    public GameLogListAdminResponseDto gameFindBySeasonId(@ModelAttribute @Valid PageRequestDto pageRequestDto) {
+        int page = pageRequestDto.getPage();
+        int size = pageRequestDto.getSize();
+
+        Pageable pageable = PageRequest.of(page - 1, size, Sort.by("startTime").descending());
+        return gameAdminService.findAllGamesByAdmin(pageable);
+    }
 
     /**
      * 특정 유저의 게임 목록 조회 API

--- a/src/main/java/com/gg/server/domain/match/controller/MatchController.java
+++ b/src/main/java/com/gg/server/domain/match/controller/MatchController.java
@@ -30,6 +30,14 @@ import org.springframework.web.bind.annotation.RestController;
 public class MatchController {
     private final MatchService matchService;
     private final MatchFindService matchFindService;
+
+    // TODO tournament slot block
+    /**
+     * 유저 슬롯 입장 요청 API (== 매칭 요청 API)
+     * @param matchRequestDto
+     * @param user 매칭 요청한 유저
+     * @return 201 (Created)
+     */
     @PostMapping("match")
     public ResponseEntity createUserMatch(@RequestBody @Valid MatchRequestDto matchRequestDto,
                                           @Parameter(hidden = true) @Login UserDto user) {
@@ -44,6 +52,13 @@ public class MatchController {
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
+    // TODO tournament slot block
+    /**
+     * 특정 시간대의 경기 매칭 가능 상태 조회 API
+     * @param mode : BOTH, NORMAL, RANK
+     * @param user
+     * @return
+     */
     @GetMapping("match/time/scope")
     public SlotStatusResponseListDto getMatchTimeScope(@RequestParam (required = true) String mode,
                                                        @Parameter(hidden = true) @Login UserDto user){

--- a/src/main/java/com/gg/server/domain/match/controller/MatchController.java
+++ b/src/main/java/com/gg/server/domain/match/controller/MatchController.java
@@ -26,25 +26,24 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/pingpong/")
+@RequestMapping("/pingpong/match")
 public class MatchController {
     private final MatchService matchService;
     private final MatchFindService matchFindService;
 
-    // TODO tournament slot block
     /**
      * 유저 슬롯 입장 요청 API (== 매칭 요청 API)
      * @param matchRequestDto
      * @param user 매칭 요청한 유저
      * @return 201 (Created)
      */
-    @PostMapping("match")
+    @PostMapping
     public ResponseEntity createUserMatch(@RequestBody @Valid MatchRequestDto matchRequestDto,
                                           @Parameter(hidden = true) @Login UserDto user) {
         matchService.makeMatch(user, matchRequestDto.getOption(), matchRequestDto.getStartTime());
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
-    @DeleteMapping("match")
+    @DeleteMapping
     public ResponseEntity deleteUserMatch(@RequestParam("startTime")
                                               @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm") LocalDateTime startTime,
                                           @Parameter(hidden = true) @Login UserDto user) {
@@ -52,20 +51,19 @@ public class MatchController {
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
-    // TODO tournament slot block
     /**
      * 특정 시간대의 경기 매칭 가능 상태 조회 API
      * @param mode : BOTH, NORMAL, RANK
      * @param user
      * @return
      */
-    @GetMapping("match/time/scope")
+    @GetMapping("/time/scope")
     public SlotStatusResponseListDto getMatchTimeScope(@RequestParam (required = true) String mode,
                                                        @Parameter(hidden = true) @Login UserDto user){
         return matchFindService.getAllMatchStatus(user, Option.getEnumValue(mode));
     }
 
-    @GetMapping("match")
+    @GetMapping
     public MatchStatusResponseListDto getCurrentMatch(@Parameter(hidden = true) @Login UserDto user) {
         return matchFindService.getCurrentMatch(user);
     }

--- a/src/main/java/com/gg/server/domain/match/service/MatchFindService.java
+++ b/src/main/java/com/gg/server/domain/match/service/MatchFindService.java
@@ -71,7 +71,6 @@ public class MatchFindService {
         return new MatchStatusResponseListDto(dtos);
     }
 
-    // TODO tournament slot block
     @Transactional(readOnly = true)
     public SlotStatusResponseListDto getAllMatchStatus(UserDto userDto, Option option) {
         SlotManagement slotManagement = slotManagementRepository.findCurrent(LocalDateTime.now())

--- a/src/main/java/com/gg/server/domain/match/service/MatchFindService.java
+++ b/src/main/java/com/gg/server/domain/match/service/MatchFindService.java
@@ -23,6 +23,7 @@ import com.gg.server.domain.slotmanagement.data.SlotManagementRepository;
 import com.gg.server.domain.tier.data.Tier;
 import com.gg.server.domain.tier.data.TierRepository;
 import com.gg.server.domain.tier.exception.TierNotFoundException;
+import com.gg.server.domain.tournament.data.TournamentRepository;
 import com.gg.server.domain.user.data.User;
 import com.gg.server.domain.user.data.UserRepository;
 import com.gg.server.domain.user.dto.UserDto;
@@ -48,6 +49,7 @@ public class MatchFindService {
     private final RankRedisRepository rankRedisRepository;
     private final RedisMatchTimeRepository redisMatchTimeRepository;
     private final TierRepository tierRepository;
+    private final TournamentRepository tournamentRepository;
 
 
     @Transactional(readOnly = true)
@@ -69,6 +71,7 @@ public class MatchFindService {
         return new MatchStatusResponseListDto(dtos);
     }
 
+    // TODO tournament slot block
     @Transactional(readOnly = true)
     public SlotStatusResponseListDto getAllMatchStatus(UserDto userDto, Option option) {
         SlotManagement slotManagement = slotManagementRepository.findCurrent(LocalDateTime.now())
@@ -82,10 +85,11 @@ public class MatchFindService {
             user = rankRedisRepository.
                     findRankByUserId(RedisKeyManager.getHashKey(season.getId()), userDto.getId());
         }
-        SlotGenerator slotGenerator = new SlotGenerator(user, slotManagement, season, option);
+        SlotGenerator slotGenerator = new SlotGenerator(user, slotManagement, season, option, tournamentRepository);
         List<Game> games = gameRepository.findAllBetween(slotGenerator.getNow(), slotGenerator.getMaxTime());
         slotGenerator.addPastSlots();
         slotGenerator.addMatchedSlots(games);
+        slotGenerator.addTournamentSlots();
 
         Optional<Game> myGame = gameRepository.findByStatusTypeAndUserId(StatusType.BEFORE, userDto.getId());
         Set<LocalDateTime> gameTimes = games.stream().map(Game::getStartTime).collect(Collectors.toSet());

--- a/src/main/java/com/gg/server/domain/match/service/MatchFindService.java
+++ b/src/main/java/com/gg/server/domain/match/service/MatchFindService.java
@@ -23,7 +23,9 @@ import com.gg.server.domain.slotmanagement.data.SlotManagementRepository;
 import com.gg.server.domain.tier.data.Tier;
 import com.gg.server.domain.tier.data.TierRepository;
 import com.gg.server.domain.tier.exception.TierNotFoundException;
+import com.gg.server.domain.tournament.data.Tournament;
 import com.gg.server.domain.tournament.data.TournamentRepository;
+import com.gg.server.domain.tournament.type.TournamentStatus;
 import com.gg.server.domain.user.data.User;
 import com.gg.server.domain.user.data.UserRepository;
 import com.gg.server.domain.user.dto.UserDto;
@@ -84,11 +86,12 @@ public class MatchFindService {
             user = rankRedisRepository.
                     findRankByUserId(RedisKeyManager.getHashKey(season.getId()), userDto.getId());
         }
-        SlotGenerator slotGenerator = new SlotGenerator(user, slotManagement, season, option, tournamentRepository);
+        SlotGenerator slotGenerator = new SlotGenerator(user, slotManagement, season, option);
         List<Game> games = gameRepository.findAllBetween(slotGenerator.getNow(), slotGenerator.getMaxTime());
         slotGenerator.addPastSlots();
         slotGenerator.addMatchedSlots(games);
-        slotGenerator.addTournamentSlots();
+        List<Tournament> tournaments = tournamentRepository.findAllByStatusIsNot(TournamentStatus.END);
+        slotGenerator.addTournamentSlots(tournaments);
 
         Optional<Game> myGame = gameRepository.findByStatusTypeAndUserId(StatusType.BEFORE, userDto.getId());
         Set<LocalDateTime> gameTimes = games.stream().map(Game::getStartTime).collect(Collectors.toSet());

--- a/src/main/java/com/gg/server/domain/match/service/MatchService.java
+++ b/src/main/java/com/gg/server/domain/match/service/MatchService.java
@@ -144,7 +144,7 @@ public class MatchService {
         if (penaltyService.isPenaltyUser(userDto.getIntraId())) {
             throw new PenaltyUserSlotException();
         }
-        if (isNotEndedTournament(startTime)) {
+        if (isExistTournamentNotEnded(startTime)) {
             throw new TournamentConflictException();
         }
         if (gameRepository.findByStartTime(startTime).isPresent()) {
@@ -196,15 +196,19 @@ public class MatchService {
     }
 
     /**
-     * 진행중인 토너먼트 유무 확인
+     * LIVE, BEFORE 상태인 토너먼트와 진행 시간이 겹치지 않으면 true, 겹치면 false
      * @param time 현재 시간
      * @return 종료되지 않은 토너먼트 있으면 true, 없으면 false
      */
-    private boolean isNotEndedTournament(LocalDateTime time) {
+    private boolean isExistTournamentNotEnded(LocalDateTime time) {
         List<Tournament> tournamentList = tournamentRepository.findAllByStatusIsNot(TournamentStatus.END);
         for (Tournament tournament : tournamentList) {
             if (time.isAfter(tournament.getStartTime()) &&
                 time.isBefore(tournament.getEndTime())) {
+                return false;
+            }
+            if (time.isEqual(tournament.getStartTime()) ||
+                time.isEqual(tournament.getEndTime())) {
                 return false;
             }
         }

--- a/src/main/java/com/gg/server/domain/match/service/MatchService.java
+++ b/src/main/java/com/gg/server/domain/match/service/MatchService.java
@@ -21,6 +21,8 @@ import com.gg.server.domain.rank.redis.RankRedisRepository;
 import com.gg.server.domain.rank.redis.RedisKeyManager;
 import com.gg.server.domain.season.data.Season;
 import com.gg.server.domain.season.service.SeasonFindService;
+import com.gg.server.domain.tournament.exception.TournamentConflictException;
+import com.gg.server.domain.tournament.service.TournamentService;
 import com.gg.server.domain.user.data.User;
 import com.gg.server.domain.user.data.UserRepository;
 import com.gg.server.domain.user.dto.UserDto;
@@ -45,6 +47,7 @@ public class MatchService {
     private final PenaltyService penaltyService;
     private final GameUpdateService gameUpdateService;
     private final UserRepository userRepository;
+    private final TournamentService tournamentService;
 
     /**
      * 1) 매칭 가능한 유저 있을 경우 : 게임 생성
@@ -124,9 +127,23 @@ public class MatchService {
         }
     }
 
+    /**
+     * 매칭 요청 시 유효성 검사
+     * @param userDto 매칭 요청한 유저
+     * @param startTime 매칭 요청 시간
+     * @throws PenaltyUserSlotException 패널티 유저일 경우
+     * @throws TournamentConflictException 토너먼트가 존재할 경우
+     * @throws GameAlreadyExistException 게임이 이미 존재할 경우
+     * @throws EnrolledSlotException 매칭된 게임이 이미 있을 경우 || 유저 이미 큐에 등록할 경우
+     * @throws SlotCountException 4번 이상 매치 넣을 경우
+     *
+     */
     private void checkValid(UserDto userDto, LocalDateTime startTime) {
         if (penaltyService.isPenaltyUser(userDto.getIntraId())) {
             throw new PenaltyUserSlotException();
+        }
+        if (tournamentService.isNotEndedTournament(startTime)) {
+            throw new TournamentConflictException();
         }
         if (gameRepository.findByStartTime(startTime).isPresent()) {
             throw new GameAlreadyExistException();

--- a/src/main/java/com/gg/server/domain/match/type/Option.java
+++ b/src/main/java/com/gg/server/domain/match/type/Option.java
@@ -11,9 +11,10 @@ public enum Option {
     //match에서는 Both를 써서 자료형 따로 만듬
     BOTH(0,"both"),
     NORMAL(1,"normal"),
-    RANK(2,"rank");
+    RANK(2,"rank"),
+    TOURNAMENT(3,"tournament");
 
-    // 모드는 3가지가 있음.
+    // 모드는 4가지가 있음.
 
     private final Integer value;
     private final String code;

--- a/src/main/java/com/gg/server/domain/match/utils/SlotGenerator.java
+++ b/src/main/java/com/gg/server/domain/match/utils/SlotGenerator.java
@@ -36,9 +36,8 @@ public class SlotGenerator {
     private final RedisMatchUser matchUser;
     private final MatchCalculator matchCalculator;
     private final Option option;
-    private final TournamentRepository tournamentRepository;
 
-    public SlotGenerator(RankRedis user, SlotManagement slotManagement, Season season, Option option, TournamentRepository tournamentRepository) {
+    public SlotGenerator(RankRedis user, SlotManagement slotManagement, Season season, Option option) {
         this.interval = slotManagement.getGameInterval();
         this.now = LocalDateTime.now();
         this.minTime = LocalDateTime.of(
@@ -49,7 +48,6 @@ public class SlotGenerator {
         this.slots = new HashMap<LocalDateTime, SlotStatusDto>();
         this.matchUser = new RedisMatchUser(user.getUserId(), user.getPpp(), option);
         this.matchCalculator = new MatchCalculator(season.getPppGap(), matchUser);
-        this.tournamentRepository = tournamentRepository;
     }
 
     public void addPastSlots() {
@@ -66,8 +64,7 @@ public class SlotGenerator {
     /**
      * BEFORE, LIVE 상태의 토너먼트 진행 시간에 슬롯을 block함
      */
-    public void addTournamentSlots() {
-        List<Tournament> tournaments = tournamentRepository.findAllByStatusIsNot(TournamentStatus.END);
+    public void addTournamentSlots(List<Tournament> tournaments) {
         for (Tournament tournament : tournaments) {
             LocalDateTime startTime = tournament.getStartTime();
             LocalDateTime endTime = tournament.getEndTime();

--- a/src/main/java/com/gg/server/domain/match/utils/SlotGenerator.java
+++ b/src/main/java/com/gg/server/domain/match/utils/SlotGenerator.java
@@ -64,7 +64,7 @@ public class SlotGenerator {
     }
 
     /**
-     * BEFORE, READY, LIVE 상태의 토너먼트 진행 시간에 슬롯을 blocked함
+     * BEFORE, LIVE 상태의 토너먼트 진행 시간에 슬롯을 block함
      */
     public void addTournamentSlots() {
         List<Tournament> tournaments = tournamentRepository.findAllByStatusIsNot(TournamentStatus.END);

--- a/src/main/java/com/gg/server/domain/tournament/data/Tournament.java
+++ b/src/main/java/com/gg/server/domain/tournament/data/Tournament.java
@@ -18,7 +18,6 @@ import lombok.*;
 @Getter
 @Entity
 @ToString
-@Builder
 public class Tournament extends BaseTimeEntity {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -70,18 +69,6 @@ public class Tournament extends BaseTimeEntity {
         this.tournamentGames = tournamentGames != null ? tournamentGames : new ArrayList<>();
         this.tournamentUsers = tournamentUsers != null ? tournamentUsers : new ArrayList<>();
     }
-
-    // TODO TournamentDto 사용할 건지 고민해보기
-//    static public Tournament from(TournamentDto tournamentDto) {
-//        return Tournament.builder()
-//                .title(tournamentDto.getTitle())
-//                .contents(tournamentDto.getContents())
-//                .startTime(tournamentDto.getStartTime())
-//                .endTime(tournamentDto.getEndTime())
-//                .type(tournamentDto.getType())
-//                .status(tournamentDto.getStatus())
-//                .build();
-//    }
 
     public void update(String title, String contents, LocalDateTime startTime, LocalDateTime endTime, TournamentType type, TournamentStatus status) {
         this.title = title;

--- a/src/main/java/com/gg/server/domain/tournament/data/Tournament.java
+++ b/src/main/java/com/gg/server/domain/tournament/data/Tournament.java
@@ -18,6 +18,7 @@ import lombok.*;
 @Getter
 @Entity
 @ToString
+@Builder
 public class Tournament extends BaseTimeEntity {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -59,16 +60,6 @@ public class Tournament extends BaseTimeEntity {
     private List<TournamentUser> tournamentUsers = new ArrayList<>();
 
     @Builder
-    public Tournament(String title, String contents, LocalDateTime startTime, LocalDateTime endTime, TournamentType type, TournamentStatus status) {
-        this.title = title;
-        this.contents = contents;
-        this.startTime = startTime;
-        this.endTime = endTime;
-        this.type = type;
-        this.status = status;
-    }
-
-    @Builder
     public Tournament(String title, String contents, LocalDateTime startTime, LocalDateTime endTime, TournamentType type, TournamentStatus status, User winner, List<TournamentGame> tournamentGames, List<TournamentUser> tournamentUsers) {
         this.title = title;
         this.contents = contents;
@@ -78,17 +69,6 @@ public class Tournament extends BaseTimeEntity {
         this.status = status;
         this.tournamentGames = tournamentGames != null ? tournamentGames : new ArrayList<>();
         this.tournamentUsers = tournamentUsers != null ? tournamentUsers : new ArrayList<>();
-    }
-
-    static public Tournament of(String title, String contents, LocalDateTime startTime, LocalDateTime endTime, TournamentType type, TournamentStatus status) {
-        return Tournament.builder()
-                .title(title)
-                .contents(contents)
-                .startTime(startTime)
-                .endTime(endTime)
-                .type(type)
-                .status(status)
-                .build();
     }
 
     // TODO TournamentDto 사용할 건지 고민해보기

--- a/src/main/java/com/gg/server/domain/tournament/exception/TournamentConflictException.java
+++ b/src/main/java/com/gg/server/domain/tournament/exception/TournamentConflictException.java
@@ -9,6 +9,6 @@ public class TournamentConflictException extends DuplicationException {
     }
 
     public TournamentConflictException() {
-        super("이미 토너먼트가 존재합니다.", ErrorCode.TOURNAMENT_CONFLICT);
+        super(ErrorCode.TOURNAMENT_CONFLICT.getMessage(), ErrorCode.TOURNAMENT_CONFLICT);
     }
 }

--- a/src/main/java/com/gg/server/domain/tournament/exception/TournamentConflictException.java
+++ b/src/main/java/com/gg/server/domain/tournament/exception/TournamentConflictException.java
@@ -7,4 +7,8 @@ public class TournamentConflictException extends DuplicationException {
     public TournamentConflictException(String message, ErrorCode errorCode) {
         super(message, errorCode);
     }
+
+    public TournamentConflictException() {
+        super("이미 토너먼트가 존재합니다.", ErrorCode.TOURNAMENT_CONFLICT);
+    }
 }

--- a/src/main/java/com/gg/server/domain/tournament/service/TournamentService.java
+++ b/src/main/java/com/gg/server/domain/tournament/service/TournamentService.java
@@ -29,8 +29,9 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.ArrayList;
 
 @Service
 @RequiredArgsConstructor
@@ -98,6 +99,22 @@ public class TournamentService {
             tournamentUserStatus = tournamentUser.get().getIsJoined() ? TournamentUserStatus.PLAYER : TournamentUserStatus.WAIT;
         }
         return new TournamentUserRegistrationResponseDto(tournamentUserStatus);
+    }
+
+    /**
+     * 진행중인 토너먼트 유무 확인
+     * @param time 현재 시간
+     * @return 종료되지 않은 토너먼트 있으면 true, 없으면 false
+     */
+    public boolean isNotEndedTournament(LocalDateTime time) {
+        List<Tournament> tournamentList = tournamentRepository.findAllByStatusIsNot(TournamentStatus.END);
+        for (Tournament tournament : tournamentList) {
+            if (time.isAfter(tournament.getStartTime()) &&
+                time.isBefore(tournament.getEndTime())) {
+                return false;
+            }
+        }
+        return true;
     }
 
     /**

--- a/src/main/java/com/gg/server/domain/tournament/type/TournamentType.java
+++ b/src/main/java/com/gg/server/domain/tournament/type/TournamentType.java
@@ -9,7 +9,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum TournamentType {
     ROOKIE("rookie", "초보"),
-    MASTER("master", "고수");
+    MASTER("master", "고수"),
+    CUSTOM("custom", "커스텀");
 
     private final String code;
     private final String desc;

--- a/src/test/java/com/gg/server/domain/match/service/MatchServiceTest.java
+++ b/src/test/java/com/gg/server/domain/match/service/MatchServiceTest.java
@@ -24,6 +24,7 @@ import com.gg.server.domain.penalty.redis.RedisPenaltyUser;
 import com.gg.server.domain.rank.redis.RankRedis;
 import com.gg.server.domain.rank.redis.RankRedisRepository;
 import com.gg.server.domain.rank.redis.RedisKeyManager;
+import com.gg.server.domain.rank.service.RedisUploadService;
 import com.gg.server.domain.season.data.Season;
 import com.gg.server.domain.slotmanagement.SlotManagement;
 import com.gg.server.domain.slotmanagement.data.SlotManagementRepository;
@@ -89,6 +90,8 @@ class MatchServiceTest {
     SlotManagementRepository slotManagementRepository;
     @Autowired
     TierRepository tierRepository;
+    @Autowired
+    RedisUploadService redisUploadService;
     List<User> users;
     List<LocalDateTime> slotTimes;
 
@@ -434,11 +437,8 @@ class MatchServiceTest {
             tournamentRepository.save(tournament);
             tierRepository.save(new Tier("image url"));
 
-            //
-            tierRepository.flush();
-            List<Tier> all = tierRepository.findAll();
-            System.out.println("all = " + all);
-
+            // TODO 현재 upload redis해도 redis 데이터 없다는 에러 발생함
+            redisUploadService.uploadRedis();
             // when
             SlotStatusResponseListDto allMatchStatus = matchFindService.getAllMatchStatus(UserDto.from(users.get(0)),
                 Option.NORMAL);

--- a/src/test/java/com/gg/server/domain/match/service/MatchServiceTest.java
+++ b/src/test/java/com/gg/server/domain/match/service/MatchServiceTest.java
@@ -35,10 +35,7 @@ import java.util.Optional;
 import java.util.Random;
 import lombok.RequiredArgsConstructor;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -90,18 +87,18 @@ class MatchServiceTest {
         Integer userCount = random.nextInt(10) + 5;
         Integer pppGap = random.nextInt(100) + 50;
         Season season = matchTestSetting.makeTestSeason(pppGap);
-        this.testSeason = season;
+        testSeason = season;
         List<User> users = new ArrayList<User>();
         for(int i = 0; i < userCount; i++) {
             User user = matchTestSetting.createUser();
             users.add(user);
         }
-        this.users = users;
+        users = users;
         users.stream().forEach(user ->
                 matchTestSetting.addUsertoRankRedis(user.getId(), random.nextInt(season.getPppGap()), season.getId()));
         SlotManagement slotManagement = matchTestSetting.makeTestSlotManagement(15);
         List<LocalDateTime> slotTimes = matchTestSetting.getTestSlotTimes(slotManagement.getGameInterval());
-        this.slotTimes = slotTimes;
+        slotTimes = slotTimes;
     }
     @AfterEach
     void clear() {
@@ -110,324 +107,339 @@ class MatchServiceTest {
         connection.close();
     }
 
-    @DisplayName("매칭 가능 상대가 없는 경우 큐에 들어감")
-    @Test
-    void addMatchDifferentOption() {
-        System.out.println("this.users = " + this.users);
-        matchService.makeMatch(UserDto.from(users.get(0)), Option.NORMAL, this.slotTimes.get(0));
-        matchService.makeMatch(UserDto.from(users.get(1)), Option.RANK, this.slotTimes.get(0));
-        Long size = redisTemplate.opsForList().size(MatchKey.getTime(slotTimes.get(0)));
-        Assertions.assertThat(size).isEqualTo(2L);
-    }
+    @Nested
+    @DisplayName("매칭 요청 API 테스트")
+    class MatchTest {
+        @DisplayName("매칭 가능 상대가 없는 경우 큐에 들어감")
+        @Test
+        void addMatchDifferentOption() {
+            System.out.println("users = " + users);
+            matchService.makeMatch(UserDto.from(users.get(0)), Option.NORMAL, slotTimes.get(0));
+            matchService.makeMatch(UserDto.from(users.get(1)), Option.RANK, slotTimes.get(0));
+            Long size = redisTemplate.opsForList().size(MatchKey.getTime(slotTimes.get(0)));
+            Assertions.assertThat(size).isEqualTo(2L);
+        }
 
-    @DisplayName("normal both 매칭 시 게임 생성")
-    @Test
-    void makeGameWithNormalAndBoth() {
-        System.out.println("this.users = " + this.users);
-        matchService.makeMatch(UserDto.from(users.get(0)), Option.NORMAL, this.slotTimes.get(0));
-        matchService.makeMatch(UserDto.from(users.get(1)), Option.BOTH, this.slotTimes.get(0));
-        matchService.makeMatch(UserDto.from(users.get(2)), Option.BOTH, this.slotTimes.get(1));
-        matchService.makeMatch(UserDto.from(users.get(3)), Option.NORMAL, this.slotTimes.get(1));
-        Optional<Game> game1 = gameRepository.findByStartTime(slotTimes.get(0));
-        Optional<Game> game2 = gameRepository.findByStartTime(slotTimes.get(1));
-        Assertions.assertThat(game1).isPresent();
-        Assertions.assertThat(game2).isPresent();
-        System.out.println("normal user + matchService = " + matchFindService.getAllMatchStatus(UserDto.from(users.get(0)), Option.NORMAL));
-        System.out.println();
-        System.out.println("normal user both + matchService = " + matchFindService.getAllMatchStatus(UserDto.from(users.get(0)), Option.BOTH));
-        System.out.println("both user + matchService = " + matchFindService.getAllMatchStatus(UserDto.from(users.get(1)),
+        @DisplayName("normal both 매칭 시 게임 생성")
+        @Test
+        void makeGameWithNormalAndBoth() {
+            System.out.println("users = " + users);
+            matchService.makeMatch(UserDto.from(users.get(0)), Option.NORMAL, slotTimes.get(0));
+            matchService.makeMatch(UserDto.from(users.get(1)), Option.BOTH, slotTimes.get(0));
+            matchService.makeMatch(UserDto.from(users.get(2)), Option.BOTH, slotTimes.get(1));
+            matchService.makeMatch(UserDto.from(users.get(3)), Option.NORMAL, slotTimes.get(1));
+            Optional<Game> game1 = gameRepository.findByStartTime(slotTimes.get(0));
+            Optional<Game> game2 = gameRepository.findByStartTime(slotTimes.get(1));
+            Assertions.assertThat(game1).isPresent();
+            Assertions.assertThat(game2).isPresent();
+            System.out.println("normal user + matchService = " + matchFindService.getAllMatchStatus(UserDto.from(users.get(0)), Option.NORMAL));
+            System.out.println();
+            System.out.println("normal user both + matchService = " + matchFindService.getAllMatchStatus(UserDto.from(users.get(0)), Option.BOTH));
+            System.out.println("both user + matchService = " + matchFindService.getAllMatchStatus(UserDto.from(users.get(1)),
                 Option.BOTH));
-        System.out.println("both user normal matchService = " + matchFindService.getAllMatchStatus(UserDto.from(users.get(1)),
+            System.out.println("both user normal matchService = " + matchFindService.getAllMatchStatus(UserDto.from(users.get(1)),
                 Option.NORMAL));
+        }
+
+        @DisplayName("Queue에 매칭 가능한 normal 상대가 있을 경우 게임 생성")
+        @Test
+        void addMatchSameNormalOption() {
+            matchService.makeMatch(UserDto.from(users.get(2)), Option.RANK, slotTimes.get(0));
+            matchService.makeMatch(UserDto.from(users.get(0)), Option.NORMAL, slotTimes.get(0));
+            matchService.makeMatch(UserDto.from(users.get(1)), Option.NORMAL, slotTimes.get(0));
+            matchService.cancelMatch(UserDto.from(users.get(0)), slotTimes.get(0));
+            Optional<Game> game = gameRepository.findByStartTime(slotTimes.get(0));
+            Assertions.assertThat(game).isEmpty();
+            Long size = redisTemplate.opsForList().size(MatchKey.getTime(slotTimes.get(0)));
+            List<RedisMatchUser> allMatchUsers = redisMatchTimeRepository.getAllMatchUsers(slotTimes.get(0));
+            Assertions.assertThat(size).isEqualTo(2L);
+            RedisMatchUser remainedUser = (RedisMatchUser) redisTemplate.opsForList().index(MatchKey.getTime(slotTimes.get(0)), 0);
+            Assertions.assertThat(remainedUser.getUserId()).isEqualTo(users.get(2).getId());
+            Assertions.assertThat(notiRepository.findAllByUser(users.get(1)).size()).isEqualTo(2);
+            Assertions.assertThat(notiRepository.findAllByUser(users.get(0)).size()).isEqualTo(1);
+            Assertions.assertThat(notiRepository.findAllByUser(users.get(2)).size()).isEqualTo(0);
+        }
+
+        @DisplayName("게임 재생성 테스트")
+        @Test
+        void remakeGameAfterCancelling() {
+            matchService.makeMatch(UserDto.from(users.get(2)), Option.RANK, slotTimes.get(0));
+            matchService.makeMatch(UserDto.from(users.get(0)), Option.NORMAL, slotTimes.get(0));
+            matchService.makeMatch(UserDto.from(users.get(1)), Option.BOTH, slotTimes.get(0));
+            matchService.cancelMatch(UserDto.from(users.get(2)), slotTimes.get(0));
+            Optional<Game> game = gameRepository.findByStartTime(slotTimes.get(0));
+            Assertions.assertThat(game).isPresent();
+            Long size = redisTemplate.opsForList().size(MatchKey.getTime(slotTimes.get(0)));
+            Assertions.assertThat(size).isEqualTo(2L);
+            RedisMatchUser remainedUser = (RedisMatchUser) redisTemplate.opsForList().index(MatchKey.getTime(slotTimes.get(0)), 0);
+            Assertions.assertThat(remainedUser.getUserId()).isEqualTo(users.get(0).getId());
+            Assertions.assertThat(notiRepository.findAllByUser(users.get(1)).size()).isEqualTo(1);
+            Assertions.assertThat(notiRepository.findAllByUser(users.get(0)).size()).isEqualTo(1);
+            Assertions.assertThat(notiRepository.findAllByUser(users.get(2)).size()).isEqualTo(1);
+        }
+
+        @DisplayName("Queue에 user가 선택한 random option으로 매칭 가능한 상대가 없을 경우")
+        @Test
+        void addMatchRankOptionAndPppGapBiggerThanSeasonPppGap() {
+            User user1 = matchTestSetting.createUser();
+            matchTestSetting.addUsertoRankRedis(user1.getId(),
+                testSeason.getStartPpp() + testSeason.getPppGap() + 1, testSeason.getId());//pppGap차이가 충분히 큰 경우
+            matchService.makeMatch(UserDto.from(user1), Option.RANK, slotTimes.get(0));
+            matchService.makeMatch(UserDto.from(users.get(0)), Option.NORMAL, slotTimes.get(0));
+            matchService.makeMatch(UserDto.from(users.get(1)), Option.RANK, slotTimes.get(0));
+            Long size = redisTemplate.opsForList().size(MatchKey.getTime(slotTimes.get(0)));
+            Assertions.assertThat(size).isEqualTo(3L);
+            Optional<Game> game = gameRepository.findByStartTime(slotTimes.get(0));
+            Assertions.assertThat(game.isEmpty()).isEqualTo(true);
+
+        }
+
+        @DisplayName("Queue에 user가 선택한 random option으로 매칭 가능한 상대가 있는 경우")
+        @Test
+        void addMatchRankOptionAndPppGapSamllerThanOrEqualToSeasonPppGap() {
+            RankRedis userRank = rankRedisRepository.findRankByUserId(RedisKeyManager
+                .getHashKey(testSeason.getId()), users.get(0).getId());
+            User user1 = matchTestSetting.createUser();
+            matchTestSetting.addUsertoRankRedis(user1.getId(),userRank.getPpp() + testSeason.getPppGap()
+                , testSeason.getId());//pppGap차이가 pppGap만큼
+            matchService.makeMatch(UserDto.from(user1), Option.RANK, slotTimes.get(0));
+            matchService.makeMatch(UserDto.from(users.get(0)), Option.RANK, slotTimes.get(0));
+            Long size = redisTemplate.opsForList().size(MatchKey.getTime(slotTimes.get(0)));
+            Assertions.assertThat(size).isEqualTo(0L);
+            Optional<Game> game = gameRepository.findByStartTime(slotTimes.get(0));
+            Assertions.assertThat(game.isEmpty()).isEqualTo(false);
+        }
+
+        @DisplayName("Queue에 user가 선택한 both option으로 매칭 가능한 상대가 있는 경우")
+        @Test
+        void addMatchBothOptionAndPppGapSmallerThanOrEqualToSeasonPppGap() {
+            RankRedis userRank = rankRedisRepository.findRankByUserId(RedisKeyManager
+                .getHashKey(testSeason.getId()), users.get(0).getId());
+            User user1 = matchTestSetting.createUser();
+            matchTestSetting.addUsertoRankRedis(user1.getId(),userRank.getPpp() + testSeason.getPppGap()
+                , testSeason.getId());//pppGap차이가 pppGap만큼
+            matchService.makeMatch(UserDto.from(user1), Option.BOTH, slotTimes.get(0));
+            matchService.makeMatch(UserDto.from(users.get(0)), Option.BOTH, slotTimes.get(0));
+            Long size = redisTemplate.opsForList().size(MatchKey.getTime(slotTimes.get(0)));
+            Assertions.assertThat(size).isEqualTo(0L);
+            Optional<Game> game = gameRepository.findByStartTime(slotTimes.get(0));
+            Assertions.assertThat(game.isEmpty()).isEqualTo(false);
+            Assertions.assertThat(game.get().getMode()).isEqualTo(Mode.RANK);
+        }
     }
 
-    @DisplayName("Queue에 매칭 가능한 normal 상대가 있을 경우 게임 생성")
-    @Test
-    void addMatchSameNormalOption() {
-        matchService.makeMatch(UserDto.from(users.get(2)), Option.RANK, this.slotTimes.get(0));
-        matchService.makeMatch(UserDto.from(users.get(0)), Option.NORMAL, this.slotTimes.get(0));
-        matchService.makeMatch(UserDto.from(users.get(1)), Option.NORMAL, this.slotTimes.get(0));
-        matchService.cancelMatch(UserDto.from(users.get(0)), this.slotTimes.get(0));
-        Optional<Game> game = gameRepository.findByStartTime(slotTimes.get(0));
-        Assertions.assertThat(game).isEmpty();
-        Long size = redisTemplate.opsForList().size(MatchKey.getTime(this.slotTimes.get(0)));
-        List<RedisMatchUser> allMatchUsers = redisMatchTimeRepository.getAllMatchUsers(this.slotTimes.get(0));
-        Assertions.assertThat(size).isEqualTo(2L);
-        RedisMatchUser remainedUser = (RedisMatchUser) redisTemplate.opsForList().index(MatchKey.getTime(slotTimes.get(0)), 0);
-        Assertions.assertThat(remainedUser.getUserId()).isEqualTo(users.get(2).getId());
-        Assertions.assertThat(notiRepository.findAllByUser(users.get(1)).size()).isEqualTo(2);
-        Assertions.assertThat(notiRepository.findAllByUser(users.get(0)).size()).isEqualTo(1);
-        Assertions.assertThat(notiRepository.findAllByUser(users.get(2)).size()).isEqualTo(0);
-    }
-
-    @DisplayName("게임 재생성 테스트")
-    @Test
-    void remakeGameAfterCancelling() {
-        matchService.makeMatch(UserDto.from(users.get(2)), Option.RANK, this.slotTimes.get(0));
-        matchService.makeMatch(UserDto.from(users.get(0)), Option.NORMAL, this.slotTimes.get(0));
-        matchService.makeMatch(UserDto.from(users.get(1)), Option.BOTH, this.slotTimes.get(0));
-        matchService.cancelMatch(UserDto.from(users.get(2)), this.slotTimes.get(0));
-        Optional<Game> game = gameRepository.findByStartTime(slotTimes.get(0));
-        Assertions.assertThat(game).isPresent();
-        Long size = redisTemplate.opsForList().size(MatchKey.getTime(this.slotTimes.get(0)));
-        Assertions.assertThat(size).isEqualTo(2L);
-        RedisMatchUser remainedUser = (RedisMatchUser) redisTemplate.opsForList().index(MatchKey.getTime(slotTimes.get(0)), 0);
-        Assertions.assertThat(remainedUser.getUserId()).isEqualTo(users.get(0).getId());
-        Assertions.assertThat(notiRepository.findAllByUser(users.get(1)).size()).isEqualTo(1);
-        Assertions.assertThat(notiRepository.findAllByUser(users.get(0)).size()).isEqualTo(1);
-        Assertions.assertThat(notiRepository.findAllByUser(users.get(2)).size()).isEqualTo(1);
-    }
-
-    @DisplayName("Queue에 user가 선택한 random option으로 매칭 가능한 상대가 없을 경우")
-    @Test
-    void addMatchRankOptionAndPppGapBiggerThanSeasonPppGap() {
-        User user1 = matchTestSetting.createUser();
-        matchTestSetting.addUsertoRankRedis(user1.getId(),
-                this.testSeason.getStartPpp() + this.testSeason.getPppGap() + 1, this.testSeason.getId());//pppGap차이가 충분히 큰 경우
-        matchService.makeMatch(UserDto.from(user1), Option.RANK, this.slotTimes.get(0));
-        matchService.makeMatch(UserDto.from(users.get(0)), Option.NORMAL, this.slotTimes.get(0));
-        matchService.makeMatch(UserDto.from(users.get(1)), Option.RANK, this.slotTimes.get(0));
-        Long size = redisTemplate.opsForList().size(MatchKey.getTime(slotTimes.get(0)));
-        Assertions.assertThat(size).isEqualTo(3L);
-        Optional<Game> game = gameRepository.findByStartTime(slotTimes.get(0));
-        Assertions.assertThat(game.isEmpty()).isEqualTo(true);
-
-    }
-
-    @DisplayName("Queue에 user가 선택한 random option으로 매칭 가능한 상대가 있는 경우")
-    @Test
-    void addMatchRankOptionAndPppGapSamllerThanOrEqualToSeasonPppGap() {
-        RankRedis userRank = rankRedisRepository.findRankByUserId(RedisKeyManager
-                .getHashKey(this.testSeason.getId()), users.get(0).getId());
-        User user1 = matchTestSetting.createUser();
-        matchTestSetting.addUsertoRankRedis(user1.getId(),userRank.getPpp() + this.testSeason.getPppGap()
-                , this.testSeason.getId());//pppGap차이가 pppGap만큼
-        matchService.makeMatch(UserDto.from(user1), Option.RANK, this.slotTimes.get(0));
-        matchService.makeMatch(UserDto.from(users.get(0)), Option.RANK, this.slotTimes.get(0));
-        Long size = redisTemplate.opsForList().size(MatchKey.getTime(slotTimes.get(0)));
-        Assertions.assertThat(size).isEqualTo(0L);
-        Optional<Game> game = gameRepository.findByStartTime(slotTimes.get(0));
-        Assertions.assertThat(game.isEmpty()).isEqualTo(false);
-    }
-
-    @DisplayName("Queue에 user가 선택한 both option으로 매칭 가능한 상대가 있는 경우")
-    @Test
-    void addMatchBothOptionAndPppGapSmallerThanOrEqualToSeasonPppGap() {
-        RankRedis userRank = rankRedisRepository.findRankByUserId(RedisKeyManager
-                .getHashKey(this.testSeason.getId()), users.get(0).getId());
-        User user1 = matchTestSetting.createUser();
-        matchTestSetting.addUsertoRankRedis(user1.getId(),userRank.getPpp() + this.testSeason.getPppGap()
-                , this.testSeason.getId());//pppGap차이가 pppGap만큼
-        matchService.makeMatch(UserDto.from(user1), Option.BOTH, this.slotTimes.get(0));
-        matchService.makeMatch(UserDto.from(users.get(0)), Option.BOTH, this.slotTimes.get(0));
-        Long size = redisTemplate.opsForList().size(MatchKey.getTime(slotTimes.get(0)));
-        Assertions.assertThat(size).isEqualTo(0L);
-        Optional<Game> game = gameRepository.findByStartTime(slotTimes.get(0));
-        Assertions.assertThat(game.isEmpty()).isEqualTo(false);
-        Assertions.assertThat(game.get().getMode()).isEqualTo(Mode.RANK);
-    }
-
-
-    @DisplayName("게임 생성되었을 때 경기 취소")
-    @Test
-    void cancelMatchAfterMakingGameEntity() {
-        //normal 게임 생성
-        matchService.makeMatch(UserDto.from(users.get(0)), Option.NORMAL, this.slotTimes.get(3));
-        matchService.makeMatch(UserDto.from(users.get(1)), Option.NORMAL, this.slotTimes.get(3));
-        //user2 다른 슬롯 등록
-        //첫번째 유저 경기 취소
-        org.junit.jupiter.api.Assertions.assertThrows(
+    @Nested
+    @DisplayName("매칭 취소 API 테스트")
+    class CancelMatch {
+        @DisplayName("게임 생성되었을 때 경기 취소")
+        @Test
+        void cancelMatchAfterMakingGameEntity() {
+            //normal 게임 생성
+            matchService.makeMatch(UserDto.from(users.get(0)), Option.NORMAL, slotTimes.get(3));
+            matchService.makeMatch(UserDto.from(users.get(1)), Option.NORMAL, slotTimes.get(3));
+            //user2 다른 슬롯 등록
+            //첫번째 유저 경기 취소
+            org.junit.jupiter.api.Assertions.assertThrows(
                 EnrolledSlotException.class,
-                () -> matchService.makeMatch(UserDto.from(users.get(0)), Option.NORMAL, this.slotTimes.get(0))
-        );
-        matchService.cancelMatch(UserDto.from(users.get(0)), slotTimes.get(3));
-        Optional<Game> game = gameRepository.findByStartTime(slotTimes.get(3));
-        Assertions.assertThat(game.isEmpty()).isEqualTo(true);
-        Assertions.assertThat(redisMatchUserRepository.countMatchTime(users.get(1).getId())).isEqualTo(0L);
+                () -> matchService.makeMatch(UserDto.from(users.get(0)), Option.NORMAL, slotTimes.get(0))
+            );
+            matchService.cancelMatch(UserDto.from(users.get(0)), slotTimes.get(3));
+            Optional<Game> game = gameRepository.findByStartTime(slotTimes.get(3));
+            Assertions.assertThat(game.isEmpty()).isEqualTo(true);
+            Assertions.assertThat(redisMatchUserRepository.countMatchTime(users.get(1).getId())).isEqualTo(0L);
 
-        //알람 확인
-        List<Noti> notifications = notiRepository.findAllByUser(users.get(1));
-        System.out.println("users.get(0).getIntraId() = " + users.get(0).getIntraId());
-        for (Noti noti : notifications) {
-            System.out.println("noti.getMessage() = " + noti.getMessage());
-        }
-        Assertions.assertThat(notifications.size()).isEqualTo(2);
-        Assertions.assertThat(notifications.get(0).getType()).isEqualTo(NotiType.MATCHED);
-        Assertions.assertThat(notifications.get(1).getType()).isEqualTo(NotiType.CANCELEDBYMAN);
+            //알람 확인
+            List<Noti> notifications = notiRepository.findAllByUser(users.get(1));
+            System.out.println("users.get(0).getIntraId() = " + users.get(0).getIntraId());
+            for (Noti noti : notifications) {
+                System.out.println("noti.getMessage() = " + noti.getMessage());
+            }
+            Assertions.assertThat(notifications.size()).isEqualTo(2);
+            Assertions.assertThat(notifications.get(0).getType()).isEqualTo(NotiType.MATCHED);
+            Assertions.assertThat(notifications.get(1).getType()).isEqualTo(NotiType.CANCELEDBYMAN);
 
-        //패널티 확인
-        Optional<RedisPenaltyUser> penaltyUser = penaltyUserRedisRepository.findByIntraId(users.get(0).getIntraId());
-        Assertions.assertThat(penaltyUser).isPresent();
-        Assertions.assertThat(penaltyUser.get().getPenaltyTime()).isEqualTo(1);
-        org.junit.jupiter.api.Assertions.assertThrows(PenaltyUserSlotException.class, () -> {
-                matchService.makeMatch(UserDto.from(users.get(0)), Option.BOTH, slotTimes.get(10));
+            //패널티 확인
+            Optional<RedisPenaltyUser> penaltyUser = penaltyUserRedisRepository.findByIntraId(users.get(0).getIntraId());
+            Assertions.assertThat(penaltyUser).isPresent();
+            Assertions.assertThat(penaltyUser.get().getPenaltyTime()).isEqualTo(1);
+            org.junit.jupiter.api.Assertions.assertThrows(PenaltyUserSlotException.class, () -> {
+                    matchService.makeMatch(UserDto.from(users.get(0)), Option.BOTH, slotTimes.get(10));
                 }
-        );
+            );
+        }
+
+        @DisplayName("게임 생성 전 경기 취소")
+        @Test
+        void cancelBeforeMakingGameEntity() {
+            RankRedis userRank = rankRedisRepository.findRankByUserId(RedisKeyManager
+                .getHashKey(testSeason.getId()), users.get(0).getId());
+            User user1 = matchTestSetting.createUser();
+            matchTestSetting.addUsertoRankRedis(user1.getId(),userRank.getPpp() + testSeason.getPppGap() + 100
+                , testSeason.getId());
+            //매칭이 이루어질 수 없는 유저 3명을 큐에 등록
+            matchService.makeMatch(UserDto.from(users.get(0)), Option.RANK, slotTimes.get(0));
+            matchService.makeMatch(UserDto.from(users.get(1)), Option.NORMAL, slotTimes.get(0));
+            matchService.makeMatch(UserDto.from(user1), Option.RANK, slotTimes.get(0));
+            //user1의 취소
+            matchService.cancelMatch(UserDto.from(users.get(1)), slotTimes.get(0));
+            List<RedisMatchUser> allMatchUsers = redisMatchTimeRepository.getAllMatchUsers(slotTimes.get(0));
+            Assertions.assertThat(allMatchUsers.size()).isEqualTo(2L);
+
+        }
     }
 
-
-    @DisplayName("게임 생성 전 경기 취소")
-    @Test
-    void cancelBeforeMakingGameEntity() {
-        RankRedis userRank = rankRedisRepository.findRankByUserId(RedisKeyManager
-                .getHashKey(this.testSeason.getId()), users.get(0).getId());
-        User user1 = matchTestSetting.createUser();
-        matchTestSetting.addUsertoRankRedis(user1.getId(),userRank.getPpp() + this.testSeason.getPppGap() + 100
-                , this.testSeason.getId());
-        //매칭이 이루어질 수 없는 유저 3명을 큐에 등록
-        matchService.makeMatch(UserDto.from(users.get(0)), Option.RANK, slotTimes.get(0));
-        matchService.makeMatch(UserDto.from(users.get(1)), Option.NORMAL, slotTimes.get(0));
-        matchService.makeMatch(UserDto.from(user1), Option.RANK, slotTimes.get(0));
-        //user1의 취소
-        matchService.cancelMatch(UserDto.from(users.get(1)), slotTimes.get(0));
-        List<RedisMatchUser> allMatchUsers = redisMatchTimeRepository.getAllMatchUsers(slotTimes.get(0));
-        Assertions.assertThat(allMatchUsers.size()).isEqualTo(2L);
-
-    }
-
-    @DisplayName("슬롯 조회 : 게임 생성한 후 내 테이블로 인식")
-    @Test
-    void readMyTableAfterMakingGame() {
-        //normal 게임 생성
-        matchService.makeMatch(UserDto.from(users.get(0)), Option.NORMAL, slotTimes.get(0));
-        matchService.makeMatch(UserDto.from(users.get(0)), Option.RANK, slotTimes.get(4));
-        matchService.makeMatch(UserDto.from(users.get(1)), Option.RANK, slotTimes.get(1));
-        matchService.makeMatch(UserDto.from(users.get(2)), Option.NORMAL, slotTimes.get(2));
-        SlotStatusResponseListDto slotStatusList = matchFindService.getAllMatchStatus(UserDto.from(users.get(0)),
+    @Nested
+    @DisplayName("특정 시간대의 경기 매칭 가능 상태 조회 API 테스트")
+    class GetMatchTimeScope {
+        @DisplayName("슬롯 조회 : 게임 생성한 후 내 테이블로 인식")
+        @Test
+        void readMyTableAfterMakingGame() {
+            //normal 게임 생성
+            matchService.makeMatch(UserDto.from(users.get(0)), Option.NORMAL, slotTimes.get(0));
+            matchService.makeMatch(UserDto.from(users.get(0)), Option.RANK, slotTimes.get(4));
+            matchService.makeMatch(UserDto.from(users.get(1)), Option.RANK, slotTimes.get(1));
+            matchService.makeMatch(UserDto.from(users.get(2)), Option.NORMAL, slotTimes.get(2));
+            SlotStatusResponseListDto slotStatusList = matchFindService.getAllMatchStatus(UserDto.from(users.get(0)),
                 Option.NORMAL);
-        for (int i = 0; i < 3; i++) {
-            System.out.println("slotTimes = " + String.valueOf(i) + slotTimes.get(i));
+            for (int i = 0; i < 3; i++) {
+                System.out.println("slotTimes = " + String.valueOf(i) + slotTimes.get(i));
+            }
+            for (List<SlotStatusDto> dtos : slotStatusList.getMatchBoards()) {
+                for (SlotStatusDto dto: dtos) {
+                    System.out.println("dto = " + dto);
+                    if (dto.getStartTime().equals(slotTimes.get(0))) {
+                        Assertions.assertThat(dto.getStatus()).isEqualTo(SlotStatus.MYTABLE.getCode());
+                    }
+                    if (dto.getStartTime().equals(slotTimes.get(1))) {
+                        Assertions.assertThat(dto.getStatus()).isEqualTo(SlotStatus.OPEN.getCode());
+                    }
+                    if (dto.getStartTime().equals(slotTimes.get(2))) {
+                        Assertions.assertThat(dto.getStatus()).isEqualTo(SlotStatus.MATCH.getCode());
+                    }
+                    if (dto.getStartTime().equals(slotTimes.get(4))) {
+                        Assertions.assertThat(dto.getStatus()).isEqualTo(SlotStatus.CLOSE.getCode());
+                    }
+                }
+            }
+
         }
-        for (List<SlotStatusDto> dtos : slotStatusList.getMatchBoards()) {
-            for (SlotStatusDto dto: dtos) {
-                System.out.println("dto = " + dto);
-                if (dto.getStartTime().equals(slotTimes.get(0))) {
-                    Assertions.assertThat(dto.getStatus()).isEqualTo(SlotStatus.MYTABLE.getCode());
+
+        @DisplayName("슬롯 조회 : 게임 생성 전 내 테이블로 인식")
+        @Test
+        void readMyTableBeforeMakingGame() {
+            for (int i = 0; i < 3; i++) {
+                matchService.makeMatch(UserDto.from(users.get(0)), Option.NORMAL, slotTimes.get(i));
+            }
+            matchService.makeMatch(UserDto.from(users.get(1)), Option.NORMAL, slotTimes.get(3));
+            matchService.makeMatch(UserDto.from(users.get(2)), Option.NORMAL, slotTimes.get(3));
+            SlotStatusResponseListDto slotStatusList = matchFindService.getAllMatchStatus(UserDto.from(users.get(0)),
+                Option.NORMAL);
+            for (List<SlotStatusDto> dtos : slotStatusList.getMatchBoards()) {
+                for (SlotStatusDto dto: dtos) {
+                    if (dto.getStartTime().equals(slotTimes.get(0))) {
+                        Assertions.assertThat(dto.getStatus()).isEqualTo(SlotStatus.MYTABLE.getCode());
+                    }
+                    if (dto.getStartTime().equals(slotTimes.get(1))) {
+                        Assertions.assertThat(dto.getStatus()).isEqualTo(SlotStatus.MYTABLE.getCode());
+                    }
+                    if (dto.getStartTime().equals(slotTimes.get(2))) {
+                        Assertions.assertThat(dto.getStatus()).isEqualTo(SlotStatus.MYTABLE.getCode());
+                    }
+                    if (dto.getStartTime().equals(slotTimes.get(3))) {
+                        Assertions.assertThat(dto.getStatus()).isEqualTo(SlotStatus.CLOSE.getCode());
+                    }
                 }
-                if (dto.getStartTime().equals(slotTimes.get(1))) {
-                    Assertions.assertThat(dto.getStatus()).isEqualTo(SlotStatus.OPEN.getCode());
-                }
-                if (dto.getStartTime().equals(slotTimes.get(2))) {
-                    Assertions.assertThat(dto.getStatus()).isEqualTo(SlotStatus.MATCH.getCode());
-                }
-                if (dto.getStartTime().equals(slotTimes.get(4))) {
-                    Assertions.assertThat(dto.getStatus()).isEqualTo(SlotStatus.CLOSE.getCode());
+            }
+
+        }
+
+        @DisplayName("슬롯 조회 : 게임 등록 되면 제 3자한테 closed 처리")
+        @Test
+        void getClosedStatusOfExistGame() {
+            matchService.makeMatch(UserDto.from(users.get(1)), Option.NORMAL, slotTimes.get(3));
+            matchService.makeMatch(UserDto.from(users.get(2)), Option.NORMAL, slotTimes.get(3));
+            SlotStatusResponseListDto allMatchStatus = matchFindService.getAllMatchStatus(UserDto.from(users.get(3)),
+                Option.NORMAL);
+            for (List<SlotStatusDto> dtos : allMatchStatus.getMatchBoards()) {
+                for (SlotStatusDto dto: dtos) {
+                    if (dto.getStartTime().equals(slotTimes.get(3))) {
+                        Assertions.assertThat(dto.getStatus()).isEqualTo(SlotStatus.CLOSE.getCode());
+                    }
                 }
             }
         }
 
-    }
-
-    @DisplayName("슬롯 조회 : 게임 생성 전 내 테이블로 인식")
-    @Test
-    void readMyTableBeforeMakingGame() {
-        for (int i = 0; i < 3; i++) {
-            matchService.makeMatch(UserDto.from(users.get(0)), Option.NORMAL, slotTimes.get(i));
-        }
-        matchService.makeMatch(UserDto.from(users.get(1)), Option.NORMAL, slotTimes.get(3));
-        matchService.makeMatch(UserDto.from(users.get(2)), Option.NORMAL, slotTimes.get(3));
-        SlotStatusResponseListDto slotStatusList = matchFindService.getAllMatchStatus(UserDto.from(users.get(0)),
+        @DisplayName("슬롯 조회 : 게임 등록 되면 제3자가 다른 게임 등록해도 제 3자한테 closed 처리")
+        @Test
+        void getClosedStatusOfExistGame2() {
+            matchService.makeMatch(UserDto.from(users.get(1)), Option.NORMAL, slotTimes.get(3));
+            matchService.makeMatch(UserDto.from(users.get(2)), Option.NORMAL, slotTimes.get(3));
+            matchService.makeMatch(UserDto.from(users.get(3)), Option.NORMAL, slotTimes.get(4));
+            matchService.makeMatch(UserDto.from(users.get(4)), Option.NORMAL, slotTimes.get(4));
+            SlotStatusResponseListDto allMatchStatus = matchFindService.getAllMatchStatus(UserDto.from(users.get(3)),
                 Option.NORMAL);
-        for (List<SlotStatusDto> dtos : slotStatusList.getMatchBoards()) {
-            for (SlotStatusDto dto: dtos) {
-                if (dto.getStartTime().equals(slotTimes.get(0))) {
-                    Assertions.assertThat(dto.getStatus()).isEqualTo(SlotStatus.MYTABLE.getCode());
-                }
-                if (dto.getStartTime().equals(slotTimes.get(1))) {
-                    Assertions.assertThat(dto.getStatus()).isEqualTo(SlotStatus.MYTABLE.getCode());
-                }
-                if (dto.getStartTime().equals(slotTimes.get(2))) {
-                    Assertions.assertThat(dto.getStatus()).isEqualTo(SlotStatus.MYTABLE.getCode());
-                }
-                if (dto.getStartTime().equals(slotTimes.get(3))) {
-                    Assertions.assertThat(dto.getStatus()).isEqualTo(SlotStatus.CLOSE.getCode());
-                }
-            }
-        }
-
-    }
-
-    @DisplayName("슬롯 조회 : 게임 등록 되면 제 3자한테 closed 처리")
-    @Test
-    void getClosedStatusOfExistGame() {
-        matchService.makeMatch(UserDto.from(users.get(1)), Option.NORMAL, slotTimes.get(3));
-        matchService.makeMatch(UserDto.from(users.get(2)), Option.NORMAL, slotTimes.get(3));
-        SlotStatusResponseListDto allMatchStatus = matchFindService.getAllMatchStatus(UserDto.from(users.get(3)),
-                Option.NORMAL);
-        for (List<SlotStatusDto> dtos : allMatchStatus.getMatchBoards()) {
-            for (SlotStatusDto dto: dtos) {
-                if (dto.getStartTime().equals(slotTimes.get(3))) {
-                    Assertions.assertThat(dto.getStatus()).isEqualTo(SlotStatus.CLOSE.getCode());
+            for (List<SlotStatusDto> dtos : allMatchStatus.getMatchBoards()) {
+                for (SlotStatusDto dto: dtos) {
+                    if (dto.getStartTime().equals(slotTimes.get(3))) {
+                        Assertions.assertThat(dto.getStatus()).isEqualTo(SlotStatus.CLOSE.getCode());
+                    }
                 }
             }
         }
     }
 
-    @DisplayName("슬롯 조회 : 게임 등록 되면 제3자가 다른 게임 등록해도 제 3자한테 closed 처리")
-    @Test
-    void getClosedStatusOfExistGame2() {
-        matchService.makeMatch(UserDto.from(users.get(1)), Option.NORMAL, slotTimes.get(3));
-        matchService.makeMatch(UserDto.from(users.get(2)), Option.NORMAL, slotTimes.get(3));
-        matchService.makeMatch(UserDto.from(users.get(3)), Option.NORMAL, slotTimes.get(4));
-        matchService.makeMatch(UserDto.from(users.get(4)), Option.NORMAL, slotTimes.get(4));
-        SlotStatusResponseListDto allMatchStatus = matchFindService.getAllMatchStatus(UserDto.from(users.get(3)),
-                Option.NORMAL);
-        for (List<SlotStatusDto> dtos : allMatchStatus.getMatchBoards()) {
-            for (SlotStatusDto dto: dtos) {
-                if (dto.getStartTime().equals(slotTimes.get(3))) {
-                    Assertions.assertThat(dto.getStatus()).isEqualTo(SlotStatus.CLOSE.getCode());
-                }
+    @Nested
+    @DisplayName("현재 매치 정보 조회 API 테스트")
+    class GetCurrentMatch {
+        @DisplayName("current Match 조회 : user가 등록한 슬롯이 매칭되었을 때")
+        @Test
+        void readCurrentMatchAfterMakingGameEntity() {
+            //게임생성
+            matchService.makeMatch(UserDto.from(users.get(1)), Option.NORMAL, slotTimes.get(3));
+            matchService.makeMatch(UserDto.from(users.get(2)), Option.NORMAL, slotTimes.get(3));
+            UserDto userDto = UserDto.from(users.get(1));
+            MatchStatusResponseListDto currentMatch = matchFindService.getCurrentMatch(userDto);
+            //user의 current match 확인
+            List<MatchStatusDto> match = currentMatch.getMatch();
+            Assertions.assertThat(match.size()).isEqualTo(1);
+            Assertions.assertThat(match.get(0).getMyTeam().get(0)).isEqualTo(users.get(1).getIntraId());
+            Assertions.assertThat(match.get(0).getEnemyTeam().get(0)).isEqualTo(users.get(2).getIntraId());
+            Assertions.assertThat(match.get(0).getStartTime()).isEqualTo(slotTimes.get(3));
+            Assertions.assertThat(match.get(0).getIsMatched()).isEqualTo(true);
+        }
+
+        @DisplayName("current Match 조회 : user가 등록한 슬롯이 매칭되지 않았을 때")
+        @Test
+        void readCurrentMatchBeforeMakingGameEntity() {
+            //유저 슬롯 3개 등록 시도
+            for (int i = 0; i < 3; i++) {
+                System.out.println("slotTimes = " + slotTimes.get(i));
+                matchService.makeMatch(UserDto.from(users.get(1)), Option.NORMAL, slotTimes.get(i));
+            }
+            UserDto userDto = UserDto.from(users.get(1));
+            MatchStatusResponseListDto currentMatch = matchFindService.getCurrentMatch(userDto);
+            List<MatchStatusDto> match = currentMatch.getMatch();
+            //user current match 확인
+            Assertions.assertThat(match.size()).isEqualTo(3);
+            for (int i = 0; i < 3; i++) {
+                System.out.println("match = " + match.get(i).getStartTime());
+                Assertions.assertThat(match.get(i).getMyTeam().size()).isEqualTo(0);
+                Assertions.assertThat(match.get(i).getEnemyTeam().size()).isEqualTo(0);
+                Assertions.assertThat(match.get(i).getStartTime()).isEqualTo(slotTimes.get(i));
+                Assertions.assertThat(match.get(i).getIsMatched()).isEqualTo(false);
             }
         }
-    }
 
-    @DisplayName("current Match 조회 : user가 등록한 슬롯이 매칭되었을 때")
-    @Test
-    void readCurrentMatchAfterMakingGameEntity() {
-        //게임생성
-        matchService.makeMatch(UserDto.from(users.get(1)), Option.NORMAL, slotTimes.get(3));
-        matchService.makeMatch(UserDto.from(users.get(2)), Option.NORMAL, slotTimes.get(3));
-        UserDto userDto = UserDto.from(users.get(1));
-        MatchStatusResponseListDto currentMatch = matchFindService.getCurrentMatch(userDto);
-        //user의 current match 확인
-        List<MatchStatusDto> match = currentMatch.getMatch();
-        Assertions.assertThat(match.size()).isEqualTo(1);
-        Assertions.assertThat(match.get(0).getMyTeam().get(0)).isEqualTo(users.get(1).getIntraId());
-        Assertions.assertThat(match.get(0).getEnemyTeam().get(0)).isEqualTo(users.get(2).getIntraId());
-        Assertions.assertThat(match.get(0).getStartTime()).isEqualTo(slotTimes.get(3));
-        Assertions.assertThat(match.get(0).getIsMatched()).isEqualTo(true);
-    }
-
-    @DisplayName("current Match 조회 : user가 등록한 슬롯이 매칭되지 않았을 때")
-    @Test
-    void readCurrentMatchBeforeMakingGameEntity() {
-        //유저 슬롯 3개 등록 시도
-        for (int i = 0; i < 3; i++) {
-            System.out.println("slotTimes = " + slotTimes.get(i));
-            matchService.makeMatch(UserDto.from(users.get(1)), Option.NORMAL, slotTimes.get(i));
-        }
-        UserDto userDto = UserDto.from(users.get(1));
-        MatchStatusResponseListDto currentMatch = matchFindService.getCurrentMatch(userDto);
-        List<MatchStatusDto> match = currentMatch.getMatch();
-        //user current match 확인
-        Assertions.assertThat(match.size()).isEqualTo(3);
-        for (int i = 0; i < 3; i++) {
-            System.out.println("match = " + match.get(i).getStartTime());
-            Assertions.assertThat(match.get(i).getMyTeam().size()).isEqualTo(0);
-            Assertions.assertThat(match.get(i).getEnemyTeam().size()).isEqualTo(0);
-            Assertions.assertThat(match.get(i).getStartTime()).isEqualTo(slotTimes.get(i));
-            Assertions.assertThat(match.get(i).getIsMatched()).isEqualTo(false);
-        }
-    }
-
-    @DisplayName("Guest User slot 조회")
-    @Test
-    void readAllSlotsAndCurrentMatchForGuset() {
-        User guestUser = matchTestSetting.createGuestUser();
-        MatchStatusResponseListDto currentMatch = matchFindService.getCurrentMatch(UserDto.from(guestUser));
-        SlotStatusResponseListDto allMatchStatus = matchFindService.getAllMatchStatus(UserDto.from(guestUser),
+        @DisplayName("Guest User slot 조회")
+        @Test
+        void readAllSlotsAndCurrentMatchForGuset() {
+            User guestUser = matchTestSetting.createGuestUser();
+            MatchStatusResponseListDto currentMatch = matchFindService.getCurrentMatch(UserDto.from(guestUser));
+            SlotStatusResponseListDto allMatchStatus = matchFindService.getAllMatchStatus(UserDto.from(guestUser),
                 Option.NORMAL);
-        Assertions.assertThat(currentMatch.getMatch().size()).isEqualTo(0);
-        System.out.println("allMatchStatus = " + allMatchStatus);
+            Assertions.assertThat(currentMatch.getMatch().size()).isEqualTo(0);
+            System.out.println("allMatchStatus = " + allMatchStatus);
+        }
+
     }
 }

--- a/src/test/java/com/gg/server/domain/match/service/MatchTestUtils.java
+++ b/src/test/java/com/gg/server/domain/match/service/MatchTestUtils.java
@@ -94,11 +94,6 @@ public class MatchTestUtils {
     }
 
     public SlotManagement makeTestSlotManagement(Integer interval) {
-        SlotManagement slotManagement1 = slotManagementRepository.findCurrent(LocalDateTime.now())
-                .orElseThrow(SlotNotFoundException::new);
-        if (slotManagement1 !=  null) {
-            return slotManagement1;
-        }
         SlotManagement slotManagement = SlotManagement.builder()
                 .futureSlotTime(10)
                 .pastSlotTime(0)

--- a/src/test/java/com/gg/server/domain/match/service/MatchTestUtils.java
+++ b/src/test/java/com/gg/server/domain/match/service/MatchTestUtils.java
@@ -78,6 +78,10 @@ public class MatchTestUtils {
         return sampleSlots;
     }
     public Season makeTestSeason(Integer pppGap) {
+        Optional<Season> currentSeason = seasonRepository.findCurrentSeason(LocalDateTime.now());
+        if (currentSeason.isPresent()) {
+            return currentSeason.get();
+        }
         Season season = new Season(
                 "test",
                 LocalDateTime.now().minusDays(1),

--- a/src/test/java/com/gg/server/domain/match/service/MatchTestUtils.java
+++ b/src/test/java/com/gg/server/domain/match/service/MatchTestUtils.java
@@ -78,10 +78,6 @@ public class MatchTestUtils {
         return sampleSlots;
     }
     public Season makeTestSeason(Integer pppGap) {
-        Optional<Season> currentSeason = seasonRepository.findCurrentSeason(LocalDateTime.now());
-        if (currentSeason.isPresent()) {
-            return currentSeason.get();
-        }
         Season season = new Season(
                 "test",
                 LocalDateTime.now().minusDays(1),


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - `TOURNAMENT` 추가로 인한 match, slot 관련 로직 수정
 
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
### 슬롯 block 시키는 로직 추가
 1. 게임 매칭 요청했을 때 토너먼트 확인 후 블락 
    - `POST /pingpong/match?type={type}`
    - `MatchService`의   `makeMatch()` -> `checkValid()`에서 토너먼트 시간과 겹칠 경우 exception throw
 2. 슬롯 정보 가져올 때 토너먼트 확인 후 블락
    - `GET /pingpong/match/time/scope?mode={mode}`
    - `MatchFindServie`의 `getAllMatchStatus()`에서 토너먼트에 대한 슬롯 block 로직 추가
 ### 테스트
  - `MatchServiceTest` 기존 코드  `@Nested`로 리팩토링 
  - 테스트코드는 기존 match 레거시 테스트코드에 맞게 작성했습니다.
  - 현재 게임 매칭 요청에 대한 테스트코드는 레디스 관련 문제로 동작하지 않습니다.
  - 동일한 테스트 환경에서 동일한 데이터로 테스트하기 위해 `MatchTestUtils`의 `makeTestSeason()`에서 저장되어있는 season을 확인하는 로직을 삭제했습니다.
  ### 기타
   - `TournamentStatus`에 `CUSTOM` 추가
   - `Match`의 `Option`에 `TOURNAMENT` 추가
   - 삭제했던 게임 전체 / 시즌별 조회하기 API `GET /pingpong/admin/games?page={page}`추가
   - `TournamentConflictException`에 default constructor 추가
   - `Tournament` Entity에 `@Builder` 중복 사용 제거

  ## 💡Issue 번호 <!-- issue number을 link 시켜주세요 (ex. "- close #4242") -->
 - close #339 
 - close #347 