### PR TITLE
✨ [Feature] 테스트 환경 개선 및 CI 추가

### DIFF
--- a/.github/workflows/test-code-action.yml
+++ b/.github/workflows/test-code-action.yml
@@ -1,0 +1,43 @@
+name: 💻 Test code validation
+
+on:
+  push:
+    branches: [ main, dev ]
+  pull_request:
+    branches: [ main, dev ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      - name: ️👶 Unit Test with Gradle
+        run: ./gradlew --console verbose clean unitTestCoverage
+      - name: mv for separate report
+        run: mv ./build/reports/jacoco/test ./build/reports/jacoco/unitTest
+      - name: 📲 Upload unitTest coverage to Codecov
+        uses: codecov/codecov-action@v2
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
+          files: ./build/reports/jacoco/unitTest/jacocoTestReport.xml
+          flags: unitTest
+          name: codecov-unit
+          verbose: true
+      - name: 👨‍👨‍👧‍👦 Integration Test with Gradle
+        run: ./gradlew --console verbose clean integrationTestCoverage
+      - name: 📲 Upload integrationTest coverage to Codecov
+        uses: codecov/codecov-action@v2
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
+          files: ./build/reports/jacoco/test/jacocoTestReport.xml
+          flags: integrationTest
+          name: codecov-integration
+          verbose: true

--- a/.github/workflows/test-code-action.yml
+++ b/.github/workflows/test-code-action.yml
@@ -19,14 +19,16 @@ jobs:
         run: chmod +x gradlew
       - name: ️👶 Unit Test with Gradle
         run: ./gradlew --console verbose clean unitTestCoverage
-      - name: mv for separate report
+      - name: mv for separate report folder
         run: mv ./build/reports/jacoco/test ./build/reports/jacoco/unitTest
+      - name: mv for separate report name
+        run: mv ./build/reports/jacoco/unitTest/jacocoTestReport.xml ./build/reports/jacoco/unitTest/unitTestReport.xml
       - name: 📲 Upload unitTest coverage to Codecov
         uses: codecov/codecov-action@v2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
-          files: ./build/reports/jacoco/unitTest/jacocoTestReport.xml
+          files: ./build/reports/jacoco/unitTest/unitTestReport.xml
           flags: unitTest
           name: codecov-unit
           verbose: true

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
 	id 'io.spring.dependency-management' version '1.0.11.RELEASE'
 	id 'org.asciidoctor.jvm.convert' version '3.3.2'
 	id 'java'
+	id 'jacoco'
 }
 
 springBoot {
@@ -57,7 +58,7 @@ dependencies {
 	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 
 	/* lombok */
-	implementation 'org.projectlombok:lombok:1.18.20'
+	implementation 'org.projectlombok:lombok:1.18.26'
 	annotationProcessor 'org.projectlombok:lombok'
 	compileOnly 'org.projectlombok:lombok'
 
@@ -100,7 +101,91 @@ dependencies {
 
 	//testcontainers 추가
 	testImplementation "org.testcontainers:mysql:1.19.3"
+	testImplementation "com.redis:testcontainers-redis:2.0.1"
 	testImplementation "org.junit.jupiter:junit-jupiter:5.8.1"
 	testImplementation "org.testcontainers:testcontainers:1.19.3"
 	testImplementation "org.testcontainers:junit-jupiter:1.19.3"
+}
+
+//테스트 커버리지 측정도구
+jacoco {
+	toolVersion = "0.8.5"
+}
+
+//커버리지 리포트 생성
+jacocoTestReport {
+	reports {
+		xml.enabled false
+		html.enabled true
+		csv.enabled true
+	}
+
+	afterEvaluate {
+		//dto 및 외부 연동 서비스는 테스트에서 제외
+		classDirectories.setFrom(files(classDirectories.files.collect {
+			fileTree(dir: it,
+					exclude: [
+							'*Application*',
+							"**/config/*",
+							"**/security/*",
+							"**/dto/*",
+							"**/aws/*",
+							"*NotiMailSender*",
+							'*SlackbotService*'
+					]
+			)
+		}))
+	}
+}
+
+// 커버리지 검증 설정
+jacocoTestCoverageVerification {
+	violationRules {
+		rule {
+			enabled = true
+			element = 'CLASS'
+
+			//브랜치 커버리지
+			limit {
+				counter = 'BRANCH'
+				value = 'COVEREDRATIO'
+				minimum = 0.00
+			}
+
+			//라인 커버리지
+			limit {
+				counter = 'LINE'
+				value = 'COVEREDRATIO'
+				minimum = 0.00
+			}
+
+			//검증에서 제외할 패키지, 클래스 설정
+			excludes = [
+					'*Application*',
+					"**/config/*",
+					"**/security/*",
+					"**/dto/*",
+					"**/aws/*",
+					"*NotiMailSender*",
+					'*SlackbotService*',
+			]
+		}
+	}
+}
+
+test {
+	useJUnitPlatform()
+}
+
+//jacocoTestReport 는 jacocoTestCoverageVerification 이후에 실행되도록 설정
+task testCoverage(type: Test) {
+	group 'verification'
+	description 'Runs the unit tests with coverage'
+
+	dependsOn(':test',
+			':jacocoTestReport',
+			':jacocoTestCoverageVerification')
+
+	tasks['jacocoTestReport'].mustRunAfter(tasks['test'])
+	tasks['jacocoTestCoverageVerification'].mustRunAfter(tasks['jacocoTestReport'])
 }

--- a/build.gradle
+++ b/build.gradle
@@ -109,37 +109,40 @@ dependencies {
 
 //테스트 커버리지 측정도구
 jacoco {
-	toolVersion = "0.8.5"
+	toolVersion = "0.8.8"
 }
+
+// dto, 외부 연동 서비스는 테스트에서 제외
+def	jacocoExcludes = [
+	'*Application*',
+	"**/config/*",
+	"**/security/*",
+	"**/dto/*",
+	"**/aws/*",
+	"*NotiMailSender*",
+	'*SlackbotService*',
+]
 
 //커버리지 리포트 생성
 jacocoTestReport {
+
 	reports {
-		xml.enabled false
+		xml.enabled true
 		html.enabled true
-		csv.enabled true
+		csv.enabled false
 	}
 
 	afterEvaluate {
 		//dto 및 외부 연동 서비스는 테스트에서 제외
 		classDirectories.setFrom(files(classDirectories.files.collect {
-			fileTree(dir: it,
-					exclude: [
-							'*Application*',
-							"**/config/*",
-							"**/security/*",
-							"**/dto/*",
-							"**/aws/*",
-							"*NotiMailSender*",
-							'*SlackbotService*'
-					]
-			)
-		}))
+			fileTree(dir: it, exclude: jacocoExcludes)})
+		)
 	}
 }
 
 // 커버리지 검증 설정
 jacocoTestCoverageVerification {
+
 	violationRules {
 		rule {
 			enabled = true
@@ -152,6 +155,13 @@ jacocoTestCoverageVerification {
 				minimum = 0.00
 			}
 
+			//메소드 커버리지
+			limit {
+				counter = 'METHOD'
+				value = 'COVEREDRATIO'
+				minimum = 0.00
+			}
+
 			//라인 커버리지
 			limit {
 				counter = 'LINE'
@@ -159,33 +169,82 @@ jacocoTestCoverageVerification {
 				minimum = 0.00
 			}
 
-			//검증에서 제외할 패키지, 클래스 설정
-			excludes = [
-					'*Application*',
-					"**/config/*",
-					"**/security/*",
-					"**/dto/*",
-					"**/aws/*",
-					"*NotiMailSender*",
-					'*SlackbotService*',
-			]
+			//검증에서 제외할 패키지, 클래스
+			excludes = jacocoExcludes
 		}
 	}
 }
 
+//전체 테스트
 test {
+	description = 'Runs the total tests.'
 	useJUnitPlatform()
 }
 
-//jacocoTestReport 는 jacocoTestCoverageVerification 이후에 실행되도록 설정
-task testCoverage(type: Test) {
+//유닛 테스트
+task unitTest(type: Test) {
+	group = 'verification'
+	description = 'Runs the unit tests.'
+	useJUnitPlatform{
+		includeTags 'UnitTest'
+		excludeTags 'IntegrationTest'
+	}
+
+	jacoco {
+		destinationFile = file("$buildDir/jacoco/test.exec")
+	}
+
+}
+
+//통합 테스트
+task integrationTest(type: Test) {
+	group = 'verification'
+	description = 'Runs the integration tests.'
+	useJUnitPlatform{
+		includeTags 'IntegrationTest'
+		excludeTags 'UnitTest'
+	}
+
+	jacoco {
+		destinationFile = file("$buildDir/jacoco/test.exec")
+	}
+}
+
+//전체 테스트, 리포트 생성, 검증
+task totalTestCoverage(type: Test) {
 	group 'verification'
-	description 'Runs the unit tests with coverage'
+	description 'Runs the total tests with coverage'
 
 	dependsOn(':test',
 			':jacocoTestReport',
 			':jacocoTestCoverageVerification')
 
 	tasks['jacocoTestReport'].mustRunAfter(tasks['test'])
+	tasks['jacocoTestCoverageVerification'].mustRunAfter(tasks['jacocoTestReport'])
+}
+
+//유닛 테스트, 리포트 생성, 검증
+task unitTestCoverage(type: Test) {
+	group 'verification'
+	description 'Runs the unit tests with coverage'
+
+	dependsOn(':unitTest',
+			':jacocoTestReport',
+			':jacocoTestCoverageVerification')
+
+	tasks['jacocoTestReport'].mustRunAfter(tasks['unitTest'])
+	tasks['jacocoTestCoverageVerification'].mustRunAfter(tasks['jacocoTestReport'])
+}
+
+//통합 테스트, 리포트 생성, 검증
+task integrationTestCoverage(type: Test) {
+	group 'verification'
+	description 'Runs the integration tests with coverage'
+
+	dependsOn(':integrationTest',
+			':jacocoTestReport',
+			':jacocoTestCoverageVerification')
+
+	tasks['jacocoTestReport'].mustRunAfter(tasks['integrationTest'])
 	tasks['jacocoTestCoverageVerification'].mustRunAfter(tasks['jacocoTestReport'])
 }

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,11 +2,11 @@ coverage:
   status:
     project:
       unit:
-        target: 30%
+        target: auto
         flags:
           - unitTest
       integration:
-        target: 80%
+        target: auto
         flags:
           - integrationTest
 flags:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,18 @@
+coverage:
+  status:
+    project:
+      unit:
+        target: 30%
+        flags:
+          - unitTest
+      integration:
+        target: 80%
+        flags:
+          - integrationTest
+flags:
+  unitTest:
+    paths:
+      - src/main/java/com/gg/server/
+  integrationTest:
+    paths:
+      - src/main/java/com/gg/server/

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,11 +2,11 @@ coverage:
   status:
     project:
       unit:
-        target: auto
+        target: 5%
         flags:
           - unitTest
       integration:
-        target: auto
+        target: 60%
         flags:
           - integrationTest
 flags:

--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,2 @@
+config.stopBubbling = true
+lombok.addLombokGeneratedAnnotation = true

--- a/src/main/java/com/gg/server/global/security/repository/OAuthAuthorizationRequestBasedOnCookieRepository.java
+++ b/src/main/java/com/gg/server/global/security/repository/OAuthAuthorizationRequestBasedOnCookieRepository.java
@@ -2,16 +2,13 @@ package com.gg.server.global.security.repository;
 
 
 import com.gg.server.global.security.cookie.CookieUtil;
-import com.gg.server.global.utils.ApplicationYmlRead;
 import com.nimbusds.oauth2.sdk.util.StringUtils;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 import org.springframework.stereotype.Repository;
-import org.springframework.web.servlet.i18n.CookieLocaleResolver;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 
 @Repository
 @RequiredArgsConstructor

--- a/src/test/java/com/gg/server/ServerApplicationTests.java
+++ b/src/test/java/com/gg/server/ServerApplicationTests.java
@@ -1,15 +1,13 @@
 package com.gg.server;
 
+import com.gg.server.utils.annotation.IntegrationTest;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.aop.scope.ScopedProxyUtils;
-import org.springframework.boot.test.context.SpringBootTest;
 
-import java.time.LocalDateTime;
 import java.util.TimeZone;
 
-@SpringBootTest
+@IntegrationTest
 class ServerApplicationTests {
 
 	@Test

--- a/src/test/java/com/gg/server/admin/announcement/controller/AnnouncementAdminControllerFailTest.java
+++ b/src/test/java/com/gg/server/admin/announcement/controller/AnnouncementAdminControllerFailTest.java
@@ -2,6 +2,7 @@ package com.gg.server.admin.announcement.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.gg.server.admin.announcement.data.AnnouncementAdminRepository;
+import com.gg.server.utils.annotation.IntegrationTest;
 import com.gg.server.global.security.jwt.utils.AuthTokenProvider;
 import com.gg.server.utils.TestDataUtils;
 import lombok.RequiredArgsConstructor;
@@ -10,7 +11,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,7 +18,7 @@ import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuild
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @RequiredArgsConstructor
-@SpringBootTest
+@IntegrationTest
 @AutoConfigureMockMvc
 @Transactional
 public class AnnouncementAdminControllerFailTest {

--- a/src/test/java/com/gg/server/admin/announcement/controller/AnnouncementAdminControllerTest.java
+++ b/src/test/java/com/gg/server/admin/announcement/controller/AnnouncementAdminControllerTest.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.gg.server.admin.announcement.data.AnnouncementAdminRepository;
 import com.gg.server.admin.announcement.dto.AnnouncementAdminAddDto;
 import com.gg.server.admin.announcement.dto.AnnouncementAdminListResponseDto;
+import com.gg.server.utils.annotation.IntegrationTest;
 import com.gg.server.domain.announcement.data.Announcement;
 import com.gg.server.domain.announcement.exception.AnnounceNotFoundException;
 import com.gg.server.global.security.jwt.utils.AuthTokenProvider;
@@ -20,13 +21,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
-@SpringBootTest
+@IntegrationTest
 @AutoConfigureMockMvc
 @Transactional
 class AnnouncementAdminControllerTest {

--- a/src/test/java/com/gg/server/admin/coin/controller/CoinAdminControllerTest.java
+++ b/src/test/java/com/gg/server/admin/coin/controller/CoinAdminControllerTest.java
@@ -2,6 +2,7 @@ package com.gg.server.admin.coin.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.gg.server.admin.coin.dto.CoinUpdateRequestDto;
+import com.gg.server.utils.annotation.IntegrationTest;
 import com.gg.server.domain.user.data.UserRepository;
 import com.gg.server.global.security.jwt.utils.AuthTokenProvider;
 import com.gg.server.utils.TestDataUtils;
@@ -12,7 +13,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,7 +21,7 @@ import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuild
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @RequiredArgsConstructor
-@SpringBootTest
+@IntegrationTest
 @AutoConfigureMockMvc
 @Transactional
 class CoinAdminControllerTest {

--- a/src/test/java/com/gg/server/admin/coin/controller/CoinPolicyAdminControllerFailTest.java
+++ b/src/test/java/com/gg/server/admin/coin/controller/CoinPolicyAdminControllerFailTest.java
@@ -3,6 +3,7 @@ package com.gg.server.admin.coin.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.gg.server.admin.coin.data.CoinPolicyAdminRepository;
 import com.gg.server.admin.coin.dto.CoinPolicyAdminAddDto;
+import com.gg.server.utils.annotation.IntegrationTest;
 import com.gg.server.global.security.jwt.utils.AuthTokenProvider;
 import com.gg.server.utils.TestDataUtils;
 import lombok.RequiredArgsConstructor;
@@ -11,7 +12,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,7 +20,7 @@ import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuild
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @RequiredArgsConstructor
-@SpringBootTest
+@IntegrationTest
 @AutoConfigureMockMvc
 @Transactional
 public class CoinPolicyAdminControllerFailTest {

--- a/src/test/java/com/gg/server/admin/coin/controller/CoinPolicyAdminControllerTest.java
+++ b/src/test/java/com/gg/server/admin/coin/controller/CoinPolicyAdminControllerTest.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.gg.server.admin.coin.data.CoinPolicyAdminRepository;
 import com.gg.server.admin.coin.dto.CoinPolicyAdminAddDto;
 import com.gg.server.admin.coin.dto.CoinPolicyAdminListResponseDto;
+import com.gg.server.utils.annotation.IntegrationTest;
 import com.gg.server.domain.coin.data.CoinPolicy;
 import com.gg.server.domain.coin.exception.CoinPolicyNotFoundException;
 import com.gg.server.domain.user.data.User;
@@ -21,13 +22,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
-@SpringBootTest
+@IntegrationTest
 @AutoConfigureMockMvc
 @Transactional
 class CoinPolicyAdminControllerTest {

--- a/src/test/java/com/gg/server/admin/feedback/controller/FeedbackAdminControllerTest.java
+++ b/src/test/java/com/gg/server/admin/feedback/controller/FeedbackAdminControllerTest.java
@@ -3,6 +3,7 @@ package com.gg.server.admin.feedback.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.gg.server.admin.feedback.data.FeedbackAdminRepository;
 import com.gg.server.admin.feedback.dto.FeedbackListAdminResponseDto;
+import com.gg.server.utils.annotation.IntegrationTest;
 import com.gg.server.domain.feedback.data.Feedback;
 import com.gg.server.domain.feedback.type.FeedbackType;
 import com.gg.server.domain.user.data.User;
@@ -15,7 +16,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,7 +24,7 @@ import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuild
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @RequiredArgsConstructor
-@SpringBootTest
+@IntegrationTest
 @AutoConfigureMockMvc
 @Transactional
 class FeedbackAdminControllerTest {

--- a/src/test/java/com/gg/server/admin/game/controller/GameAdminControllerTest.java
+++ b/src/test/java/com/gg/server/admin/game/controller/GameAdminControllerTest.java
@@ -3,6 +3,7 @@ package com.gg.server.admin.game.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.gg.server.admin.game.dto.GameLogListAdminResponseDto;
 import com.gg.server.admin.game.dto.RankGamePPPModifyReqDto;
+import com.gg.server.config.RedisInitializer;
 import com.gg.server.config.TestRedisConfig;
 import com.gg.server.domain.game.data.GameRepository;
 import com.gg.server.domain.game.dto.GameTeamUser;
@@ -33,6 +34,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -47,6 +49,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @RequiredArgsConstructor
 @SpringBootTest
 @Import(TestRedisConfig.class)
+@ContextConfiguration(initializers = RedisInitializer.class)
 @AutoConfigureMockMvc
 @Transactional
 @DisplayName("[Admin] Game Admin Controller Integration Test")

--- a/src/test/java/com/gg/server/admin/game/controller/GameAdminControllerTest.java
+++ b/src/test/java/com/gg/server/admin/game/controller/GameAdminControllerTest.java
@@ -3,8 +3,7 @@ package com.gg.server.admin.game.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.gg.server.admin.game.dto.GameLogListAdminResponseDto;
 import com.gg.server.admin.game.dto.RankGamePPPModifyReqDto;
-import com.gg.server.config.RedisInitializer;
-import com.gg.server.config.TestRedisConfig;
+import com.gg.server.utils.annotation.IntegrationTest;
 import com.gg.server.domain.game.data.GameRepository;
 import com.gg.server.domain.game.dto.GameTeamUser;
 import com.gg.server.domain.game.dto.request.RankResultReqDto;
@@ -31,10 +30,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -47,9 +43,7 @@ import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuild
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @RequiredArgsConstructor
-@SpringBootTest
-@Import(TestRedisConfig.class)
-@ContextConfiguration(initializers = RedisInitializer.class)
+@IntegrationTest
 @AutoConfigureMockMvc
 @Transactional
 @DisplayName("[Admin] Game Admin Controller Integration Test")

--- a/src/test/java/com/gg/server/admin/item/controller/ItemAdminControllerTest.java
+++ b/src/test/java/com/gg/server/admin/item/controller/ItemAdminControllerTest.java
@@ -11,6 +11,7 @@ import com.gg.server.admin.item.data.ItemAdminRepository;
 import com.gg.server.admin.item.dto.ItemListResponseDto;
 import com.gg.server.admin.item.dto.ItemUpdateRequestDto;
 import com.gg.server.admin.item.service.ItemAdminService;
+import com.gg.server.utils.annotation.IntegrationTest;
 import com.gg.server.domain.item.data.Item;
 import com.gg.server.domain.item.type.ItemType;
 import com.gg.server.domain.user.data.UserRepository;
@@ -27,7 +28,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -35,7 +35,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.MockMvc;
 
-@SpringBootTest
+@IntegrationTest
 @AutoConfigureMockMvc
 @Transactional
 class ItemAdminControllerTest {

--- a/src/test/java/com/gg/server/admin/megaphone/controller/MegaphoneAdminControllerTest.java
+++ b/src/test/java/com/gg/server/admin/megaphone/controller/MegaphoneAdminControllerTest.java
@@ -1,5 +1,6 @@
 package com.gg.server.admin.megaphone.controller;
 
+import com.gg.server.utils.annotation.IntegrationTest;
 import com.gg.server.global.security.jwt.utils.AuthTokenProvider;
 import com.gg.server.utils.TestDataUtils;
 import javax.transaction.Transactional;
@@ -9,14 +10,13 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @RequiredArgsConstructor
-@SpringBootTest
+@IntegrationTest
 @AutoConfigureMockMvc
 @Transactional
 class MegaphoneAdminControllerTest {

--- a/src/test/java/com/gg/server/admin/noti/controller/NotiAdminControllerTest.java
+++ b/src/test/java/com/gg/server/admin/noti/controller/NotiAdminControllerTest.java
@@ -6,6 +6,7 @@ import com.gg.server.admin.noti.dto.NotiAdminDto;
 import com.gg.server.admin.noti.dto.NotiListAdminResponseDto;
 import com.gg.server.admin.noti.dto.SendNotiAdminRequestDto;
 import com.gg.server.admin.noti.service.NotiAdminService;
+import com.gg.server.utils.annotation.IntegrationTest;
 import com.gg.server.domain.noti.data.Noti;
 import com.gg.server.domain.noti.data.NotiRepository;
 import com.gg.server.domain.noti.type.NotiType;
@@ -20,7 +21,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -38,7 +38,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @RequiredArgsConstructor
-@SpringBootTest
+@IntegrationTest
 @AutoConfigureMockMvc
 class NotiAdminControllerTest {
     @Autowired

--- a/src/test/java/com/gg/server/admin/penalty/controller/PenaltyAdminControllerTest.java
+++ b/src/test/java/com/gg/server/admin/penalty/controller/PenaltyAdminControllerTest.java
@@ -11,8 +11,7 @@ import com.gg.server.admin.penalty.data.PenaltyUserAdminRedisRepository;
 import com.gg.server.admin.penalty.dto.PenaltyListResponseDto;
 import com.gg.server.admin.penalty.dto.PenaltyRequestDto;
 import com.gg.server.admin.penalty.service.PenaltyAdminService;
-import com.gg.server.config.RedisInitializer;
-import com.gg.server.config.TestRedisConfig;
+import com.gg.server.utils.annotation.IntegrationTest;
 import com.gg.server.domain.penalty.data.Penalty;
 import com.gg.server.domain.penalty.redis.RedisPenaltyUser;
 import com.gg.server.domain.penalty.type.PenaltyType;
@@ -37,18 +36,13 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.data.redis.connection.RedisConnection;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
-@SpringBootTest
-@Import(TestRedisConfig.class)
-@ContextConfiguration(initializers = RedisInitializer.class)
+@IntegrationTest
 @AutoConfigureMockMvc
 @Transactional
 class PenaltyAdminControllerTest {

--- a/src/test/java/com/gg/server/admin/penalty/controller/PenaltyAdminControllerTest.java
+++ b/src/test/java/com/gg/server/admin/penalty/controller/PenaltyAdminControllerTest.java
@@ -11,6 +11,7 @@ import com.gg.server.admin.penalty.data.PenaltyUserAdminRedisRepository;
 import com.gg.server.admin.penalty.dto.PenaltyListResponseDto;
 import com.gg.server.admin.penalty.dto.PenaltyRequestDto;
 import com.gg.server.admin.penalty.service.PenaltyAdminService;
+import com.gg.server.config.RedisInitializer;
 import com.gg.server.config.TestRedisConfig;
 import com.gg.server.domain.penalty.data.Penalty;
 import com.gg.server.domain.penalty.redis.RedisPenaltyUser;
@@ -41,11 +42,13 @@ import org.springframework.context.annotation.Import;
 import org.springframework.data.redis.connection.RedisConnection;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
 @Import(TestRedisConfig.class)
+@ContextConfiguration(initializers = RedisInitializer.class)
 @AutoConfigureMockMvc
 @Transactional
 class PenaltyAdminControllerTest {

--- a/src/test/java/com/gg/server/admin/receipt/controller/ReceiptAdminControllerTest.java
+++ b/src/test/java/com/gg/server/admin/receipt/controller/ReceiptAdminControllerTest.java
@@ -9,6 +9,7 @@ import com.gg.server.admin.item.dto.ItemUpdateRequestDto;
 import com.gg.server.admin.receipt.data.ReceiptAdminRepository;
 import com.gg.server.admin.receipt.dto.ReceiptListResponseDto;
 import com.gg.server.admin.receipt.service.ReceiptAdminService;
+import com.gg.server.utils.annotation.IntegrationTest;
 import com.gg.server.domain.item.data.Item;
 import com.gg.server.domain.item.type.ItemType;
 import com.gg.server.domain.user.data.User;
@@ -21,14 +22,13 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
-@SpringBootTest
+@IntegrationTest
 @AutoConfigureMockMvc
 @Transactional
 class ReceiptAdminControllerTest {

--- a/src/test/java/com/gg/server/admin/season/SeasonAdminControllerTest.java
+++ b/src/test/java/com/gg/server/admin/season/SeasonAdminControllerTest.java
@@ -12,6 +12,7 @@ import com.gg.server.admin.season.dto.SeasonCreateRequestDto;
 import com.gg.server.admin.season.dto.SeasonListAdminResponseDto;
 import com.gg.server.admin.season.dto.SeasonUpdateRequestDto;
 import com.gg.server.admin.season.service.SeasonAdminService;
+import com.gg.server.config.RedisInitializer;
 import com.gg.server.config.TestRedisConfig;
 import com.gg.server.domain.rank.data.RankRepository;
 import com.gg.server.domain.rank.exception.RedisDataNotFoundException;
@@ -35,6 +36,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.transaction.annotation.Transactional;
@@ -42,6 +44,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @SpringBootTest
 @Import(TestRedisConfig.class)
+@ContextConfiguration(initializers = RedisInitializer.class)
 @AutoConfigureMockMvc
 @Transactional
 class SeasonAdminControllerTest {

--- a/src/test/java/com/gg/server/admin/season/SeasonAdminControllerTest.java
+++ b/src/test/java/com/gg/server/admin/season/SeasonAdminControllerTest.java
@@ -12,8 +12,7 @@ import com.gg.server.admin.season.dto.SeasonCreateRequestDto;
 import com.gg.server.admin.season.dto.SeasonListAdminResponseDto;
 import com.gg.server.admin.season.dto.SeasonUpdateRequestDto;
 import com.gg.server.admin.season.service.SeasonAdminService;
-import com.gg.server.config.RedisInitializer;
-import com.gg.server.config.TestRedisConfig;
+import com.gg.server.utils.annotation.IntegrationTest;
 import com.gg.server.domain.rank.data.RankRepository;
 import com.gg.server.domain.rank.exception.RedisDataNotFoundException;
 import com.gg.server.domain.rank.redis.RankRedisRepository;
@@ -33,18 +32,13 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
-@SpringBootTest
-@Import(TestRedisConfig.class)
-@ContextConfiguration(initializers = RedisInitializer.class)
+@IntegrationTest
 @AutoConfigureMockMvc
 @Transactional
 class SeasonAdminControllerTest {

--- a/src/test/java/com/gg/server/admin/slotmanagement/controller/SlotAdminControllerFailTest.java
+++ b/src/test/java/com/gg/server/admin/slotmanagement/controller/SlotAdminControllerFailTest.java
@@ -7,6 +7,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.gg.server.admin.slotmanagement.data.adminSlotManagementRepository;
 import com.gg.server.admin.slotmanagement.dto.SlotCreateRequestDto;
+import com.gg.server.utils.annotation.IntegrationTest;
 import com.gg.server.domain.slotmanagement.SlotManagement;
 import com.gg.server.domain.slotmanagement.data.SlotManagementRepository;
 import com.gg.server.global.security.jwt.utils.AuthTokenProvider;
@@ -19,13 +20,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
-@SpringBootTest
+@IntegrationTest
 @AutoConfigureMockMvc
 @Transactional
 public class SlotAdminControllerFailTest {

--- a/src/test/java/com/gg/server/admin/slotmanagement/controller/SlotAdminControllerTest.java
+++ b/src/test/java/com/gg/server/admin/slotmanagement/controller/SlotAdminControllerTest.java
@@ -10,6 +10,7 @@ import com.gg.server.admin.slotmanagement.data.adminSlotManagementRepository;
 import com.gg.server.admin.slotmanagement.dto.SlotAdminDto;
 import com.gg.server.admin.slotmanagement.dto.SlotCreateRequestDto;
 import com.gg.server.admin.slotmanagement.dto.SlotListAdminResponseDto;
+import com.gg.server.utils.annotation.IntegrationTest;
 import com.gg.server.domain.slotmanagement.SlotManagement;
 import com.gg.server.domain.slotmanagement.data.SlotManagementRepository;
 import com.gg.server.global.security.jwt.utils.AuthTokenProvider;
@@ -23,13 +24,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
-@SpringBootTest
+@IntegrationTest
 @AutoConfigureMockMvc
 @Transactional
 class SlotAdminControllerTest {

--- a/src/test/java/com/gg/server/admin/tournament/controller/TournamentAdminControllerTest.java
+++ b/src/test/java/com/gg/server/admin/tournament/controller/TournamentAdminControllerTest.java
@@ -12,6 +12,7 @@ import com.gg.server.admin.tournament.dto.TournamentAdminAddUserRequestDto;
 import com.gg.server.admin.tournament.dto.TournamentAdminUpdateRequestDto;
 import com.gg.server.admin.tournament.service.TournamentAdminService;
 import com.gg.server.domain.game.type.Mode;
+import com.gg.server.utils.annotation.IntegrationTest;
 import com.gg.server.domain.tournament.data.Tournament;
 import com.gg.server.domain.tournament.data.TournamentUser;
 import com.gg.server.domain.tournament.data.TournamentUserRepository;
@@ -34,12 +35,11 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
-@SpringBootTest
+@IntegrationTest
 @AutoConfigureMockMvc
 @RequiredArgsConstructor
 @Transactional

--- a/src/test/java/com/gg/server/admin/tournament/controller/TournamentAdminUserControllerTest.java
+++ b/src/test/java/com/gg/server/admin/tournament/controller/TournamentAdminUserControllerTest.java
@@ -1,6 +1,7 @@
 package com.gg.server.admin.tournament.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gg.server.utils.annotation.IntegrationTest;
 import com.gg.server.domain.tournament.data.Tournament;
 import com.gg.server.domain.tournament.dto.TournamentUserListResponseDto;
 import com.gg.server.domain.user.data.User;
@@ -17,7 +18,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,7 +25,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest
+@IntegrationTest
 @AutoConfigureMockMvc
 @Transactional
 @Slf4j

--- a/src/test/java/com/gg/server/admin/tournament/service/TournamentAdminServiceTest.java
+++ b/src/test/java/com/gg/server/admin/tournament/service/TournamentAdminServiceTest.java
@@ -29,6 +29,7 @@ import com.gg.server.domain.user.type.RacketType;
 import com.gg.server.domain.user.type.RoleType;
 import com.gg.server.domain.user.type.SnsType;
 import com.gg.server.global.exception.custom.InvalidParameterException;
+import com.gg.server.utils.annotation.UnitTest;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -42,6 +43,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+@UnitTest
 @ExtendWith(MockitoExtension.class)
 class TournamentAdminServiceTest {
     @Mock

--- a/src/test/java/com/gg/server/admin/user/controller/UserAdminControllerTest.java
+++ b/src/test/java/com/gg/server/admin/user/controller/UserAdminControllerTest.java
@@ -14,6 +14,7 @@ import com.gg.server.admin.user.dto.UserImageListAdminResponseDto;
 import com.gg.server.admin.user.dto.UserSearchAdminDto;
 import com.gg.server.admin.user.dto.UserSearchAdminResponseDto;
 import com.gg.server.admin.user.service.UserAdminService;
+import com.gg.server.utils.annotation.IntegrationTest;
 import com.gg.server.domain.user.data.User;
 import com.gg.server.domain.user.data.UserImage;
 import com.gg.server.domain.user.data.UserRepository;
@@ -30,14 +31,13 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.test.web.servlet.MockMvc;
 
 @RequiredArgsConstructor
-@SpringBootTest
+@IntegrationTest
 @AutoConfigureMockMvc
 class UserAdminControllerTest {
 

--- a/src/test/java/com/gg/server/config/RedisInitializer.java
+++ b/src/test/java/com/gg/server/config/RedisInitializer.java
@@ -1,0 +1,26 @@
+package com.gg.server.config;
+
+import com.redis.testcontainers.RedisContainer;
+import org.springframework.boot.test.util.TestPropertyValues;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.testcontainers.utility.DockerImageName;
+
+public class RedisInitializer implements
+    ApplicationContextInitializer<ConfigurableApplicationContext> {
+    private static final RedisContainer REDIS_CONTAINER =
+        new RedisContainer(DockerImageName.parse("redis:5.0.3-alpine"))
+            .withExposedPorts(6379);
+
+    static {
+        REDIS_CONTAINER.start();
+    }
+
+    @Override
+    public void initialize(ConfigurableApplicationContext applicationContext) {
+        TestPropertyValues.of(
+                "spring.redis.host=" + REDIS_CONTAINER.getHost(),
+                "spring.redis.port=" + REDIS_CONTAINER.getMappedPort(6379)
+        ).applyTo(applicationContext.getEnvironment());
+    }
+}

--- a/src/test/java/com/gg/server/domain/announcement/controller/AnnouncementControllerTest.java
+++ b/src/test/java/com/gg/server/domain/announcement/controller/AnnouncementControllerTest.java
@@ -4,6 +4,7 @@ import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuild
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gg.server.utils.annotation.IntegrationTest;
 import com.gg.server.domain.announcement.data.Announcement;
 import com.gg.server.domain.announcement.data.AnnouncementRepository;
 import com.gg.server.domain.announcement.exception.AnnounceNotFoundException;
@@ -18,12 +19,11 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
-@SpringBootTest
+@IntegrationTest
 @AutoConfigureMockMvc
 class AnnouncementControllerTest {
     @Autowired

--- a/src/test/java/com/gg/server/domain/coin/service/CoinHistoryServiceTest.java
+++ b/src/test/java/com/gg/server/domain/coin/service/CoinHistoryServiceTest.java
@@ -2,6 +2,7 @@ package com.gg.server.domain.coin.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.gg.server.utils.annotation.IntegrationTest;
 import com.gg.server.domain.coin.data.CoinHistory;
 import com.gg.server.domain.coin.data.CoinHistoryRepository;
 import com.gg.server.domain.coin.data.CoinPolicy;
@@ -16,10 +17,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
-@SpringBootTest
+@IntegrationTest
 @RequiredArgsConstructor
 @Transactional
 class CoinHistoryServiceTest {

--- a/src/test/java/com/gg/server/domain/coin/service/UserCoinChangeServiceTest.java
+++ b/src/test/java/com/gg/server/domain/coin/service/UserCoinChangeServiceTest.java
@@ -2,6 +2,7 @@ package com.gg.server.domain.coin.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.gg.server.utils.annotation.IntegrationTest;
 import com.gg.server.domain.coin.data.CoinHistoryRepository;
 import com.gg.server.domain.coin.data.CoinPolicy;
 import com.gg.server.domain.coin.data.CoinPolicyRepository;
@@ -24,10 +25,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
-@SpringBootTest
+@IntegrationTest
 @RequiredArgsConstructor
 @Transactional
 class UserCoinChangeServiceTest {

--- a/src/test/java/com/gg/server/domain/feedback/controller/FeedbackControllerTest.java
+++ b/src/test/java/com/gg/server/domain/feedback/controller/FeedbackControllerTest.java
@@ -1,40 +1,29 @@
 package com.gg.server.domain.feedback.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.gg.server.admin.announcement.dto.AnnouncementAdminAddDto;
-import com.gg.server.admin.announcement.dto.AnnouncementAdminListResponseDto;
-import com.gg.server.admin.season.dto.SeasonAdminDto;
-import com.gg.server.admin.season.dto.SeasonListAdminResponseDto;
+import com.gg.server.utils.annotation.IntegrationTest;
 import com.gg.server.domain.feedback.data.Feedback;
 import com.gg.server.domain.feedback.data.FeedbackRepository;
 import com.gg.server.domain.feedback.dto.FeedbackRequestDto;
 import com.gg.server.domain.feedback.type.FeedbackType;
-import com.gg.server.domain.season.data.Season;
 import com.gg.server.global.security.jwt.utils.AuthTokenProvider;
 import com.gg.server.utils.TestDataUtils;
 import lombok.RequiredArgsConstructor;
 import org.apache.http.HttpHeaders;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @RequiredArgsConstructor
-@SpringBootTest
+@IntegrationTest
 @AutoConfigureMockMvc
 class FeedbackControllerTest {
     @Autowired

--- a/src/test/java/com/gg/server/domain/game/GameControllerTest.java
+++ b/src/test/java/com/gg/server/domain/game/GameControllerTest.java
@@ -6,16 +6,12 @@ import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuild
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.gg.server.config.RedisInitializer;
-import com.gg.server.config.TestRedisConfig;
-import com.gg.server.domain.game.dto.request.TournamentResultReqDto;
-import com.gg.server.domain.game.service.GameFindService;
-import com.gg.server.domain.game.service.GameService;
 import com.gg.server.domain.game.data.Game;
 import com.gg.server.domain.game.data.GameRepository;
 import com.gg.server.domain.game.dto.GameListResDto;
 import com.gg.server.domain.game.dto.GameTeamInfo;
 import com.gg.server.domain.game.dto.request.RankResultReqDto;
+import com.gg.server.domain.game.dto.request.TournamentResultReqDto;
 import com.gg.server.domain.game.service.GameFindService;
 import com.gg.server.domain.game.service.GameService;
 import com.gg.server.domain.game.type.Mode;
@@ -44,6 +40,7 @@ import com.gg.server.domain.user.type.RoleType;
 import com.gg.server.domain.user.type.SnsType;
 import com.gg.server.global.security.jwt.utils.AuthTokenProvider;
 import com.gg.server.utils.TestDataUtils;
+import com.gg.server.utils.annotation.IntegrationTest;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -56,19 +53,14 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
-@SpringBootTest
-@Import(TestRedisConfig.class)
-@ContextConfiguration(initializers = RedisInitializer.class)
+@IntegrationTest
 @AutoConfigureMockMvc
 @RequiredArgsConstructor
 @Transactional

--- a/src/test/java/com/gg/server/domain/game/GameControllerTest.java
+++ b/src/test/java/com/gg/server/domain/game/GameControllerTest.java
@@ -6,6 +6,7 @@ import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuild
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gg.server.config.RedisInitializer;
 import com.gg.server.config.TestRedisConfig;
 import com.gg.server.domain.game.dto.request.TournamentResultReqDto;
 import com.gg.server.domain.game.service.GameFindService;
@@ -61,11 +62,13 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
 @Import(TestRedisConfig.class)
+@ContextConfiguration(initializers = RedisInitializer.class)
 @AutoConfigureMockMvc
 @RequiredArgsConstructor
 @Transactional

--- a/src/test/java/com/gg/server/domain/game/service/GameDBTest.java
+++ b/src/test/java/com/gg/server/domain/game/service/GameDBTest.java
@@ -5,6 +5,7 @@ import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuild
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.gg.server.admin.game.service.GameAdminService;
+import com.gg.server.utils.annotation.IntegrationTest;
 import com.gg.server.domain.game.data.Game;
 import com.gg.server.domain.game.data.GameRepository;
 import com.gg.server.domain.game.type.Mode;
@@ -29,11 +30,10 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
-@SpringBootTest
+@IntegrationTest
 @RequiredArgsConstructor
 @AutoConfigureMockMvc
 @Transactional

--- a/src/test/java/com/gg/server/domain/game/service/GameFindServiceTest.java
+++ b/src/test/java/com/gg/server/domain/game/service/GameFindServiceTest.java
@@ -2,6 +2,7 @@ package com.gg.server.domain.game.service;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
+import com.gg.server.utils.annotation.IntegrationTest;
 import com.gg.server.domain.game.data.Game;
 import com.gg.server.domain.game.data.GameRepository;
 import com.gg.server.domain.game.dto.GameListResDto;
@@ -28,14 +29,13 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.transaction.annotation.Transactional;
 
-@SpringBootTest
+@IntegrationTest
 @RequiredArgsConstructor
 @Transactional
 public class GameFindServiceTest {

--- a/src/test/java/com/gg/server/domain/game/service/GameServiceTest.java
+++ b/src/test/java/com/gg/server/domain/game/service/GameServiceTest.java
@@ -2,6 +2,7 @@ package com.gg.server.domain.game.service;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
+import com.gg.server.config.RedisInitializer;
 import com.gg.server.config.TestRedisConfig;
 import com.gg.server.domain.game.data.Game;
 import com.gg.server.domain.game.data.GameRepository;
@@ -34,10 +35,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
 @Import(TestRedisConfig.class)
+@ContextConfiguration(initializers = RedisInitializer.class)
 @RequiredArgsConstructor
 @Transactional
 public class GameServiceTest {

--- a/src/test/java/com/gg/server/domain/game/service/GameServiceTest.java
+++ b/src/test/java/com/gg/server/domain/game/service/GameServiceTest.java
@@ -2,8 +2,7 @@ package com.gg.server.domain.game.service;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
-import com.gg.server.config.RedisInitializer;
-import com.gg.server.config.TestRedisConfig;
+import com.gg.server.utils.annotation.IntegrationTest;
 import com.gg.server.domain.game.data.Game;
 import com.gg.server.domain.game.data.GameRepository;
 import com.gg.server.domain.game.dto.request.RankResultReqDto;
@@ -33,14 +32,9 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
-import org.springframework.test.context.ContextConfiguration;
 import org.springframework.transaction.annotation.Transactional;
 
-@SpringBootTest
-@Import(TestRedisConfig.class)
-@ContextConfiguration(initializers = RedisInitializer.class)
+@IntegrationTest
 @RequiredArgsConstructor
 @Transactional
 public class GameServiceTest {

--- a/src/test/java/com/gg/server/domain/game/service/GameStatusServiceTest.java
+++ b/src/test/java/com/gg/server/domain/game/service/GameStatusServiceTest.java
@@ -2,6 +2,7 @@ package com.gg.server.domain.game.service;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
+import com.gg.server.utils.annotation.IntegrationTest;
 import com.gg.server.domain.game.data.Game;
 import com.gg.server.domain.game.data.GameRepository;
 import com.gg.server.domain.game.type.Mode;
@@ -26,10 +27,9 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
-@SpringBootTest
+@IntegrationTest
 @RequiredArgsConstructor
 @Transactional
 public class GameStatusServiceTest {

--- a/src/test/java/com/gg/server/domain/item/controller/ItemGiftControllerTest.java
+++ b/src/test/java/com/gg/server/domain/item/controller/ItemGiftControllerTest.java
@@ -1,6 +1,7 @@
 package com.gg.server.domain.item.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gg.server.utils.annotation.IntegrationTest;
 import com.gg.server.domain.item.dto.ItemGiftRequestDto;
 import com.gg.server.domain.item.service.ItemService;
 import com.gg.server.domain.user.dto.UserDto;
@@ -12,7 +13,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
@@ -24,7 +24,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 
 @RequiredArgsConstructor
-@SpringBootTest
+@IntegrationTest
 @AutoConfigureMockMvc
 @Transactional
 class ItemGiftControllerTest {

--- a/src/test/java/com/gg/server/domain/item/controller/ItemPurchaseControllerTest.java
+++ b/src/test/java/com/gg/server/domain/item/controller/ItemPurchaseControllerTest.java
@@ -1,6 +1,7 @@
 package com.gg.server.domain.item.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gg.server.utils.annotation.IntegrationTest;
 import com.gg.server.domain.item.service.ItemService;
 import com.gg.server.domain.user.dto.UserDto;
 import com.gg.server.global.security.jwt.utils.AuthTokenProvider;
@@ -11,7 +12,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 import javax.transaction.Transactional;
@@ -21,7 +21,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 
 @RequiredArgsConstructor
-@SpringBootTest
+@IntegrationTest
 @AutoConfigureMockMvc
 @Transactional
 class ItemPurchaseControllerTest {

--- a/src/test/java/com/gg/server/domain/item/controller/ItemStoreListControllerTest.java
+++ b/src/test/java/com/gg/server/domain/item/controller/ItemStoreListControllerTest.java
@@ -1,5 +1,6 @@
 package com.gg.server.domain.item.controller;
 
+import com.gg.server.utils.annotation.IntegrationTest;
 import com.gg.server.domain.item.data.ItemRepository;
 import com.gg.server.domain.item.dto.ItemStoreListResponseDto;
 import com.gg.server.domain.item.dto.ItemStoreResponseDto;
@@ -13,7 +14,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
@@ -27,7 +27,7 @@ import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuild
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @RequiredArgsConstructor
-@SpringBootTest
+@IntegrationTest
 @AutoConfigureMockMvc
 @Transactional
 class ItemStoreListControllerTest {

--- a/src/test/java/com/gg/server/domain/item/controller/UserItemResponseControllerTest.java
+++ b/src/test/java/com/gg/server/domain/item/controller/UserItemResponseControllerTest.java
@@ -1,20 +1,20 @@
 package com.gg.server.domain.item.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gg.server.utils.annotation.IntegrationTest;
 import com.gg.server.domain.item.service.ItemService;
 import com.gg.server.utils.TestDataUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest
+@IntegrationTest
 @AutoConfigureMockMvc
 @Transactional
 public class UserItemResponseControllerTest {

--- a/src/test/java/com/gg/server/domain/match/service/MatchBothServiceTest.java
+++ b/src/test/java/com/gg/server/domain/match/service/MatchBothServiceTest.java
@@ -2,6 +2,7 @@ package com.gg.server.domain.match.service;
 
 import com.gg.server.admin.penalty.data.PenaltyAdminRepository;
 import com.gg.server.admin.penalty.type.PenaltyKey;
+import com.gg.server.config.RedisInitializer;
 import com.gg.server.config.TestRedisConfig;
 import com.gg.server.domain.game.data.Game;
 import com.gg.server.domain.game.data.GameRepository;
@@ -36,10 +37,12 @@ import org.springframework.context.annotation.Import;
 import org.springframework.data.redis.connection.RedisConnection;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
 @Import(TestRedisConfig.class)
+@ContextConfiguration(initializers = RedisInitializer.class)
 @Transactional
 @AutoConfigureMockMvc
 @RequiredArgsConstructor

--- a/src/test/java/com/gg/server/domain/match/service/MatchBothServiceTest.java
+++ b/src/test/java/com/gg/server/domain/match/service/MatchBothServiceTest.java
@@ -2,8 +2,7 @@ package com.gg.server.domain.match.service;
 
 import com.gg.server.admin.penalty.data.PenaltyAdminRepository;
 import com.gg.server.admin.penalty.type.PenaltyKey;
-import com.gg.server.config.RedisInitializer;
-import com.gg.server.config.TestRedisConfig;
+import com.gg.server.utils.annotation.IntegrationTest;
 import com.gg.server.domain.game.data.Game;
 import com.gg.server.domain.game.data.GameRepository;
 import com.gg.server.domain.match.data.RedisMatchTimeRepository;
@@ -32,17 +31,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.data.redis.connection.RedisConnection;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.test.context.ContextConfiguration;
 import org.springframework.transaction.annotation.Transactional;
 
-@SpringBootTest
-@Import(TestRedisConfig.class)
-@ContextConfiguration(initializers = RedisInitializer.class)
+@IntegrationTest
 @Transactional
 @AutoConfigureMockMvc
 @RequiredArgsConstructor

--- a/src/test/java/com/gg/server/domain/match/service/MatchServiceTest.java
+++ b/src/test/java/com/gg/server/domain/match/service/MatchServiceTest.java
@@ -1,8 +1,7 @@
 package com.gg.server.domain.match.service;
 
 import com.gg.server.admin.penalty.data.PenaltyAdminRepository;
-import com.gg.server.config.RedisInitializer;
-import com.gg.server.config.TestRedisConfig;
+import com.gg.server.utils.annotation.IntegrationTest;
 import com.gg.server.domain.game.data.Game;
 import com.gg.server.domain.game.data.GameRepository;
 import com.gg.server.domain.game.type.Mode;
@@ -54,18 +53,13 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.data.redis.connection.RedisConnection;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.test.context.ContextConfiguration;
 import org.springframework.transaction.annotation.Transactional;
 
-@SpringBootTest
+@IntegrationTest
 @Transactional
-@Import(TestRedisConfig.class)
-@ContextConfiguration(initializers = RedisInitializer.class)
 @RequiredArgsConstructor
 class MatchServiceTest {
     @Autowired

--- a/src/test/java/com/gg/server/domain/match/service/MatchServiceTest.java
+++ b/src/test/java/com/gg/server/domain/match/service/MatchServiceTest.java
@@ -1,6 +1,7 @@
 package com.gg.server.domain.match.service;
 
 import com.gg.server.admin.penalty.data.PenaltyAdminRepository;
+import com.gg.server.config.RedisInitializer;
 import com.gg.server.config.TestRedisConfig;
 import com.gg.server.domain.game.data.Game;
 import com.gg.server.domain.game.data.GameRepository;
@@ -58,11 +59,13 @@ import org.springframework.context.annotation.Import;
 import org.springframework.data.redis.connection.RedisConnection;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
 @Transactional
 @Import(TestRedisConfig.class)
+@ContextConfiguration(initializers = RedisInitializer.class)
 @RequiredArgsConstructor
 class MatchServiceTest {
     @Autowired

--- a/src/test/java/com/gg/server/domain/megaphone/controller/MegaphoneControllerTest.java
+++ b/src/test/java/com/gg/server/domain/megaphone/controller/MegaphoneControllerTest.java
@@ -8,6 +8,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.gg.server.admin.item.dto.ItemUpdateRequestDto;
+import com.gg.server.utils.annotation.IntegrationTest;
 import com.gg.server.domain.item.data.Item;
 import com.gg.server.domain.item.type.ItemType;
 import com.gg.server.domain.megaphone.data.Megaphone;
@@ -31,13 +32,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
-@SpringBootTest
+@IntegrationTest
 @AutoConfigureMockMvc
 class MegaphoneControllerTest {
     @Autowired

--- a/src/test/java/com/gg/server/domain/noti/controller/NotiControllerTest.java
+++ b/src/test/java/com/gg/server/domain/noti/controller/NotiControllerTest.java
@@ -1,6 +1,7 @@
 package com.gg.server.domain.noti.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gg.server.utils.annotation.IntegrationTest;
 import com.gg.server.domain.noti.data.Noti;
 import com.gg.server.domain.noti.data.NotiRepository;
 import com.gg.server.domain.noti.dto.NotiListResponseDto;
@@ -17,7 +18,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.web.servlet.MockMvc;
 
 import javax.transaction.Transactional;
@@ -29,7 +29,7 @@ import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuild
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @RequiredArgsConstructor
-@SpringBootTest
+@IntegrationTest
 @AutoConfigureMockMvc
 @Transactional
 class NotiControllerTest {

--- a/src/test/java/com/gg/server/domain/noti/service/NotiServiceTest.java
+++ b/src/test/java/com/gg/server/domain/noti/service/NotiServiceTest.java
@@ -1,5 +1,6 @@
 package com.gg.server.domain.noti.service;
 
+import com.gg.server.utils.annotation.IntegrationTest;
 import com.gg.server.domain.noti.data.Noti;
 import com.gg.server.domain.noti.data.NotiRepository;
 import com.gg.server.domain.noti.type.NotiType;
@@ -14,7 +15,6 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 
 import javax.transaction.Transactional;
 
@@ -23,7 +23,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 @RequiredArgsConstructor
-@SpringBootTest
+@IntegrationTest
 @Slf4j
 class NotiServiceTest {
 

--- a/src/test/java/com/gg/server/domain/rank/controller/RankControllerTest.java
+++ b/src/test/java/com/gg/server/domain/rank/controller/RankControllerTest.java
@@ -1,8 +1,7 @@
 package com.gg.server.domain.rank.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.gg.server.config.RedisInitializer;
-import com.gg.server.config.TestRedisConfig;
+import com.gg.server.utils.annotation.IntegrationTest;
 import com.gg.server.domain.rank.dto.ExpRankPageResponseDto;
 import com.gg.server.domain.rank.dto.RankDto;
 import com.gg.server.domain.rank.dto.RankPageResponseDto;
@@ -21,9 +20,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
-import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -35,10 +31,8 @@ import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuild
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 
-@SpringBootTest
+@IntegrationTest
 @Transactional
-@Import(TestRedisConfig.class)
-@ContextConfiguration(initializers = RedisInitializer.class)
 @AutoConfigureMockMvc
 class RankControllerTest {
 

--- a/src/test/java/com/gg/server/domain/rank/controller/RankControllerTest.java
+++ b/src/test/java/com/gg/server/domain/rank/controller/RankControllerTest.java
@@ -1,6 +1,7 @@
 package com.gg.server.domain.rank.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gg.server.config.RedisInitializer;
 import com.gg.server.config.TestRedisConfig;
 import com.gg.server.domain.rank.dto.ExpRankPageResponseDto;
 import com.gg.server.domain.rank.dto.RankDto;
@@ -22,6 +23,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -36,6 +38,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest
 @Transactional
 @Import(TestRedisConfig.class)
+@ContextConfiguration(initializers = RedisInitializer.class)
 @AutoConfigureMockMvc
 class RankControllerTest {
 

--- a/src/test/java/com/gg/server/domain/rank/redis/RankRedisRepositoryTest.java
+++ b/src/test/java/com/gg/server/domain/rank/redis/RankRedisRepositoryTest.java
@@ -1,16 +1,16 @@
 package com.gg.server.domain.rank.redis;
 
+import com.gg.server.utils.annotation.IntegrationTest;
 import com.gg.server.domain.rank.exception.RedisDataNotFoundException;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 
 import java.util.List;
 
-@SpringBootTest
+@IntegrationTest
 class RankRedisRepositoryTest {
 
 
@@ -216,7 +216,7 @@ class RankRedisRepositoryTest {
     }
 
     @Test
-    @DisplayName("")
+    @DisplayName("유저 랭크를 삭제한다")
     public void deleteUserRank () throws Exception
     {
         //given

--- a/src/test/java/com/gg/server/domain/rank/redis/RedisTransactionTest.java
+++ b/src/test/java/com/gg/server/domain/rank/redis/RedisTransactionTest.java
@@ -1,15 +1,15 @@
 package com.gg.server.domain.rank.redis;
 
 
+import com.gg.server.utils.annotation.IntegrationTestWithRedisTransaction;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.transaction.annotation.Transactional;
 
-@SpringBootTest
+@IntegrationTestWithRedisTransaction
 public class RedisTransactionTest {
 
     @Autowired

--- a/src/test/java/com/gg/server/domain/season/SeasonTestController.java
+++ b/src/test/java/com/gg/server/domain/season/SeasonTestController.java
@@ -1,11 +1,19 @@
 package com.gg.server.domain.season;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gg.server.domain.season.data.Season;
+import com.gg.server.domain.season.data.SeasonRepository;
+import com.gg.server.domain.season.dto.SeasonListResDto;
+import com.gg.server.domain.season.dto.SeasonResDto;
 import com.gg.server.domain.season.service.SeasonService;
-import com.gg.server.domain.season.data.*;
-import com.gg.server.domain.season.dto.*;
 import com.gg.server.global.security.jwt.utils.AuthTokenProvider;
 import com.gg.server.utils.TestDataUtils;
+import com.gg.server.utils.annotation.IntegrationTest;
+import java.time.LocalDateTime;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.apache.http.HttpHeaders;
 import org.junit.jupiter.api.BeforeEach;
@@ -13,24 +21,13 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
-import java.util.List;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-
-//@WebMvcTest(SeasonController.class)
-//@MockBeans({
-//        @MockBean(UserRepository.class)
-//})
 @RequiredArgsConstructor
-@SpringBootTest
+@IntegrationTest
 @AutoConfigureMockMvc
 public class SeasonTestController {
 

--- a/src/test/java/com/gg/server/domain/season/SeasonTriggerTest.java
+++ b/src/test/java/com/gg/server/domain/season/SeasonTriggerTest.java
@@ -1,6 +1,7 @@
 package com.gg.server.domain.season;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gg.server.utils.annotation.IntegrationTest;
 import com.gg.server.domain.game.type.Mode;
 import com.gg.server.domain.season.data.Season;
 import com.gg.server.domain.season.data.SeasonRepository;
@@ -16,13 +17,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cglib.proxy.UndeclaredThrowableException;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
-@SpringBootTest
+@IntegrationTest
 @AutoConfigureMockMvc
 @Slf4j
 public class SeasonTriggerTest {

--- a/src/test/java/com/gg/server/domain/tournament/controller/TournamentFindControllerTest.java
+++ b/src/test/java/com/gg/server/domain/tournament/controller/TournamentFindControllerTest.java
@@ -1,6 +1,7 @@
 package com.gg.server.domain.tournament.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gg.server.utils.annotation.IntegrationTest;
 import com.gg.server.domain.tournament.data.Tournament;
 import com.gg.server.domain.tournament.data.TournamentUser;
 import com.gg.server.domain.tournament.data.TournamentUserRepository;
@@ -26,7 +27,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
@@ -38,7 +38,7 @@ import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuild
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest
+@IntegrationTest
 @AutoConfigureMockMvc
 @Transactional
 @RequiredArgsConstructor

--- a/src/test/java/com/gg/server/domain/tournament/controller/TournamentGameControllerTest.java
+++ b/src/test/java/com/gg/server/domain/tournament/controller/TournamentGameControllerTest.java
@@ -1,7 +1,7 @@
 package com.gg.server.domain.tournament.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.gg.server.domain.game.data.Game;
+import com.gg.server.utils.annotation.IntegrationTest;
 import com.gg.server.domain.game.type.Mode;
 import com.gg.server.domain.season.data.Season;
 import com.gg.server.domain.tournament.data.Tournament;
@@ -26,7 +26,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -35,11 +34,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 import java.time.LocalDateTime;
-import java.util.List;
 import java.util.Objects;
-import java.util.Random;
 
-@SpringBootTest
+@IntegrationTest
 @AutoConfigureMockMvc
 @Transactional
 @RequiredArgsConstructor

--- a/src/test/java/com/gg/server/domain/tournament/controller/TournamentSchedulerTest.java
+++ b/src/test/java/com/gg/server/domain/tournament/controller/TournamentSchedulerTest.java
@@ -11,6 +11,7 @@ import com.gg.server.domain.tournament.service.TournamentService;
 import com.gg.server.domain.tournament.type.TournamentStatus;
 import com.gg.server.global.scheduler.TournamentScheduler;
 import com.gg.server.utils.TestDataUtils;
+import com.gg.server.utils.annotation.IntegrationTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,7 +24,7 @@ import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.*;
 
-@SpringBootTest
+@IntegrationTest
 @Transactional
 public class TournamentSchedulerTest {
     @Autowired

--- a/src/test/java/com/gg/server/domain/tournament/service/TournamentServiceTest.java
+++ b/src/test/java/com/gg/server/domain/tournament/service/TournamentServiceTest.java
@@ -23,10 +23,12 @@ import com.gg.server.domain.user.exception.UserNotFoundException;
 import com.gg.server.domain.user.type.RacketType;
 import com.gg.server.domain.user.type.RoleType;
 import com.gg.server.domain.user.type.SnsType;
+import com.gg.server.utils.annotation.UnitTest;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -35,6 +37,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+@UnitTest
 @ExtendWith(MockitoExtension.class)
 class TournamentServiceTest {
     @Mock
@@ -102,6 +105,23 @@ class TournamentServiceTest {
     @DisplayName("토너먼트_유저_참가_취소_테스트")
     class cancelTournamentUserRegistration {
         @Test
+        @DisplayName("유저_참가_취소_성공")
+        @Disabled
+        void success() {
+            // given
+            Tournament tournament = createTournament(1L, TournamentStatus.BEFORE,
+                LocalDateTime.now(), LocalDateTime.now().plusHours(2));
+            User user = createUser("testUser");
+            TournamentUser tournamentUser = new TournamentUser(user, tournament, true, LocalDateTime.now());
+            tournament.addTournamentUser(tournamentUser);
+            given(tournamentRepository.findById(tournament.getId())).willReturn(Optional.of(tournament));
+            given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
+
+            // when, then
+            tournamentService.cancelTournamentUserRegistration(tournament.getId(), UserDto.from(user));
+        }
+
+        @Test
         @DisplayName("찾을_수_없는_토너먼트")
         void tournamentNotFound() {
             // given
@@ -112,6 +132,22 @@ class TournamentServiceTest {
             // when, then
             assertThatThrownBy(()->tournamentService.cancelTournamentUserRegistration(tournamentId, UserDto.from(user)))
                 .isInstanceOf(TournamentNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("db에_없는_유저")
+        @Disabled
+        void userNotFound() {
+            // given
+            UserDto userDto = UserDto.builder().id(1L).intraId("testUser").build();
+            Tournament tournament = createTournament(1L, TournamentStatus.BEFORE,
+                LocalDateTime.now(), LocalDateTime.now().plusHours(2));
+            given(tournamentRepository.findById(tournament.getId())).willReturn(Optional.of(tournament));
+            given(userRepository.findById(userDto.getId())).willReturn(Optional.empty());
+
+            // when, then
+            assertThatThrownBy(()->tournamentService.cancelTournamentUserRegistration(tournament.getId(), userDto))
+                .isInstanceOf(UserNotFoundException.class);
         }
     }
 

--- a/src/test/java/com/gg/server/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/gg/server/domain/user/controller/UserControllerTest.java
@@ -10,8 +10,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.gg.server.admin.item.dto.ItemUpdateRequestDto;
-import com.gg.server.config.RedisInitializer;
-import com.gg.server.config.TestRedisConfig;
+import com.gg.server.utils.annotation.IntegrationTest;
 import com.gg.server.domain.coin.data.CoinHistoryRepository;
 import com.gg.server.domain.coin.data.CoinPolicyRepository;
 import com.gg.server.domain.coin.service.CoinHistoryService;
@@ -72,12 +71,9 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -91,9 +87,7 @@ import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuild
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import org.springframework.web.multipart.MultipartFile;
 
-@SpringBootTest
-@Import(TestRedisConfig.class)
-@ContextConfiguration(initializers = RedisInitializer.class)
+@IntegrationTest
 @AutoConfigureMockMvc
 @Transactional
 @Slf4j

--- a/src/test/java/com/gg/server/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/gg/server/domain/user/controller/UserControllerTest.java
@@ -10,6 +10,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.gg.server.admin.item.dto.ItemUpdateRequestDto;
+import com.gg.server.config.RedisInitializer;
 import com.gg.server.config.TestRedisConfig;
 import com.gg.server.domain.coin.data.CoinHistoryRepository;
 import com.gg.server.domain.coin.data.CoinPolicyRepository;
@@ -76,6 +77,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -91,6 +93,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 @SpringBootTest
 @Import(TestRedisConfig.class)
+@ContextConfiguration(initializers = RedisInitializer.class)
 @AutoConfigureMockMvc
 @Transactional
 @Slf4j

--- a/src/test/java/com/gg/server/utils/annotation/IntegrationTest.java
+++ b/src/test/java/com/gg/server/utils/annotation/IntegrationTest.java
@@ -1,0 +1,30 @@
+package com.gg.server.utils.annotation;
+
+import com.gg.server.utils.config.RedisInitializer;
+import com.gg.server.utils.config.TestRedisConfig;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.Tag;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ContextConfiguration;
+
+/**
+ * 통합테스트 환경의 의존성 관리를 위한 어노테이션.
+ *
+ * <p>
+ *   기본적으로 redis 트랜잭션을 false로 처리하는 설정을 Import 한다.
+ * </p>
+ *
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@SpringBootTest
+@Import(TestRedisConfig.class)
+@ContextConfiguration(initializers = RedisInitializer.class)
+@Tag(TestType.INTEGRATION_TEST)
+public @interface IntegrationTest {
+
+}

--- a/src/test/java/com/gg/server/utils/annotation/IntegrationTestAspect.java
+++ b/src/test/java/com/gg/server/utils/annotation/IntegrationTestAspect.java
@@ -1,0 +1,24 @@
+package com.gg.server.utils.annotation;
+
+import com.gg.server.domain.rank.redis.RankRedisRepository;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.After;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+public class IntegrationTestAspect {
+
+    @Autowired
+    private RankRedisRepository rankRedisRepository;
+
+    /**
+     * 통합테스트 종료 후 redis 데이터 삭제
+     */
+    @After("execution(* *(..)) && @within(integrationTest)")
+    public void afterTest(JoinPoint joinPoint, IntegrationTest integrationTest) {
+        rankRedisRepository.deleteAll();
+    }
+}

--- a/src/test/java/com/gg/server/utils/annotation/IntegrationTestWithRedisTransaction.java
+++ b/src/test/java/com/gg/server/utils/annotation/IntegrationTestWithRedisTransaction.java
@@ -1,0 +1,27 @@
+package com.gg.server.utils.annotation;
+
+import com.gg.server.utils.config.RedisInitializer;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.Tag;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ContextConfiguration;
+
+/**
+ * 통합테스트 환경의 의존성 관리를 위한 어노테이션.
+ *
+ * <p>
+ *   기본적으로 redis 트랜잭션을 false로 처리하는 설정을 Import 한다.
+ * </p>
+ *
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@SpringBootTest
+@ContextConfiguration(initializers = RedisInitializer.class)
+@Tag(TestType.INTEGRATION_TEST)
+public @interface IntegrationTestWithRedisTransaction {
+
+}

--- a/src/test/java/com/gg/server/utils/annotation/TestType.java
+++ b/src/test/java/com/gg/server/utils/annotation/TestType.java
@@ -1,0 +1,14 @@
+package com.gg.server.utils.annotation;
+
+/**
+ * TestType.
+ *
+ * <p>
+ *  Tag 에서 사용할 테스트 타입을 정의
+ * </p>
+ *
+ */
+public class TestType {
+    public static final String UNIT_TEST = "UnitTest";
+    public static final String INTEGRATION_TEST = "IntegrationTest";
+}

--- a/src/test/java/com/gg/server/utils/annotation/UnitTest.java
+++ b/src/test/java/com/gg/server/utils/annotation/UnitTest.java
@@ -1,0 +1,18 @@
+package com.gg.server.utils.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.Tag;
+
+/**
+ * Unit 테스트를 위한 어노테이션
+ *
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Tag(TestType.UNIT_TEST)
+public @interface UnitTest {
+
+}

--- a/src/test/java/com/gg/server/utils/config/RedisInitializer.java
+++ b/src/test/java/com/gg/server/utils/config/RedisInitializer.java
@@ -1,4 +1,4 @@
-package com.gg.server.config;
+package com.gg.server.utils.config;
 
 import com.redis.testcontainers.RedisContainer;
 import org.springframework.boot.test.util.TestPropertyValues;

--- a/src/test/java/com/gg/server/utils/config/TestRedisConfig.java
+++ b/src/test/java/com/gg/server/utils/config/TestRedisConfig.java
@@ -1,4 +1,4 @@
-package com.gg.server.config;
+package com.gg.server.utils.config;
 
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -15,9 +15,6 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
  *  테스트에서 redis Transaction을 사용하지 않기 위한 설정
  *  해당 빈을 사용할 경우 각 테스트마다 redis 데이터 초기화 필요
  * </p>
- *
- * @author : middlefitting
- * @since : 2023/12/08
  */
 @TestConfiguration
 public class TestRedisConfig {

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -147,9 +147,6 @@ spring:
   # Redis 설정
   cache:
     type: redis
-  redis:
-    host: 127.0.0.1
-    port: 6379
   sql:
     init:
       mode: always


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 테스트 환경을 개선하고 테스트 CI를 구축합니다.
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->

### 테스트 환경 설정
- test(전체 테스트), integrationTest(통합 테스트), unitTest(유닛 테스트) 를 @ Tag 애노테이션 기반으로 분리하여 실행할 수 있습니다.

### 테스트를 설정 간편화를 위한 어노테이션 추가
> @ IntegrationTest
- 레디스 트랜잭션을 사용하지 않고 통합테스트를 진행합니다.
- 기타 @ SpringBoot, @ Tag, 테스트 컨테이너 Redis 의존성을 설정합니다

> @ IntegrationTestWithRedisTransaction
- 레디스 트랜잭션을 사용해서 통합테스트를 진행합니다.
- 기타 @ SpringBoot, @ Tag, 테스트 컨테이너 Redis 의존성을 설정합니다

> @ UnitTest
- @ Tag를 설정합니다

### jacoco 도입
- 코드 커버리지 관리를 목적으로 도입하였습니다.
- jacocoTestReport 테스트 코드 실행에 따른 보고서를 만듭니다.
- jacocoTestCoverageVerification 테스트 코드 보고서를 통해 검증을 수행합니다. 현재는 기존 커버리지가 낮아 검증 조건을 0으로 설정하였습니다.
- 테스트 -> jacocoTestReport -> jacocoTestCoverageVerification 플로우로 진행합니다
- 리포트는 build/reports/jacoco/tests/html/index.html 파일을 통해 확인할 수 있습니다.
<img width="736" alt="image" src="https://github.com/42organization/42gg.server.dev.v2/assets/76660692/62ba9b2a-f7d5-4d3a-aee0-f95c2c1c8aa3">

### CodeCov 도입
- jacoco 리포트를 기반으로 코드 커버리지를 시각화합니다. 
- 풀리퀘 당시 보고서를 바탕으로 코드가 테스트를 제대로 작성하였는지 확인할 수 있습니다.
- 보고서 페이지는 ci 결과에서 들어갈 수 있습니다.
<img width="654" alt="image" src="https://github.com/42organization/42gg.server.dev.v2/assets/76660692/3309d030-064c-4fb0-94fe-345e5042e147">

- 기간, 브랜치 별로 커버리지를 확인할 수 있습니다.
<img width="1348" alt="image" src="https://github.com/42organization/42gg.server.dev.v2/assets/76660692/3b339991-da31-4b53-8dd2-b42d6555a70b">

- flag 별로 커버리지를 확인할 수 있습니다. (커버리지 비율은 소스 트리 상에서 현재 플래그에 따른 비율이 보이지 않지만 실제 파일에서 플래그를 적용할 수 있습니다)
<img width="856" alt="image" src="https://github.com/42organization/42gg.server.dev.v2/assets/76660692/f1365a69-7369-439c-9039-fb59a6eecb25">
<img width="1366" alt="image" src="https://github.com/42organization/42gg.server.dev.v2/assets/76660692/c2642982-293b-4dab-99f3-f0a468c643ad">
<img width="1286" alt="image" src="https://github.com/42organization/42gg.server.dev.v2/assets/76660692/40b9f9c3-a000-41b0-809d-4f15b03a59f5">


### Test CI 추가
- mysql, redis 테스트를 docker 컨테이너를 사용해서 진행하기 때문에 git acton에서도 테스트가 가능합니다.
- 깃허브 액션으로 test ci를 dev, main 브랜치 풀리퀘, 푸쉬 상황에 진행합니다
- 앞으로는 테스트 ci를 통과하지 못하면 풀리퀘를 거부하도록 진행할 예정입니다.
- 액션 이후에는 codecov 타깃 커버리지 검증을 수행합니다
<img width="489" alt="image" src="https://github.com/42organization/42gg.server.dev.v2/assets/76660692/b25c70a5-9aa4-4449-9ecb-893223fdeffc">


 ## ✅ 변경로직 <!-- 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
  - 테스트 환경에서 redis -> 테스트 컨테이너를 사용하도록 변경
 ## 💡Issue 번호 <!-- issue number을 link 시켜주세요 (ex. "- close #4242") -->
 - #374