### PR TITLE
✨ [Feature] 토너먼트 Id에 해당하는 게임 전체 조회 api 추가

### DIFF
--- a/src/main/java/com/gg/server/domain/game/data/GameRepository.java
+++ b/src/main/java/com/gg/server/domain/game/data/GameRepository.java
@@ -51,6 +51,13 @@ public interface GameRepository extends JpaRepository<Game, Long>, GameRepositor
             "where t1.gameId IN (:games) and t1.teamId <t2.teamId and t1.gameId=t2.gameId order by t1.startTime desc;", nativeQuery = true)
     List<GameTeamUser> findTeamsByGameIsInAndNormalMode(@Param("games") List<Long> games);
 
+    @Query(value = "select t1.gameId, t1.startTime, t1.status, t1.mode, " +
+            "t1.intraId t1IntraId, t1.teamId t1TeamId, t1.win t1IsWin, t1.score t1Score, t1.image t1Image, t1.total_exp t1Exp, t1.wins t1Wins, t1.losses t1Losses, " +
+            "t2.win t2IsWin, t1.teamId t2TeamId, t2.score t2Score, t2.intraId t2IntraId, t2.wins t2Wins, t2.losses t2Losses, t2.image t2Image, t2.total_exp t2Exp " +
+            "from v_rank_game_detail t1, v_rank_game_detail t2 " +
+            "where t1.gameId = (:gameId) and t1.teamId <t2.teamId and t1.gameId=t2.gameId order by t1.startTime desc;", nativeQuery = true)
+    GameTeamUser findTeamsByGameId(@Param("gameId") Long gameId);
+
     @Query(value = "SELECT teamId, gameId, score, startTime, status, mode, userId, intraId, image, total_exp exp" +
             " FROM v_teamuser where gameId = :gameId", nativeQuery = true)
     List<GameTeamUserInfo> findTeamGameUser(@Param("gameId") Long gameId);

--- a/src/main/java/com/gg/server/domain/game/dto/GameResultResDto.java
+++ b/src/main/java/com/gg/server/domain/game/dto/GameResultResDto.java
@@ -41,6 +41,14 @@ public class GameResultResDto {
                     new TeamUserInfoDto(game.getT1IntraId(), game.getT1Image(), game.getT1Exp(), game.getT1Wins(), game.getT1Losses())), game.getT1IsWin(), game.getT1Score());
             team2 = new TeamUserListDto(Arrays.asList(
                     new TeamUserInfoDto(game.getT2IntraId(), game.getT2Image(), game.getT2Exp(), game.getT2Wins(), game.getT2Losses())), game.getT2IsWin(), game.getT2Score());
+        } else if (mode == Mode.TOURNAMENT) {
+            team1 = new TeamUserListDto(
+                    game.getT1TeamId(),
+                    Arrays.asList(new TeamUserInfoDto(game.getT1IntraId(), game.getT1Image(), game.getT1Exp(), game.getT1Wins(), game.getT1Losses())),
+                    game.getT1IsWin(), game.getT1Score());
+            team2 = new TeamUserListDto(game.getT2TeamId(),
+                    Arrays.asList(new TeamUserInfoDto(game.getT2IntraId(), game.getT2Image(), game.getT2Exp(), game.getT2Wins(), game.getT2Losses())),
+                    game.getT2IsWin(), game.getT2Score());
         }
     }
 

