### PR TITLE
✨ [Feature] 토너먼트 게임 결과 수정 api 추가

### DIFF
--- a/src/main/java/com/gg/server/admin/tournament/controller/TournamentAdminController.java
+++ b/src/main/java/com/gg/server/admin/tournament/controller/TournamentAdminController.java
@@ -1,11 +1,10 @@
 package com.gg.server.admin.tournament.controller;
 
-import com.gg.server.admin.tournament.dto.TournamentAdminAddUserRequestDto;
-import com.gg.server.admin.tournament.dto.TournamentAdminAddUserResponseDto;
-import com.gg.server.admin.tournament.dto.TournamentAdminUpdateRequestDto;
+import com.gg.server.admin.tournament.dto.*;
 import com.gg.server.admin.tournament.service.TournamentAdminService;
 import javax.validation.Valid;
 
+import com.gg.server.domain.team.dto.TeamReqDto;
 import com.gg.server.domain.tournament.dto.TournamentUserListResponseDto;
 import lombok.AllArgsConstructor;
 import org.checkerframework.checker.index.qual.Positive;
@@ -13,7 +12,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
-import com.gg.server.admin.tournament.dto.TournamentAdminCreateRequestDto;
 
 @RestController
 @AllArgsConstructor
@@ -99,5 +97,18 @@ public class TournamentAdminController {
         tournamentAdminService.deleteTournamentUser(tournamentId, userId);
 
         return new ResponseEntity<Void>(HttpStatus.NO_CONTENT);
+    }
+
+    /**
+     * <p>토너먼트 게임 점수 정보 수정</p>
+     * @param tournamentId 타겟 토너먼트 id
+     * @param tournamentGameUpdateReqDto 수정할 게임 정보
+     * @return HttpStatus.OK
+     */
+    @PatchMapping("{tournamentId}/games")
+    public ResponseEntity<Void> updateTournamentGame(@PathVariable @Positive Long tournamentId,
+                                                     @Valid @RequestBody TournamentGameUpdateReqDto tournamentGameUpdateReqDto) {
+        tournamentAdminService.updateTournamentGame(tournamentId, tournamentGameUpdateReqDto);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/gg/server/admin/tournament/controller/TournamentAdminController.java
+++ b/src/main/java/com/gg/server/admin/tournament/controller/TournamentAdminController.java
@@ -4,7 +4,6 @@ import com.gg.server.admin.tournament.dto.*;
 import com.gg.server.admin.tournament.service.TournamentAdminService;
 import javax.validation.Valid;
 
-import com.gg.server.domain.team.dto.TeamReqDto;
 import com.gg.server.domain.tournament.dto.TournamentUserListResponseDto;
 import lombok.AllArgsConstructor;
 import org.checkerframework.checker.index.qual.Positive;
@@ -107,7 +106,7 @@ public class TournamentAdminController {
      */
     @PatchMapping("{tournamentId}/games")
     public ResponseEntity<Void> updateTournamentGame(@PathVariable @Positive Long tournamentId,
-                                                     @Valid @RequestBody TournamentGameUpdateReqDto tournamentGameUpdateReqDto) {
+                                                     @Valid @RequestBody TournamentGameUpdateRequestDto tournamentGameUpdateReqDto) {
         tournamentAdminService.updateTournamentGame(tournamentId, tournamentGameUpdateReqDto);
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/com/gg/server/admin/tournament/dto/TournamentGameUpdateReqDto.java
+++ b/src/main/java/com/gg/server/admin/tournament/dto/TournamentGameUpdateReqDto.java
@@ -1,0 +1,38 @@
+package com.gg.server.admin.tournament.dto;
+
+import com.gg.server.domain.team.dto.TeamReqDto;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class TournamentGameUpdateReqDto {
+
+    @NotNull
+    private Long tournamentGameId;
+
+    @NotNull
+    private Long nextTournamentGameId;
+    @NotNull
+    @Valid
+    private TeamReqDto team1;
+    @NotNull
+    @Valid
+    private TeamReqDto team2;
+
+    @Override
+    public String toString() {
+        return "TournamentGameUpdateReqDto{" +
+                "tournamentGameId=" + tournamentGameId +
+                ", nextTournamentGameId=" + nextTournamentGameId +
+                ", team1=" + team1 +
+                ", team2=" + team2 +
+                '}';
+    }
+}

--- a/src/main/java/com/gg/server/admin/tournament/dto/TournamentGameUpdateRequestDto.java
+++ b/src/main/java/com/gg/server/admin/tournament/dto/TournamentGameUpdateRequestDto.java
@@ -12,7 +12,7 @@ import javax.validation.constraints.NotNull;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public class TournamentGameUpdateReqDto {
+public class TournamentGameUpdateRequestDto {
 
     @NotNull
     private Long tournamentGameId;

--- a/src/main/java/com/gg/server/admin/tournament/exception/TournamentNotLiveException.java
+++ b/src/main/java/com/gg/server/admin/tournament/exception/TournamentNotLiveException.java
@@ -1,0 +1,11 @@
+package com.gg.server.admin.tournament.exception;
+
+
+import com.gg.server.global.exception.ErrorCode;
+import com.gg.server.global.exception.custom.CustomRuntimeException;
+
+public class TournamentNotLiveException extends CustomRuntimeException {
+    public TournamentNotLiveException() {
+        super(ErrorCode.TOURNAMENT_NOT_LIVE.getMessage(), ErrorCode.TOURNAMENT_NOT_LIVE);
+    }
+}

--- a/src/main/java/com/gg/server/admin/tournament/service/TournamentAdminService.java
+++ b/src/main/java/com/gg/server/admin/tournament/service/TournamentAdminService.java
@@ -5,6 +5,7 @@ import com.gg.server.admin.tournament.exception.TournamentNotLiveException;
 import com.gg.server.admin.tournament.exception.TournamentTitleConflictException;
 import com.gg.server.domain.game.data.GameRepository;
 import com.gg.server.domain.game.data.Game;
+import com.gg.server.domain.game.exception.ScoreNotInvalidException;
 import com.gg.server.domain.game.service.GameService;
 import com.gg.server.domain.game.type.StatusType;
 import com.gg.server.domain.team.data.Team;
@@ -273,10 +274,10 @@ public class TournamentAdminService {
         if (reqDto.getTeam1().getScore() + reqDto.getTeam2().getScore() > 3 ||
                 reqDto.getTeam1().getScore() + reqDto.getTeam2().getScore() < 2 ||
                 reqDto.getTeam1().getScore() == reqDto.getTeam2().getScore()) {
-            throw new InvalidParameterException("점수를 잘못 입력했습니다.", ErrorCode.VALID_FAILED);
+            throw new ScoreNotInvalidException();
         }
         Tournament tournament = tournamentRepository.findById(tournamentId)
-            .orElseThrow(() -> new TournamentNotFoundException("target tournament not found", ErrorCode.TOURNAMENT_NOT_FOUND));
+            .orElseThrow(TournamentNotFoundException::new);
         if (tournament.getStatus() != TournamentStatus.LIVE) {
             throw new TournamentNotLiveException();
         }

--- a/src/main/java/com/gg/server/admin/tournament/service/TournamentAdminService.java
+++ b/src/main/java/com/gg/server/admin/tournament/service/TournamentAdminService.java
@@ -6,10 +6,8 @@ import com.gg.server.admin.tournament.exception.TournamentTitleConflictException
 import com.gg.server.domain.game.data.GameRepository;
 import com.gg.server.domain.game.data.Game;
 import com.gg.server.domain.game.exception.ScoreNotInvalidException;
-import com.gg.server.domain.game.service.GameService;
 import com.gg.server.domain.game.type.StatusType;
 import com.gg.server.domain.team.data.Team;
-import com.gg.server.domain.team.dto.TeamReqDto;
 import com.gg.server.domain.tournament.data.TournamentGame;
 import com.gg.server.domain.tournament.data.Tournament;
 import com.gg.server.domain.tournament.data.TournamentRepository;
@@ -29,7 +27,6 @@ import com.gg.server.global.exception.ErrorCode;
 import com.gg.server.global.exception.custom.InvalidParameterException;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Objects;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -270,7 +267,7 @@ public class TournamentAdminService {
      * @throws TournamentUpdateException 토너먼트가 시작되지 않았을 때
      */
     @Transactional
-    public void updateTournamentGame(Long tournamentId, TournamentGameUpdateReqDto reqDto) {
+    public void updateTournamentGame(Long tournamentId, TournamentGameUpdateRequestDto reqDto) {
         if (reqDto.getTeam1().getScore() + reqDto.getTeam2().getScore() > 3 ||
                 reqDto.getTeam1().getScore() + reqDto.getTeam2().getScore() < 2 ||
                 reqDto.getTeam1().getScore() == reqDto.getTeam2().getScore()) {
@@ -296,7 +293,7 @@ public class TournamentAdminService {
      * @param game 수정될 게임
      * @param reqDto 수정할 게임 정보
      */
-    private void updateTeamScore(Game game, TournamentGameUpdateReqDto reqDto){
+    private void updateTeamScore(Game game, TournamentGameUpdateRequestDto reqDto){
 
         List<Team> teams = game.getTeams();
         Team team1 = teams.stream().filter(t->t.getId().equals(reqDto.getTeam1().getTeamId())).findAny().orElseThrow(TournamentGameNotFoundException::new);
@@ -318,13 +315,9 @@ public class TournamentAdminService {
      * @param reqDto 수정할 게임 정보
      * @return 수정 가능 여부
      */
-    private boolean canUpdateScore(Game game, TournamentGameUpdateReqDto reqDto) {
+    private boolean canUpdateScore(Game game, TournamentGameUpdateRequestDto reqDto) {
         TournamentGame nextTournamentGame = tournamentGameRepository.findById(reqDto.getNextTournamentGameId())
                 .orElseThrow(TournamentGameNotFoundException::new);
-        if (game.getTeams().stream().noneMatch(t-> Objects.equals(t.getId(), reqDto.getTeam1().getTeamId())) ||
-                game.getTeams().stream().noneMatch(t-> Objects.equals(t.getId(), reqDto.getTeam2().getTeamId()))){
-            return false;
-        }
         if (nextTournamentGame.getGame() == null){
             return true;
         }

--- a/src/main/java/com/gg/server/domain/game/data/GameRepository.java
+++ b/src/main/java/com/gg/server/domain/game/data/GameRepository.java
@@ -53,7 +53,7 @@ public interface GameRepository extends JpaRepository<Game, Long>, GameRepositor
 
     @Query(value = "select t1.gameId, t1.startTime, t1.status, t1.mode, " +
             "t1.intraId t1IntraId, t1.teamId t1TeamId, t1.win t1IsWin, t1.score t1Score, t1.image t1Image, t1.total_exp t1Exp, t1.wins t1Wins, t1.losses t1Losses, " +
-            "t2.win t2IsWin, t1.teamId t2TeamId, t2.score t2Score, t2.intraId t2IntraId, t2.wins t2Wins, t2.losses t2Losses, t2.image t2Image, t2.total_exp t2Exp " +
+            "t2.win t2IsWin, t2.teamId t2TeamId, t2.score t2Score, t2.intraId t2IntraId, t2.wins t2Wins, t2.losses t2Losses, t2.image t2Image, t2.total_exp t2Exp " +
             "from v_rank_game_detail t1, v_rank_game_detail t2 " +
             "where t1.gameId = (:gameId) and t1.teamId <t2.teamId and t1.gameId=t2.gameId order by t1.startTime desc;", nativeQuery = true)
     GameTeamUser findTeamsByGameId(@Param("gameId") Long gameId);

--- a/src/main/java/com/gg/server/domain/game/exception/ScoreNotInvalidException.java
+++ b/src/main/java/com/gg/server/domain/game/exception/ScoreNotInvalidException.java
@@ -1,0 +1,10 @@
+package com.gg.server.domain.game.exception;
+
+import com.gg.server.global.exception.ErrorCode;
+import com.gg.server.global.exception.custom.InvalidParameterException;
+
+public class ScoreNotInvalidException extends InvalidParameterException {
+    public ScoreNotInvalidException() {
+        super(ErrorCode.SCORE_NOT_INVALID.getMessage(), ErrorCode.SCORE_NOT_INVALID);
+    }
+}

--- a/src/main/java/com/gg/server/domain/team/dto/TeamReqDto.java
+++ b/src/main/java/com/gg/server/domain/team/dto/TeamReqDto.java
@@ -1,0 +1,35 @@
+package com.gg.server.domain.team.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TeamReqDto {
+
+    @NotNull
+    private Long teamId;
+
+    @NotNull
+    @Max(value = 2, message = "점수는 최대 2점 입니다.")
+    @Min(value = 0, message = "점수는 최소 0점 입니다.")
+    private int score;
+
+    public TeamReqDto(Long teamId, int score) {
+        this.teamId = teamId;
+        this.score = score;
+    }
+
+    @Override
+    public String toString() {
+        return "TeamReqDto{" +
+                "teamId=" + teamId +
+                ", score=" + score +
+                '}';
+    }
+}

--- a/src/main/java/com/gg/server/domain/tournament/exception/TournamentGameNotFoundException.java
+++ b/src/main/java/com/gg/server/domain/tournament/exception/TournamentGameNotFoundException.java
@@ -1,0 +1,11 @@
+package com.gg.server.domain.tournament.exception;
+
+import com.gg.server.global.exception.ErrorCode;
+import com.gg.server.global.exception.custom.NotExistException;
+
+public class TournamentGameNotFoundException extends NotExistException {
+
+    public TournamentGameNotFoundException() {
+        super(ErrorCode.TOURNAMENT_GAME_NOT_FOUND.getMessage(), ErrorCode.TOURNAMENT_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/gg/server/domain/tournament/exception/TournamentNotFoundException.java
+++ b/src/main/java/com/gg/server/domain/tournament/exception/TournamentNotFoundException.java
@@ -4,6 +4,10 @@ import com.gg.server.global.exception.ErrorCode;
 import com.gg.server.global.exception.custom.NotExistException;
 
 public class TournamentNotFoundException extends NotExistException {
+
+    public TournamentNotFoundException() {
+        super(ErrorCode.TOURNAMENT_NOT_FOUND.getMessage(), ErrorCode.TOURNAMENT_NOT_FOUND);
+    }
     public TournamentNotFoundException(String message, ErrorCode errorCode) {
         super(message, errorCode);
     }

--- a/src/main/java/com/gg/server/domain/tournament/exception/TournamentUpdateException.java
+++ b/src/main/java/com/gg/server/domain/tournament/exception/TournamentUpdateException.java
@@ -4,6 +4,10 @@ import com.gg.server.global.exception.ErrorCode;
 import com.gg.server.global.exception.custom.CustomRuntimeException;
 
 public class TournamentUpdateException extends CustomRuntimeException {
+
+    public TournamentUpdateException() {
+        super(ErrorCode.TOURNAMENT_CANT_UPDATE.getMessage(), ErrorCode.TOURNAMENT_CANT_UPDATE);
+    }
     public TournamentUpdateException(String message, ErrorCode errorCode) {
         super(message, errorCode);
     }

--- a/src/main/java/com/gg/server/global/exception/ErrorCode.java
+++ b/src/main/java/com/gg/server/global/exception/ErrorCode.java
@@ -123,6 +123,9 @@ public enum ErrorCode {
     TOURNAMENT_CONFLICT(409, "TN002", "tournament conflicted"),
     TOURNAMENT_NOT_BEFORE(400, "TN003", "tournament status is not before"),
     TOURNAMENT_TITLE_CONFLICT(409, "TN004", "tournament title conflicted"),
+    TOURNAMENT_NOT_LIVE(400, "TN005", "tournament status is not live"),
+    TOURNAMENT_GAME_NOT_FOUND(404, "TN006", "tournament game not found"),
+    TOURNAMENT_CANT_UPDATE(400, "TN007", "tournament can't update"),
     ;
     private int status;
     private String errCode;

--- a/src/main/java/com/gg/server/global/exception/ErrorCode.java
+++ b/src/main/java/com/gg/server/global/exception/ErrorCode.java
@@ -81,6 +81,8 @@ public enum ErrorCode {
     GAME_DUPLICATION_EXCEPTION(409, "GM204", "GAME ALREADY EXISTS"),
     GAME_STATUS_NOT_MATCHED(400, "GM205", "게임 상태 오류입니다."),
     SCORE_ALREADY_ENTERED(400, "GM206", "점수가 이미 입력되었습니다."),
+    GAME_DUPLICATION_EXCPETION(409, "GM204", "GAME ALREADY EXISTS"),
+    SCORE_NOT_INVALID(400, "GM205", "score 입력이 유효하지 않습니다."),
 
     /** match **/
     SLOT_ENROLLED(400, "MA300", "SLOT ALREADY ENROLLED"),
@@ -119,7 +121,7 @@ public enum ErrorCode {
     SLACK_SEND_FAIL(400, "SL003","fail to send notification" ),
 
     // Tournament
-    TOURNAMENT_NOT_FOUND(404, "TN001", "tournament not found"),
+    TOURNAMENT_NOT_FOUND(404, "TN001", "target tournament not found"),
     TOURNAMENT_CONFLICT(409, "TN002", "tournament conflicted"),
     TOURNAMENT_NOT_BEFORE(400, "TN003", "tournament status is not before"),
     TOURNAMENT_TITLE_CONFLICT(409, "TN004", "tournament title conflicted"),

--- a/src/test/java/com/gg/server/admin/tournament/controller/TournamentAdminControllerTest.java
+++ b/src/test/java/com/gg/server/admin/tournament/controller/TournamentAdminControllerTest.java
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.gg.server.admin.tournament.dto.TournamentAdminCreateRequestDto;
 import com.gg.server.admin.tournament.dto.TournamentAdminAddUserRequestDto;
 import com.gg.server.admin.tournament.dto.TournamentAdminUpdateRequestDto;
-import com.gg.server.admin.tournament.dto.TournamentGameUpdateReqDto;
+import com.gg.server.admin.tournament.dto.TournamentGameUpdateRequestDto;
 import com.gg.server.admin.tournament.service.TournamentAdminService;
 import com.gg.server.domain.game.type.Mode;
 import com.gg.server.domain.tournament.data.Tournament;
@@ -21,7 +21,6 @@ import com.gg.server.domain.game.type.Mode;
 import com.gg.server.domain.season.data.Season;
 import com.gg.server.domain.team.dto.TeamReqDto;
 import com.gg.server.domain.tournament.data.*;
-import com.gg.server.domain.tournament.dto.TournamentUserListResponseDto;
 import com.gg.server.domain.tournament.type.TournamentRound;
 import com.gg.server.domain.tournament.type.TournamentStatus;
 import com.gg.server.domain.tournament.type.TournamentType;
@@ -890,7 +889,7 @@ class TournamentAdminControllerTest {
             List<TournamentGame> tournamentGameList = tournamentGameRepository.findAllByTournamentId(tournament.getId());
             TournamentGame tournamentGame = tournamentGameList.stream().filter(tg -> tg.getTournamentRound() == TournamentRound.SEMI_FINAL_1).findAny().orElseThrow();
             TournamentGame nextTournamentGame = tournamentGameList.stream().filter(tg -> tg.getTournamentRound() == TournamentRound.THE_FINAL).findAny().orElseThrow();
-            TournamentGameUpdateReqDto requestDto = new TournamentGameUpdateReqDto(tournamentGame.getId(), nextTournamentGame.getId(),
+            TournamentGameUpdateRequestDto requestDto = new TournamentGameUpdateRequestDto(tournamentGame.getId(), nextTournamentGame.getId(),
                     new TeamReqDto(tournamentGame.getGame().getTeams().get(0).getId(), myTeamScore),
                     new TeamReqDto(tournamentGame.getGame().getTeams().get(1).getId(), otherTeamScore));
 
@@ -918,7 +917,7 @@ class TournamentAdminControllerTest {
             List<TournamentGame> tournamentGameList = tournamentGameRepository.findAllByTournamentId(tournament.getId());
             TournamentGame tournamentGame = tournamentGameList.stream().filter(tg -> tg.getTournamentRound() == TournamentRound.QUARTER_FINAL_1).findAny().orElseThrow();
             TournamentGame nextTournamentGame = tournamentGameList.stream().filter(tg -> tg.getTournamentRound() == TournamentRound.SEMI_FINAL_1).findAny().orElseThrow();
-            TournamentGameUpdateReqDto requestDto = new TournamentGameUpdateReqDto(tournamentGame.getId(), nextTournamentGame.getId(),
+            TournamentGameUpdateRequestDto requestDto = new TournamentGameUpdateRequestDto(tournamentGame.getId(), nextTournamentGame.getId(),
                     new TeamReqDto(tournamentGame.getGame().getTeams().get(0).getId(), myTeamScore),
                     new TeamReqDto(tournamentGame.getGame().getTeams().get(1).getId(), otherTeamScore));
 

--- a/src/test/java/com/gg/server/admin/tournament/controller/TournamentAdminControllerTest.java
+++ b/src/test/java/com/gg/server/admin/tournament/controller/TournamentAdminControllerTest.java
@@ -852,7 +852,6 @@ class TournamentAdminControllerTest {
     @Nested
     @DisplayName("[Patch] /pingpong/admin/tournaments/{tournamentId}/games")
     class AdminUpdateTournamentGameTest {
-        List<TournamentGame> tournamentGames = new ArrayList<>();
         String accessToken;
         Tournament tournament;
         @BeforeEach
@@ -871,9 +870,9 @@ class TournamentAdminControllerTest {
                 if (tournamentRound == TournamentRound.THE_FINAL) {
                     TournamentGame tournamentGame = new TournamentGame(null, tournament, tournamentRound);
                     tournamentGameRepository.save(tournamentGame);
-                    tournamentGames.add(tournamentGame);
+                    tournament.addTournamentGame(tournamentGame);
                 }else {
-                    tournamentGames.add(testDataUtils.createTournamentGame(tournament, tournamentRound, game));
+                    tournament.addTournamentGame(testDataUtils.createTournamentGame(tournament, tournamentRound, game));
                 }
             }
         }
@@ -893,7 +892,6 @@ class TournamentAdminControllerTest {
                     new TeamReqDto(tournamentGame.getGame().getTeams().get(0).getId(), myTeamScore),
                     new TeamReqDto(tournamentGame.getGame().getTeams().get(1).getId(), otherTeamScore));
 
-            System.out.println("sgo test requestDto = " + requestDto);
             String content = objectMapper.writeValueAsString(requestDto);
             // when
             mockMvc.perform(patch(url)
@@ -921,7 +919,6 @@ class TournamentAdminControllerTest {
                     new TeamReqDto(tournamentGame.getGame().getTeams().get(0).getId(), myTeamScore),
                     new TeamReqDto(tournamentGame.getGame().getTeams().get(1).getId(), otherTeamScore));
 
-            System.out.println("sgo test requestDto = " + requestDto);
             String content = objectMapper.writeValueAsString(requestDto);
             // when
             mockMvc.perform(patch(url)

--- a/src/test/java/com/gg/server/utils/TestDataUtils.java
+++ b/src/test/java/com/gg/server/utils/TestDataUtils.java
@@ -229,10 +229,8 @@ public class TestDataUtils {
         gameRepository.save(game);
         Team myTeam = new Team(game, -1, false);
         TeamUser teamUser = new TeamUser(myTeam, curUser);
-        game.addTeam(myTeam);
         Team enemyTeam = new Team(game, -1, false);
         User enemyUser = createNewUser();
-        game.addTeam(enemyTeam);
         createUserRank(curUser, "statusMessage", season);
         createUserRank(enemyUser, "enemyUserMeassage", season);
         TeamUser enemyTeamUser = new TeamUser(enemyTeam, enemyUser);

--- a/src/test/java/com/gg/server/utils/TestDataUtils.java
+++ b/src/test/java/com/gg/server/utils/TestDataUtils.java
@@ -29,12 +29,7 @@ import com.gg.server.domain.team.data.TeamUser;
 import com.gg.server.domain.team.data.TeamUserRepository;
 import com.gg.server.domain.tier.data.Tier;
 import com.gg.server.domain.tier.data.TierRepository;
-import com.gg.server.domain.tournament.data.Tournament;
-import com.gg.server.domain.tournament.data.TournamentGame;
-import com.gg.server.domain.tournament.data.TournamentGameRepository;
-import com.gg.server.domain.tournament.data.TournamentRepository;
-import com.gg.server.domain.tournament.data.TournamentUser;
-import com.gg.server.domain.tournament.data.TournamentUserRepository;
+import com.gg.server.domain.tournament.data.*;
 import com.gg.server.domain.tournament.dto.TournamentResponseDto;
 import com.gg.server.domain.tournament.type.TournamentRound;
 import com.gg.server.domain.tournament.type.TournamentStatus;
@@ -49,14 +44,15 @@ import com.gg.server.domain.user.type.RacketType;
 import com.gg.server.domain.user.type.RoleType;
 import com.gg.server.domain.user.type.SnsType;
 import com.gg.server.global.security.jwt.utils.AuthTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
@@ -233,8 +229,10 @@ public class TestDataUtils {
         gameRepository.save(game);
         Team myTeam = new Team(game, -1, false);
         TeamUser teamUser = new TeamUser(myTeam, curUser);
+        game.addTeam(myTeam);
         Team enemyTeam = new Team(game, -1, false);
         User enemyUser = createNewUser();
+        game.addTeam(enemyTeam);
         createUserRank(curUser, "statusMessage", season);
         createUserRank(enemyUser, "enemyUserMeassage", season);
         TeamUser enemyTeamUser = new TeamUser(enemyTeam, enemyUser);
@@ -697,5 +695,14 @@ public class TestDataUtils {
                 return userImage;
             })
             .collect(Collectors.toCollection(ArrayList::new));
+    }
+
+    public List<User> createUsers(int cnt) {
+        List<User> users = new ArrayList<>();
+        for (int i = 0; i < cnt; i++) {
+            users.add(createNewUser("testUser" + i, "testUser" + i + "@gmail.com", RacketType.PENHOLDER, SnsType.NONE, RoleType.USER));
+        }
+        userRepository.saveAll(users);
+        return users;
     }
 }


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 토너먼트 게임 결과 스코어 수정 api
  - 게임이 완료 전인 wait, live 상태에서도 수정 가능
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - `TournamentAdminService` 
   1. updateTournamentGame : 토너먼트 게임 스코어 수정 함수
   2. updateTeamScore : 팀 스코어를 업데이트 하고 게임 상태를 업데이트 해주는 함수
   3. canUpdateScore : 업데이트 가능한 게임인지 확인 하는 함수
  - 예외 처리 부분들에 대해서 기본 생성자로 하도록 기본생성자 추가
  - 테스트 코드 추가
 ## 💡Issue 번호 <!-- issue number을 link 시켜주세요 (ex. "- close #4242") -->
 - close #308 