### PR TITLE
✨ [Feature] 토너먼트 첫 경기 매칭하는 Scheduler 생성

### DIFF
--- a/src/main/java/com/gg/server/admin/tournament/service/TournamentAdminService.java
+++ b/src/main/java/com/gg/server/admin/tournament/service/TournamentAdminService.java
@@ -37,13 +37,6 @@ public class TournamentAdminService {
     private final TournamentUserRepository tournamentUserRepository;
     private final UserRepository userRepository;
 
-    // 토너먼트 참가자 수 => 현재는 8강 고정
-    private static final long ALLOWED_JOINED_NUMBER = 8;
-    // 토너먼트 최소 시작 날짜 (n일 후)
-    private static final long ALLOWED_MINIMAL_START_DAYS = 2;
-    // 토너먼트 최소 진행 시간 (n시간)
-    private static final long MINIMUM_TOURNAMENT_DURATION = 2;
-
     /***
      * 토너먼트 생성 Method
      * @param tournamentAdminCreateRequestDto 토너먼트 생성에 필요한 데이터
@@ -135,7 +128,7 @@ public class TournamentAdminService {
             .findAny().ifPresent(a->{throw new TournamentConflictException("user is already participant", ErrorCode.TOURNAMENT_CONFLICT);});
 
         TournamentUser tournamentUser = new TournamentUser(targetUser, targetTournament,
-            tournamentList.size() < ALLOWED_JOINED_NUMBER, LocalDateTime.now());
+            tournamentList.size() < Tournament.ALLOWED_JOINED_NUMBER, LocalDateTime.now());
         targetTournament.addTournamentUser(tournamentUser);
         tournamentUserRepository.save(tournamentUser);
 
@@ -165,8 +158,8 @@ public class TournamentAdminService {
         TournamentUser targetTournamentUser = tournamentUserList.stream().filter(tu->tu.getUser().getId().equals(targetUser.getId()))
             .findAny().orElseThrow(UserNotFoundException::new);
         targetTournament.deleteTournamentUser(targetTournamentUser);
-        if (targetTournamentUser.getIsJoined() && tournamentUserList.size()>=ALLOWED_JOINED_NUMBER) {
-            tournamentUserList.get(Long.valueOf(ALLOWED_JOINED_NUMBER).intValue()-1).updateIsJoined(true);
+        if (targetTournamentUser.getIsJoined() && tournamentUserList.size() >= Tournament.ALLOWED_JOINED_NUMBER) {
+            tournamentUserList.get(Long.valueOf(Tournament.ALLOWED_JOINED_NUMBER).intValue()-1).updateIsJoined(true);
         }
         tournamentUserRepository.delete(targetTournamentUser);
     }
@@ -197,8 +190,8 @@ public class TournamentAdminService {
      */
     private void checkValidTournamentTime(LocalDateTime startTime, LocalDateTime endTime) {
         if (startTime.isAfter(endTime) || startTime.isEqual(endTime) ||
-                startTime.isBefore(LocalDateTime.now().plusDays(ALLOWED_MINIMAL_START_DAYS)) ||
-                startTime.plusHours(MINIMUM_TOURNAMENT_DURATION).isAfter(endTime)) {
+                startTime.isBefore(LocalDateTime.now().plusDays(Tournament.ALLOWED_MINIMAL_START_DAYS)) ||
+                startTime.plusHours(Tournament.MINIMUM_TOURNAMENT_DURATION).isAfter(endTime)) {
             throw new InvalidParameterException("invalid tournament time", ErrorCode.VALID_FAILED);
         }
     }

--- a/src/main/java/com/gg/server/admin/tournament/service/TournamentAdminService.java
+++ b/src/main/java/com/gg/server/admin/tournament/service/TournamentAdminService.java
@@ -159,7 +159,7 @@ public class TournamentAdminService {
             .findAny().orElseThrow(UserNotFoundException::new);
         targetTournament.deleteTournamentUser(targetTournamentUser);
         if (targetTournamentUser.getIsJoined() && tournamentUserList.size() >= Tournament.ALLOWED_JOINED_NUMBER) {
-            tournamentUserList.get(Long.valueOf(Tournament.ALLOWED_JOINED_NUMBER).intValue()-1).updateIsJoined(true);
+            tournamentUserList.get(Tournament.ALLOWED_JOINED_NUMBER - 1).updateIsJoined(true);
         }
         tournamentUserRepository.delete(targetTournamentUser);
     }

--- a/src/main/java/com/gg/server/domain/game/data/Game.java
+++ b/src/main/java/com/gg/server/domain/game/data/Game.java
@@ -11,6 +11,7 @@ import lombok.*;
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 @NoArgsConstructor

--- a/src/main/java/com/gg/server/domain/match/service/GameUpdateService.java
+++ b/src/main/java/com/gg/server/domain/match/service/GameUpdateService.java
@@ -33,6 +33,12 @@ public class GameUpdateService {
     private final NotiService notiService;
     private final SnsNotiService snsNotiService;
 
+    /**
+     * 게임 생성 메서드
+     * 1) 게임 취소했을 경우, 2) 게임 매칭됐을 경우, 3) 토너먼트 게임 생성
+     * @param addDto 게임 생성에 필요한 정보
+     * @param recoveredUserId 게임 취소 당한 유저의 id, -1이면 무의미함
+     */
     public void make(GameAddDto addDto, Long recoveredUserId) {
         SlotManagement slotManagement = slotManagementRepository.findCurrent(LocalDateTime.now())
                 .orElseThrow(SlotNotFoundException::new);

--- a/src/main/java/com/gg/server/domain/team/data/Team.java
+++ b/src/main/java/com/gg/server/domain/team/data/Team.java
@@ -6,6 +6,7 @@ import lombok.*;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
+import java.util.ArrayList;
 import java.util.List;
 
 @NoArgsConstructor

--- a/src/main/java/com/gg/server/domain/tournament/data/Tournament.java
+++ b/src/main/java/com/gg/server/domain/tournament/data/Tournament.java
@@ -20,11 +20,11 @@ import lombok.*;
 @ToString
 public class Tournament extends BaseTimeEntity {
     // 토너먼트 참가자 수 => 현재는 8강 고정
-    public static final long ALLOWED_JOINED_NUMBER = 8;
+    public static final int ALLOWED_JOINED_NUMBER = 8;
     // 토너먼트 최소 시작 날짜 (n일 후)
-    public static final long ALLOWED_MINIMAL_START_DAYS = 2;
+    public static final int ALLOWED_MINIMAL_START_DAYS = 2;
     // 토너먼트 최소 진행 시간 (n시간)
-    public static final long MINIMUM_TOURNAMENT_DURATION = 2;
+    public static final int MINIMUM_TOURNAMENT_DURATION = 2;
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/com/gg/server/domain/tournament/data/Tournament.java
+++ b/src/main/java/com/gg/server/domain/tournament/data/Tournament.java
@@ -19,6 +19,13 @@ import lombok.*;
 @Entity
 @ToString
 public class Tournament extends BaseTimeEntity {
+    // 토너먼트 참가자 수 => 현재는 8강 고정
+    public static final long ALLOWED_JOINED_NUMBER = 8;
+    // 토너먼트 최소 시작 날짜 (n일 후)
+    public static final long ALLOWED_MINIMAL_START_DAYS = 2;
+    // 토너먼트 최소 진행 시간 (n시간)
+    public static final long MINIMUM_TOURNAMENT_DURATION = 2;
+
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
@@ -91,7 +98,11 @@ public class Tournament extends BaseTimeEntity {
         this.tournamentUsers.remove(tournamentUser);
     }
 
-    public void update_winner(User winner) {
+    public void updateWinner(User winner) {
         this.winner = winner;
+    }
+
+    public void updateStatus(TournamentStatus status) {
+        this.status = status;
     }
 }

--- a/src/main/java/com/gg/server/domain/tournament/data/TournamentGame.java
+++ b/src/main/java/com/gg/server/domain/tournament/data/TournamentGame.java
@@ -6,10 +6,8 @@ import com.gg.server.global.utils.BaseTimeEntity;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+
+import lombok.*;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
@@ -41,9 +39,18 @@ public class TournamentGame extends BaseTimeEntity {
      * @param tournament
      * @param tournamentRound
      */
+    @Builder
     public TournamentGame(Game game, Tournament tournament, TournamentRound tournamentRound) {
         this.game = game;
         this.tournament = tournament;
         this.tournamentRound = tournamentRound;
+    }
+
+    /**
+     * TournamentGame의 게임 정보를 업데이트한다.
+     * @param game
+     */
+    public void updateGame(Game game) {
+        this.game = game;
     }
 }

--- a/src/main/java/com/gg/server/domain/tournament/data/TournamentRepository.java
+++ b/src/main/java/com/gg/server/domain/tournament/data/TournamentRepository.java
@@ -9,7 +9,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import javax.validation.constraints.NotNull;
-import java.util.List;
 
 public interface TournamentRepository extends JpaRepository<Tournament, Long> {
     List<Tournament> findAllByStatusIsNot(TournamentStatus status);
@@ -18,6 +17,7 @@ public interface TournamentRepository extends JpaRepository<Tournament, Long> {
     Page<Tournament> findAllByTypeAndStatus(@NotNull TournamentType type, @NotNull TournamentStatus status, Pageable pageable);
 
     Page<Tournament> findAllByStatus(@NotNull TournamentStatus status, Pageable pageable);
+    List<Tournament> findAllByStatus(@NotNull TournamentStatus status);
 
     Page<Tournament> findAllByType(@NotNull TournamentType type, Pageable pageable);
 

--- a/src/main/java/com/gg/server/domain/tournament/data/TournamentUser.java
+++ b/src/main/java/com/gg/server/domain/tournament/data/TournamentUser.java
@@ -12,10 +12,8 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.validation.constraints.NotNull;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+
+import lombok.*;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
@@ -43,6 +41,7 @@ public class TournamentUser extends BaseTimeEntity {
     @Column(name = "register_time")
     private LocalDateTime registerTime;
 
+    @Builder
     public TournamentUser(User user, Tournament tournament, boolean isJoined, LocalDateTime registerTime) {
         this.user = user;
         this.tournament = tournament;

--- a/src/main/java/com/gg/server/domain/tournament/service/TournamentService.java
+++ b/src/main/java/com/gg/server/domain/tournament/service/TournamentService.java
@@ -169,17 +169,17 @@ public class TournamentService {
     @Transactional
     public void startTournament() {
         LocalDate date = LocalDate.now();
-        Optional<Tournament> tournament = findImminentTournament(date);
+        List<Tournament> imminentTournaments = findImminentTournament(date);
 
-        if (tournament.isPresent()) {
-            List<TournamentUser> tournamentUsers = tournament.get().getTournamentUsers();
+        for (Tournament imminentTournament : imminentTournaments) {
+            List<TournamentUser> tournamentUsers = imminentTournament.getTournamentUsers();
             if (tournamentUsers.size() < Tournament.ALLOWED_JOINED_NUMBER) {
                 // TODO 취소 알림
-                tournamentRepository.delete(tournament.get());
+                tournamentRepository.delete(imminentTournament);
                 return;
             }
-            tournament.get().updateStatus(TournamentStatus.LIVE);
-            matchTournamentGames(tournament.get());
+            imminentTournament.updateStatus(TournamentStatus.LIVE);
+            matchTournamentGames(imminentTournament);
             // TODO 시작 알림?
         }
     }
@@ -231,15 +231,17 @@ public class TournamentService {
      * @param date 조회하려는 토너먼트의 시작 날짜
      * @return date 날짜에 시작하는 토너먼트
      */
-    private Optional<Tournament> findImminentTournament(LocalDate date) {
+    private List<Tournament> findImminentTournament(LocalDate date) {
         List<Tournament> tournaments = tournamentRepository.findAllByStatus(TournamentStatus.BEFORE);
+        List<Tournament> imminentTournaments = new ArrayList<>();
+
         for (Tournament tournament : tournaments) {
             LocalDate startDate = tournament.getStartTime().toLocalDate();
             if (startDate.isEqual(date)) {
-                return Optional.of(tournament);
+                imminentTournaments.add(tournament);
             }
         }
-        return Optional.empty();
+        return imminentTournaments;
     }
 
 

--- a/src/main/java/com/gg/server/domain/tournament/type/TournamentRound.java
+++ b/src/main/java/com/gg/server/domain/tournament/type/TournamentRound.java
@@ -11,6 +11,7 @@ public enum TournamentRound {
     // the final -> 결승
     // semi final  -> 4강
     // quarter final -> 8강
+    // ordinal()로 sorting 사용되고 있으므로 순서 중요 -> 이후에 리팩토링으로 해결하겠습니다.
     THE_FINAL("1", null),
     SEMI_FINAL_1("4-1", THE_FINAL),
     SEMI_FINAL_2("4-2", THE_FINAL),

--- a/src/main/java/com/gg/server/global/scheduler/TournamentScheduler.java
+++ b/src/main/java/com/gg/server/global/scheduler/TournamentScheduler.java
@@ -1,0 +1,24 @@
+package com.gg.server.global.scheduler;
+
+import com.gg.server.domain.tournament.service.TournamentService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class TournamentScheduler extends AbstractScheduler {
+    private final TournamentService tournamentService;
+
+    public TournamentScheduler(TournamentService tournamentService) {
+        this.tournamentService = tournamentService;
+        this.cron = "0 0 0 * * *";
+    }
+
+    @Override
+    public Runnable runnable() {
+        return () -> {
+            log.info("Tournament Scheduler Started");
+            tournamentService.startTournament();
+        };
+    }
+}

--- a/src/test/java/com/gg/server/domain/tournament/controller/TournamentFindControllerTest.java
+++ b/src/test/java/com/gg/server/domain/tournament/controller/TournamentFindControllerTest.java
@@ -307,7 +307,7 @@ public class TournamentFindControllerTest {
                     TournamentType.ROOKIE, TournamentStatus.BEFORE);
             User user = testDataUtils.createNewUser("test");
             testDataUtils.createTournamentUser(user, tournament, true);
-            tournament.update_winner(user);
+            tournament.updateWinner(user);
 
             Long tournamentId = tournament.getId();
             String url = "/pingpong/tournaments/" + tournamentId;

--- a/src/test/java/com/gg/server/domain/tournament/controller/TournamentSchedulerTest.java
+++ b/src/test/java/com/gg/server/domain/tournament/controller/TournamentSchedulerTest.java
@@ -1,0 +1,75 @@
+package com.gg.server.domain.tournament.controller;
+
+import com.gg.server.domain.game.data.GameRepository;
+import com.gg.server.domain.slotmanagement.SlotManagement;
+import com.gg.server.domain.slotmanagement.data.SlotManagementRepository;
+import com.gg.server.domain.tournament.data.Tournament;
+import com.gg.server.domain.tournament.data.TournamentGame;
+import com.gg.server.domain.tournament.data.TournamentGameRepository;
+import com.gg.server.domain.tournament.data.TournamentRepository;
+import com.gg.server.domain.tournament.service.TournamentService;
+import com.gg.server.domain.tournament.type.TournamentStatus;
+import com.gg.server.global.scheduler.TournamentScheduler;
+import com.gg.server.utils.TestDataUtils;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+public class TournamentSchedulerTest {
+    @Autowired
+    TournamentService tournamentService;
+    @Autowired
+    TestDataUtils testDataUtils;
+    @Autowired
+    SlotManagementRepository slotManagementRepository;
+    @Autowired
+    TournamentGameRepository tournamentGameRepository;
+
+    @Test
+    @DisplayName("토너먼트 스케줄러 테스트")
+    void tournamentSchedulerTest() {
+        // given
+        testDataUtils.createSeason();
+        // BEFORE로 토너먼트 생성
+        Tournament tournament = testDataUtils.createTournamentWithUser(Tournament.ALLOWED_JOINED_NUMBER, 4, "test");
+        List<TournamentGame> tournamentGameList = testDataUtils.createTournamentGameList(tournament, 7);
+        for (TournamentGame tournamentGame : tournamentGameList) {
+            tournament.addTournamentGame(tournamentGame);
+        }
+        SlotManagement slotManagement = SlotManagement.builder()
+            .pastSlotTime(0)
+            .futureSlotTime(0)
+            .openMinute(0)
+            .gameInterval(15)
+            .startTime(LocalDateTime.now().minusHours(1))
+            .build();
+        slotManagementRepository.save(slotManagement);
+
+        // when
+        tournamentService.startTournament();
+
+        // then
+        // 토너먼트의 상태가 LIVE로 변경되었는지 확인
+        assertThat(tournament.getStatus())
+            .isEqualTo(TournamentStatus.LIVE);
+
+        // game이 생성되었는지 확인
+        List<TournamentGame> tournamentGames = tournamentGameRepository.findAllByTournamentId(tournament.getId()).stream()
+            .filter(o -> o.getGame() != null)
+            .collect(Collectors.toList());
+        assertThat(tournamentGames.size()).isEqualTo(Tournament.ALLOWED_JOINED_NUMBER / 2);
+        for (TournamentGame tournamentGame : tournamentGames) {
+            assertThat(tournamentGame.getGame()).isNotNull();
+        }
+    }
+}

--- a/src/test/java/com/gg/server/utils/TestDataUtils.java
+++ b/src/test/java/com/gg/server/utils/TestDataUtils.java
@@ -248,7 +248,7 @@ public class TestDataUtils {
 
 
     public Season createSeason(){
-        LocalDateTime startTime = LocalDateTime.now();
+        LocalDateTime startTime = LocalDateTime.now().minusMinutes(5);
         LocalDateTime endTime = startTime.plusMonths(1);
         Season season = seasonRepository.findCurrentSeason(LocalDateTime.now()).orElse(null);
         if (season == null)
@@ -548,7 +548,7 @@ public class TestDataUtils {
                 for (int i = 0; i < 5; i++) {
                     Tournament tournament = createTournamentByEnum(type, status, LocalDateTime.now().plusDays(day++));
                     tournamentResponseDtos.add(new TournamentResponseDto(tournament, winnerImage, joinUserCnt));
-                    tournament.update_winner(winner);
+                    tournament.updateWinner(winner);
                     for (int j = 0; j < joinUserCnt; j++) {
                         TournamentUser tournamentUser = new TournamentUser(userRepository.findByIntraId("42gg_tester" + j).get(), tournament, true, LocalDateTime.now());
                         tournamentUserRepository.save(tournamentUser);


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 토너먼트 첫 경기 (현재 8강) 매칭하는 Scheduler 생성

## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
### 스케줄러 매칭 로직
- **스케줄러는 매일 자정에 실행됩니다.**
- **오늘 날짜 기준으로 시작하는 토너먼트가 있을 경우 토너먼트의 status를 `LIVE`로 바꾸고 첫 8강 경기 4경기를 생성합니다.**
- 8강에 대한 `TouranmentGame`을 찾고, `Team`, `TeamUser`를 생성하여 저장합니다.
- `TournamentRound` enum class를 활용하여 sort(정렬)하는데, 내부적으로 `ordinal()`로 정렬이 됩니다. **그래서 enum 값들 순서가 중요합니다. 주의를 위한 주석을 추가했습니다.** 하지만 좋은 코드는 아닌 것 같아서 이후에 enum에 대한 리팩토링을 진행할 예정입니다.

### 상수 수정
- `ALLOWED_JOINED_NUMBER`, `ALLOWED)MINIAL_START_DAYS`, `MINIMUM_TOURNAMENT_DURATION` 상수들 `TournamentAdminService`에서 `Tournament`로 옮겼습니다.
- 추가로 데이터 타입을 `long`에서 `int`로 수정했습니다.

### List 초기화
- `Game`, `Team` Entity의 멤버필드중 list에 대해서 초기화하는 코드를 추가했습니다.


## 💡Issue 번호 <!-- issue number을 link 시켜주세요 (ex. "- close #4242") -->
  - close #338 