### PR TITLE
✨  [Feature] 토너먼트 유저 참가 신청 API

### DIFF
--- a/src/main/java/com/gg/server/admin/tournament/dto/TournamentAdminAddUserResponseDto.java
+++ b/src/main/java/com/gg/server/admin/tournament/dto/TournamentAdminAddUserResponseDto.java
@@ -17,6 +17,6 @@ public class TournamentAdminAddUserResponseDto {
     private String intraId;
 
     @NotNull
-    private boolean isJoined;
+    private Boolean isJoined;
 
 }

--- a/src/main/java/com/gg/server/domain/tournament/controller/TournamentController.java
+++ b/src/main/java/com/gg/server/domain/tournament/controller/TournamentController.java
@@ -5,6 +5,7 @@ import com.gg.server.domain.tournament.service.TournamentService;
 import com.gg.server.domain.user.dto.UserDto;
 import com.gg.server.global.utils.argumentresolver.Login;
 import io.swagger.v3.oas.annotations.Parameter;
+import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.checkerframework.checker.index.qual.Positive;
 import org.springframework.data.domain.PageRequest;
@@ -77,5 +78,19 @@ public class TournamentController {
     @GetMapping("/{tournamentId}/games")
     public ResponseEntity<TournamentGameListResponseDto> getTournamentGames(@PathVariable @Positive Long tournamentId){
         return ResponseEntity.ok().body(tournamentService.getTournamentGames(tournamentId));
+    }
+
+    /**
+     * <p>토너먼트 참가 신청</p>
+     * <p>토너먼트 최대 인원보다 이미 많이 신청했다면 대기자로 들어간다</p>
+     * @param tournamentId 타겟 토너먼트 id
+     * @param user 신청 유저(본인)
+     * @return
+     */
+    @PostMapping("/{tournamentId}/users")
+    ResponseEntity<TournamentUserRegistrationResponseDto> registerTournamentUser(@PathVariable Long tournamentId, @Parameter(hidden = true) @Login UserDto user) {
+
+        return ResponseEntity.created(URI.create("/pingpong/tournaments/"+tournamentId+"/users"))
+            .body(tournamentService.registerTournamentUser(tournamentId, user));
     }
 }

--- a/src/main/java/com/gg/server/domain/tournament/data/TournamentUserRepository.java
+++ b/src/main/java/com/gg/server/domain/tournament/data/TournamentUserRepository.java
@@ -1,5 +1,6 @@
 package com.gg.server.domain.tournament.data;
 
+import com.gg.server.domain.user.data.User;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -15,4 +16,6 @@ public interface TournamentUserRepository extends JpaRepository<TournamentUser, 
     List<TournamentUser> findAllByTournamentId(Long tournamentId);
 
     Optional<TournamentUser> findByTournamentIdAndUserId(Long tournamentId, Long userId);
+
+    List<TournamentUser> findAllByUser(User user);
 }