--- a/src/main/java/com/gg/server/domain/team/dto/TeamUserListDto.java
+++ b/src/main/java/com/gg/server/domain/team/dto/TeamUserListDto.java
@@ -10,6 +10,8 @@ import java.util.List;
 @Getter
 @NoArgsConstructor
 public class TeamUserListDto {
+    Long teamId;
+
     List<TeamUserInfoDto> players;
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -21,6 +23,13 @@ public class TeamUserListDto {
         this.isWin = isWin;
         this.score = score;
         this.players = players;
+    }
+
+    public TeamUserListDto(Long teamId, List<TeamUserInfoDto> players, Boolean isWin, Integer score) {
+        this.teamId = teamId;
+        this.players = players;
+        this.isWin = isWin;
+        this.score = score;
     }
 
     @Override

--- a/src/main/java/com/gg/server/domain/tournament/controller/TournamentController.java
+++ b/src/main/java/com/gg/server/domain/tournament/controller/TournamentController.java
@@ -29,9 +29,10 @@ public class TournamentController {
      * @return 토너먼트 리스트
      */
     @GetMapping
-    public TournamentListResponseDto getAllTournamentList(@ModelAttribute @Valid TournamentFilterRequestDto tournamentFilterRequestDto){
+    public ResponseEntity<TournamentListResponseDto> getAllTournamentList(@ModelAttribute @Valid TournamentFilterRequestDto tournamentFilterRequestDto){
         Pageable pageRequest = PageRequest.of(tournamentFilterRequestDto.getPage() - 1, tournamentFilterRequestDto.getSize(), Sort.by("startTime").descending());
-        return tournamentService.getAllTournamentList(pageRequest, tournamentFilterRequestDto.getType(), tournamentFilterRequestDto.getStatus());
+        return ResponseEntity.ok().
+                body(tournamentService.getAllTournamentList(pageRequest, tournamentFilterRequestDto.getType(), tournamentFilterRequestDto.getStatus()));
     }
 
     /**

--- a/src/main/java/com/gg/server/domain/tournament/controller/TournamentController.java
+++ b/src/main/java/com/gg/server/domain/tournament/controller/TournamentController.java
@@ -1,9 +1,6 @@
 package com.gg.server.domain.tournament.controller;
 
-import com.gg.server.domain.tournament.dto.TournamentUserRegistrationResponseDto;
-import com.gg.server.domain.tournament.dto.TournamentFilterRequestDto;
-import com.gg.server.domain.tournament.dto.TournamentListResponseDto;
-import com.gg.server.domain.tournament.dto.TournamentResponseDto;
+import com.gg.server.domain.tournament.dto.*;
 import com.gg.server.domain.tournament.service.TournamentService;
 import com.gg.server.domain.user.dto.UserDto;
 import com.gg.server.global.utils.argumentresolver.Login;
@@ -15,12 +12,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
 
 import javax.validation.Valid;
 
@@ -64,5 +55,15 @@ public class TournamentController {
     public ResponseEntity<TournamentResponseDto> getTournnament(@PathVariable @Positive Long tournamentId) {
         TournamentResponseDto tournamentResponseDto = tournamentService.getTournament(tournamentId);
             return ResponseEntity.status(HttpStatus.OK).body(tournamentResponseDto);
+    }
+
+    /**
+     * 토너먼트 게임 리스트 조회
+     * @param tournamentId 토너먼트 id
+     * @return 토너먼트 게임 리스트
+     */
+    @GetMapping("/{tournamentId}/games")
+    public ResponseEntity<TournamentGameListResponseDto> getTournamentGames(@PathVariable @Positive Long tournamentId){
+        return ResponseEntity.ok().body(tournamentService.getTournamentGames(tournamentId));
     }
 }

--- a/src/main/java/com/gg/server/domain/tournament/controller/TournamentController.java
+++ b/src/main/java/com/gg/server/domain/tournament/controller/TournamentController.java
@@ -10,6 +10,7 @@ import org.checkerframework.checker.index.qual.Positive;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -28,9 +29,8 @@ public class TournamentController {
      * @return 토너먼트 리스트
      */
     @GetMapping
-    TournamentListResponseDto getAllTournamentList(@ModelAttribute @Valid TournamentFilterRequestDto tournamentFilterRequestDto){
-        Pageable pageRequest = PageRequest.of(tournamentFilterRequestDto.getPage() - 1, tournamentFilterRequestDto.getSize());
-
+    public TournamentListResponseDto getAllTournamentList(@ModelAttribute @Valid TournamentFilterRequestDto tournamentFilterRequestDto){
+        Pageable pageRequest = PageRequest.of(tournamentFilterRequestDto.getPage() - 1, tournamentFilterRequestDto.getSize(), Sort.by("startTime").descending());
         return tournamentService.getAllTournamentList(pageRequest, tournamentFilterRequestDto.getType(), tournamentFilterRequestDto.getStatus());
     }
 

--- a/src/main/java/com/gg/server/domain/tournament/data/TournamentGameRepository.java
+++ b/src/main/java/com/gg/server/domain/tournament/data/TournamentGameRepository.java
@@ -1,9 +1,12 @@
 package com.gg.server.domain.tournament.data;
 
-import java.util.List;
+import com.gg.server.domain.tournament.type.TournamentRound;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
 
 public interface TournamentGameRepository extends JpaRepository<TournamentGame, Long> {
     List<TournamentGame> findAllByTournamentId(Long tournamentId);
 
+    TournamentGame findByTournamentIdAndTournamentRound(Long id, TournamentRound tournamentRound);
 }

--- a/src/main/java/com/gg/server/domain/tournament/dto/TournamentGameListResponseDto.java
+++ b/src/main/java/com/gg/server/domain/tournament/dto/TournamentGameListResponseDto.java
@@ -1,0 +1,27 @@
+package com.gg.server.domain.tournament.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TournamentGameListResponseDto {
+    private Long tournamentId;
+    private List<TournamentGameResDto> games;
+
+    public TournamentGameListResponseDto(Long tournamentId, List<TournamentGameResDto> games) {
+        this.tournamentId = tournamentId;
+        this.games = games;
+    }
+
+    @Override
+    public String toString() {
+        return "TournamentGameListResponseDto{" +
+                "tournamentId=" + tournamentId +
+                ", games=" + games.toString() +
+                '}';
+    }
+}

--- a/src/main/java/com/gg/server/domain/tournament/dto/TournamentGameResDto.java
+++ b/src/main/java/com/gg/server/domain/tournament/dto/TournamentGameResDto.java
@@ -1,0 +1,37 @@
+package com.gg.server.domain.tournament.dto;
+
+import com.gg.server.domain.game.data.Game;
+import com.gg.server.domain.game.dto.GameResultResDto;
+import com.gg.server.domain.game.dto.GameTeamUser;
+import com.gg.server.domain.tournament.data.TournamentGame;
+import com.gg.server.domain.tournament.type.TournamentRound;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TournamentGameResDto {
+
+    private Long tournamentGameId;
+    private Long nextTournamentGameId;
+    private String tournamentRound;
+    private GameResultResDto game;
+
+    public TournamentGameResDto(TournamentGame tournamentGame, GameTeamUser game, TournamentRound tournamentRound, TournamentGame nextTournamentGame){
+        this.tournamentGameId = tournamentGame.getId();
+        this.game = game == null? null : new GameResultResDto(game);
+        this.tournamentRound = tournamentRound.name();
+        this.nextTournamentGameId = nextTournamentGame == null? null : nextTournamentGame.getId();
+    }
+
+    @Override
+    public String toString() {
+        return "TournamentGameResDto{" +
+                "tournamentGameId=" + tournamentGameId +
+                ", NextTournamentGameId=" + nextTournamentGameId +
+                ", tournamentRound='" + tournamentRound + '\'' +
+                ", gameId=" + game.getGameId() +
+                '}';
+    }
+}

--- a/src/main/java/com/gg/server/domain/tournament/service/TournamentService.java
+++ b/src/main/java/com/gg/server/domain/tournament/service/TournamentService.java
@@ -142,7 +142,7 @@ public class TournamentService {
         List<TournamentGame> tournamentGames = tournamentGameRepository.findAllByTournamentId(tournamentId);
         List<TournamentGameResDto> tournamentGameResDtoList = new ArrayList<>();
         for (TournamentGame tournamentGame : tournamentGames) {
-            TournamentGame nextTournamentGame = findNextTournamentGame(tournamentId, tournamentGame);
+            TournamentGame nextTournamentGame = findNextTournamentGame(tournamentGames, tournamentGame);
             GameTeamUser gameTeamUser = null;
             if (tournamentGame.getGame() != null) {
                 gameTeamUser = gameRepository.findTeamsByGameId(tournamentGame.getGame().getId());
@@ -154,12 +154,15 @@ public class TournamentService {
 
     /**
      * 다음 토너먼트 게임 조회
-     * @param tournamentId 토너먼트 id
+     * @param tournamentGames tournamentGames 토너먼트 게임 리스트
      * @param tournamentGame 현재 토너먼트 게임
      * @return 다음 토너먼트 게임
      */
-    private TournamentGame findNextTournamentGame(Long tournamentId, TournamentGame tournamentGame) {
+    private TournamentGame findNextTournamentGame(List<TournamentGame> tournamentGames, TournamentGame tournamentGame) {
         TournamentRound tournamentRound = tournamentGame.getTournamentRound();
-        return tournamentGameRepository.findByTournamentIdAndTournamentRound(tournamentId, tournamentRound.getNextRound());
+        return tournamentGames.stream()
+            .filter(tournamentGame1 -> tournamentGame1.getTournamentRound().equals(tournamentRound.getNextRound()))
+            .findFirst()
+            .orElse(null);
     }
 }

--- a/src/main/java/com/gg/server/domain/tournament/type/TournamentRound.java
+++ b/src/main/java/com/gg/server/domain/tournament/type/TournamentRound.java
@@ -11,22 +11,23 @@ public enum TournamentRound {
     // the final -> 결승
     // semi final  -> 4강
     // quarter final -> 8강
-    THE_FINAL("1"),
-    SEMI_FINAL_1("4-1"),
-    SEMI_FINAL_2("4-2"),
-    QUARTER_FINAL_1("8-1"),
-    QUARTER_FINAL_2("8-2"),
-    QUARTER_FINAL_3("8-3"),
-    QUARTER_FINAL_4("8-4");
+    THE_FINAL("1", null),
+    SEMI_FINAL_1("4-1", THE_FINAL),
+    SEMI_FINAL_2("4-2", THE_FINAL),
+    QUARTER_FINAL_1("8-1", SEMI_FINAL_1),
+    QUARTER_FINAL_2("8-2", SEMI_FINAL_1),
+    QUARTER_FINAL_3("8-3", SEMI_FINAL_2),
+    QUARTER_FINAL_4("8-4", SEMI_FINAL_2);
 
     private final String round;
+    private final TournamentRound nextRound;
 
     @JsonCreator
-    public static TournamentRound getEnumFromValue(String value) {
+    public static TournamentRound getEnumFromValue(String round) {
         for (TournamentRound e : values()) {
-            if (e.name().equals(value)) {
+            if (e.name().equals(round)) {
                 return e;
-            } else if (e.round.toUpperCase(Locale.ROOT).equals(value.toUpperCase(Locale.ROOT))) {
+            } else if (e.round.toUpperCase(Locale.ROOT).equals(round.toUpperCase(Locale.ROOT))) {
                 return e;
             }
         }

--- a/src/test/java/com/gg/server/domain/tournament/controller/TournamentFindControllerTest.java
+++ b/src/test/java/com/gg/server/domain/tournament/controller/TournamentFindControllerTest.java
@@ -76,7 +76,7 @@ public class TournamentFindControllerTest {
         @DisplayName("전체_조회")
         public void getTournamentList() throws Exception {
             // given
-            int page = 2;
+            int page = 1;
             int size = 20;
             String url = "/pingpong/tournaments/?page=" + page + "&size=" + size;
 
@@ -100,6 +100,8 @@ public class TournamentFindControllerTest {
                     assertThat(tournamentInfoList.get(i).getWinnerImageUrl()).isEqualTo(tournamentResponseDto.getWinnerImageUrl());
                     assertThat(tournamentInfoList.get(i).getPlayer_cnt()).isEqualTo(tournamentResponseDto.getPlayer_cnt());
                 }
+                if (i > 0)
+                    assertThat(tournamentInfoList.get(i).getStartTime()).isBefore(tournamentInfoList.get(i - 1).getEndTime());
             }
         }
 

--- a/src/test/java/com/gg/server/domain/tournament/controller/TournamentGameControllerTest.java
+++ b/src/test/java/com/gg/server/domain/tournament/controller/TournamentGameControllerTest.java
@@ -1,0 +1,104 @@
+package com.gg.server.domain.tournament.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gg.server.domain.game.data.Game;
+import com.gg.server.domain.game.type.Mode;
+import com.gg.server.domain.season.data.Season;
+import com.gg.server.domain.tournament.data.Tournament;
+import com.gg.server.domain.tournament.data.TournamentGame;
+import com.gg.server.domain.tournament.dto.TournamentGameListResponseDto;
+import com.gg.server.domain.tournament.dto.TournamentGameResDto;
+import com.gg.server.domain.tournament.type.TournamentRound;
+import com.gg.server.domain.tournament.type.TournamentStatus;
+import com.gg.server.domain.user.controller.dto.GameInfoDto;
+import com.gg.server.domain.user.data.User;
+import com.gg.server.domain.user.type.RacketType;
+import com.gg.server.domain.user.type.RoleType;
+import com.gg.server.domain.user.type.SnsType;
+import com.gg.server.global.security.jwt.utils.AuthTokenProvider;
+import com.gg.server.utils.TestDataUtils;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Objects;
+import java.util.Random;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@RequiredArgsConstructor
+@Slf4j
+public class TournamentGameControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+    @Autowired
+    TestDataUtils testDataUtils;
+    @Autowired
+    ObjectMapper objectMapper;
+    @Autowired
+    AuthTokenProvider tokenProvider;
+
+    String accessToken;
+    Tournament testTournament;
+    String tournamentUrl = "/pingpong/tournaments/";
+
+    @BeforeEach
+    void beforeEach() {
+        User tester = testDataUtils.createNewUser("findControllerTester", "findControllerTester", RacketType.DUAL, SnsType.SLACK, RoleType.ADMIN);
+        accessToken = tokenProvider.createToken(tester.getId());
+
+        Season season = testDataUtils.createSeason();
+        testTournament = testDataUtils.createTournament("Test Tournament", LocalDateTime.now(), LocalDateTime.now().plusHours(2), TournamentStatus.LIVE);
+        for (TournamentRound round : TournamentRound.values()) {
+            User gamer = testDataUtils.createNewUser("gamer" + Math.round(Math.random() * 100));
+            GameInfoDto gameInfoDto = testDataUtils.createGame(gamer, LocalDateTime.now().minusDays(10), LocalDateTime.now().minusDays(10).plusMinutes(20),season, Mode.TOURNAMENT);
+            TournamentGame tournamentGame = testDataUtils.createTournamentGame(testTournament, round, gameInfoDto);
+        }
+    }
+
+    @Nested
+    @DisplayName("토너먼트_게임_리스트_조회")
+    class findTournamentGameTest {
+
+        @Test
+        @DisplayName("[Get] pingpong/tournaments/{tournamentId}/games")
+        public void getTournamentGames() throws Exception {
+
+            // given
+            String url = tournamentUrl + testTournament.getId() + "/games";
+
+            // when
+            String contentAsString = mockMvc.perform(get(url).header("Authorization", "Bearer " + accessToken))
+                    .andExpect(status().isOk())
+                    .andReturn().getResponse().getContentAsString();
+            TournamentGameListResponseDto resp = objectMapper.readValue(contentAsString, TournamentGameListResponseDto.class);
+
+            // then
+            assertThat(resp.getTournamentId()).isEqualTo(testTournament.getId());
+            assertThat(resp.getGames().size()).isEqualTo(TournamentRound.values().length);
+            for (TournamentGameResDto tournamentGameResDto : resp.getGames()) {
+                assertThat(tournamentGameResDto.getTournamentGameId()).isNotNull();
+                assertThat(tournamentGameResDto.getTournamentRound()).isNotNull();
+                if (!Objects.equals(tournamentGameResDto.getTournamentRound(), TournamentRound.THE_FINAL.name())) {
+                    assertThat(tournamentGameResDto.getNextTournamentGameId()).isNotNull();
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 토너먼트 Id에 해당하는 게임 전체 조회 api 추가
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
 ### 토너먼트 게임 조회 controller, service 추가
  1. 토너먼트에서 이루어진 게임들(`TournamentGame`)을 찾아서 `TournamentGameListResponseDto` 에 넣어 반환
  2. TournamentGameListResponseDto -> 토너먼트, 게임, 팀, 유저 에 대한 정보를 가지고있다.
 ### TeamId를 가지고있는 Dto 추가
 1. `TeamUserListDto`에 teamId를 가지는 생성자 추가
 2. `GameRepository`에 teamId 도 포함하여 return 해주는 메소드 추가
 3.  `GameResultResDto` 에도 teamId추가
### NextTournamentId 넣어주는 로직  추가
1. `TournamentRound` Enum 에 NextRound 데이터 추가
2. `TournamentService` 에서 `findNextTournamentGame` 로 nextTournaemtGame 찾는 메소드 추가
### Tournament 전체조회 정렬 순서 변경
1. 기존 토너먼트 id순으로 오름차순 정렬 ->  startTime 기준으로 내림차순 정렬로 수정
2. 이에 따른 테스트 코드도 수정
 ## 💡Issue 번호 <!-- issue number을 link 시켜주세요 (ex. "- close #4242") -->
 -  close #307 