--- a/src/test/java/com/gg/server/domain/tournament/service/TournamentServiceTest.java
+++ b/src/test/java/com/gg/server/domain/tournament/service/TournamentServiceTest.java
@@ -157,23 +157,6 @@ class TournamentServiceTest {
     @DisplayName("토너먼트_유저_참가_취소_테스트")
     class cancelTournamentUserRegistration {
         @Test
-        @DisplayName("유저_참가_취소_성공")
-        @Disabled
-        void success() {
-            // given
-            Tournament tournament = createTournament(1L, TournamentStatus.BEFORE,
-                LocalDateTime.now(), LocalDateTime.now().plusHours(2));
-            User user = createUser("testUser");
-            TournamentUser tournamentUser = new TournamentUser(user, tournament, true, LocalDateTime.now());
-            tournament.addTournamentUser(tournamentUser);
-            given(tournamentRepository.findById(tournament.getId())).willReturn(Optional.of(tournament));
-            given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
-
-            // when, then
-            tournamentService.cancelTournamentUserRegistration(tournament.getId(), UserDto.from(user));
-        }
-
-        @Test
         @DisplayName("찾을_수_없는_토너먼트")
         void tournamentNotFound() {
             // given
@@ -184,22 +167,6 @@ class TournamentServiceTest {
             // when, then
             assertThatThrownBy(()->tournamentService.cancelTournamentUserRegistration(tournamentId, UserDto.from(user)))
                 .isInstanceOf(TournamentNotFoundException.class);
-        }
-
-        @Test
-        @DisplayName("db에_없는_유저")
-        @Disabled
-        void userNotFound() {
-            // given
-            UserDto userDto = UserDto.builder().id(1L).intraId("testUser").build();
-            Tournament tournament = createTournament(1L, TournamentStatus.BEFORE,
-                LocalDateTime.now(), LocalDateTime.now().plusHours(2));
-            given(tournamentRepository.findById(tournament.getId())).willReturn(Optional.of(tournament));
-            given(userRepository.findById(userDto.getId())).willReturn(Optional.empty());
-
-            // when, then
-            assertThatThrownBy(()->tournamentService.cancelTournamentUserRegistration(tournament.getId(), userDto))
-                .isInstanceOf(UserNotFoundException.class);
         }
     }
 

--- a/src/test/java/com/gg/server/domain/tournament/service/TournamentServiceTest.java
+++ b/src/test/java/com/gg/server/domain/tournament/service/TournamentServiceTest.java
@@ -1,6 +1,7 @@
 package com.gg.server.domain.tournament.service;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
 import com.gg.server.admin.tournament.dto.TournamentAdminCreateRequestDto;
@@ -12,6 +13,7 @@ import com.gg.server.domain.tournament.data.TournamentRepository;
 import com.gg.server.domain.tournament.data.TournamentUser;
 import com.gg.server.domain.tournament.data.TournamentUserRepository;
 import com.gg.server.domain.tournament.dto.TournamentUserRegistrationResponseDto;
+import com.gg.server.domain.tournament.exception.TournamentConflictException;
 import com.gg.server.domain.tournament.exception.TournamentNotFoundException;
 import com.gg.server.domain.tournament.type.TournamentRound;
 import com.gg.server.domain.tournament.type.TournamentStatus;
@@ -63,7 +65,6 @@ class TournamentServiceTest {
             User user = createUser("testUser");
             TournamentUser tournamentUser = new TournamentUser(user, tournament, true, LocalDateTime.now());
             given(tournamentRepository.findById(tournament.getId())).willReturn(Optional.of(tournament));
-            given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
             given(tournamentUserRepository.findByTournamentIdAndUserId(tournament.getId(), user.getId()))
                 .willReturn(Optional.of(tournamentUser));
 
@@ -84,6 +85,39 @@ class TournamentServiceTest {
             assertThatThrownBy(() -> tournamentService.getUserStatusInTournament(tournamentId, UserDto.from(user)))
                 .isInstanceOf(TournamentNotFoundException.class);
         }
+    }
+
+    @Nested
+    @DisplayName("토너먼트_유저_신청_테스트")
+    class RegisterTournamentUserTest {
+        @Test
+        @DisplayName("유저_상태_추가_성공")
+        void success() {
+            // given
+            Tournament tournament = createTournament(1L, TournamentStatus.BEFORE,
+                LocalDateTime.now(), LocalDateTime.now().plusHours(2));
+            User user = createUser("testUser");
+            List<TournamentUser> tournamentUserList = new ArrayList<>();
+            given(tournamentRepository.findById(tournament.getId())).willReturn(Optional.of(tournament));
+            given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
+            given(tournamentUserRepository.findAllByUser(any(User.class))).willReturn(tournamentUserList);
+
+            // when, then
+            TournamentUserRegistrationResponseDto responseDto =
+                tournamentService.registerTournamentUser(tournament.getId(), UserDto.from(user));
+        }
+
+        @Test
+        @DisplayName("찾을_수_없는_토너먼트")
+        void tournamentNotFound() {
+            // given
+            User user = createUser("testUser");
+            given(tournamentRepository.findById(any(Long.class))).willReturn(Optional.empty());
+
+            // when, then
+            assertThatThrownBy(()->tournamentService.registerTournamentUser(1L, UserDto.from(user)))
+                .isInstanceOf(TournamentNotFoundException.class);
+        }
 
         @Test
         @DisplayName("db에_없는_유저")
@@ -93,11 +127,29 @@ class TournamentServiceTest {
                 LocalDateTime.now(), LocalDateTime.now().plusHours(2));
             User user = createUser("testUser");
             given(tournamentRepository.findById(tournament.getId())).willReturn(Optional.of(tournament));
-            given(userRepository.findById(user.getId())).willReturn(Optional.empty());
+            given(userRepository.findById(null)).willReturn(Optional.empty());
 
             // when, then
-            assertThatThrownBy(() -> tournamentService.getUserStatusInTournament(tournament.getId(), UserDto.from(user)))
+            assertThatThrownBy(()->tournamentService.registerTournamentUser(tournament.getId(), UserDto.from(user)))
                 .isInstanceOf(UserNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("이미_신청한_토너먼트_존재")
+        void conflictedRegistration() {
+            // given
+            Tournament tournament = createTournament(1L, TournamentStatus.BEFORE,
+                LocalDateTime.now(), LocalDateTime.now().plusHours(2));
+            User user = createUser("testUser");
+            List<TournamentUser> tournamentUserList = new ArrayList<>();
+            tournamentUserList.add(new TournamentUser(user, tournament, true, LocalDateTime.now()));
+            given(tournamentRepository.findById(tournament.getId())).willReturn(Optional.of(tournament));
+            given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
+            given(tournamentUserRepository.findAllByUser(any(User.class))).willReturn(tournamentUserList);
+
+            // when, then
+            assertThatThrownBy(()->tournamentService.registerTournamentUser(tournament.getId(), UserDto.from(user)))
+                .isInstanceOf(TournamentConflictException.class);
         }
     }
 


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 유저 참가 신청 API 입니다.
  - 해당 토너먼트에 참가 신청을 하지않은 상태인 `BEFORE` 일때만 신청 가능합니다. (아닐시 throw)
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - `TournamentAdminAddUserResponseDto` : boolean -> Boolean 으로 변경
  - `TournamentAdminService`: java docs 추가 및 코드 가독성 개선
  - `TournamentController` && `TournamentService`: 토너먼트 유저 참가 신청 매서드 추가
  - `TournamentUserRepository` : findAllByUser 매서드 추가
  - `TournamentFindControllerTest` && `TournamentServiceTest`: 테스트 코드 추가
  ## ✅ 변경로직 <!-- 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
  - `TournamentServiceTest`: 잘못된 테스트 코드 삭제
 ## 💡Issue 번호 <!-- issue number을 link 시켜주세요 (ex. "- close #4242") -->
 - close #344