### PR TITLE
✨ [Feature] 토너먼트 연관관계 메서드 처리

### DIFF
--- a/src/main/java/com/gg/server/admin/tournament/service/TournamentAdminService.java
+++ b/src/main/java/com/gg/server/admin/tournament/service/TournamentAdminService.java
@@ -183,7 +183,6 @@ public class TournamentAdminService {
         TournamentRound[] rounds = TournamentRound.values();
         while (--cnt >= 0) {
             TournamentGame tournamentGame = new TournamentGame(null, tournament, rounds[cnt]);
-            tournament.addTournamentGame(tournamentGame);
         }
     }
 

--- a/src/main/java/com/gg/server/admin/tournament/service/TournamentAdminService.java
+++ b/src/main/java/com/gg/server/admin/tournament/service/TournamentAdminService.java
@@ -137,7 +137,6 @@ public class TournamentAdminService {
 
         TournamentUser tournamentUser = new TournamentUser(targetUser, targetTournament,
             tournamentList.size() < Tournament.ALLOWED_JOINED_NUMBER, LocalDateTime.now());
-        targetTournament.addTournamentUser(tournamentUser);
         tournamentUserRepository.save(tournamentUser);
 
         return new TournamentAdminAddUserResponseDto(
@@ -168,7 +167,7 @@ public class TournamentAdminService {
         List<TournamentUser> tournamentUserList = targetTournament.getTournamentUsers();
         TournamentUser targetTournamentUser = tournamentUserList.stream().filter(tu->tu.getUser().getId().equals(targetUser.getId()))
             .findAny().orElseThrow(UserNotFoundException::new);
-        targetTournament.deleteTournamentUser(targetTournamentUser);
+        targetTournamentUser.deleteTournament();
         if (targetTournamentUser.getIsJoined() && tournamentUserList.size() >= Tournament.ALLOWED_JOINED_NUMBER) {
             tournamentUserList.get(Tournament.ALLOWED_JOINED_NUMBER - 1).updateIsJoined(true);
         }

--- a/src/main/java/com/gg/server/domain/game/data/Game.java
+++ b/src/main/java/com/gg/server/domain/game/data/Game.java
@@ -5,6 +5,8 @@ import com.gg.server.domain.season.data.Season;
 import com.gg.server.domain.game.type.Mode;
 import com.gg.server.domain.game.type.StatusType;
 import com.gg.server.domain.team.data.Team;
+import com.gg.server.global.exception.ErrorCode;
+import com.gg.server.global.exception.custom.BusinessException;
 import java.util.ArrayList;
 import lombok.*;
 
@@ -87,6 +89,8 @@ public class Game {
     }
 
     public void addTeam(Team team) {
+        if (teams.contains(team))
+            throw new BusinessException(ErrorCode.TEAM_DUPLICATION);
         this.teams.add(team);
     }
 }

--- a/src/main/java/com/gg/server/domain/game/data/Game.java
+++ b/src/main/java/com/gg/server/domain/game/data/Game.java
@@ -6,14 +6,13 @@ import com.gg.server.domain.game.type.Mode;
 import com.gg.server.domain.game.type.StatusType;
 import com.gg.server.domain.team.data.Team;
 import com.gg.server.global.exception.ErrorCode;
-import com.gg.server.global.exception.custom.BusinessException;
+import com.gg.server.global.utils.BusinessChecker;
 import java.util.ArrayList;
 import lombok.*;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 
 @NoArgsConstructor
@@ -89,8 +88,9 @@ public class Game {
     }
 
     public void addTeam(Team team) {
-        if (teams.contains(team))
-            throw new BusinessException(ErrorCode.TEAM_DUPLICATION);
+        BusinessChecker.mustNotNull(team, ErrorCode.NULL_POINT);
+        BusinessChecker.mustNotExceed(1, teams, ErrorCode.TEAM_SIZE_EXCEED);
+        BusinessChecker.mustNotContains(team, teams, ErrorCode.TEAM_DUPLICATION);
         this.teams.add(team);
     }
 }

--- a/src/main/java/com/gg/server/domain/team/data/Team.java
+++ b/src/main/java/com/gg/server/domain/team/data/Team.java
@@ -1,13 +1,24 @@
 package com.gg.server.domain.team.data;
 
 import com.gg.server.domain.game.data.Game;
-import java.util.ArrayList;
-import lombok.*;
-
-import javax.persistence.*;
-import javax.validation.constraints.NotNull;
+import com.gg.server.global.exception.ErrorCode;
+import com.gg.server.global.exception.custom.BusinessException;
 import java.util.ArrayList;
 import java.util.List;
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @NoArgsConstructor
 @AllArgsConstructor
@@ -45,6 +56,8 @@ public class Team {
     }
 
     public void addTeamUser(TeamUser teamUser) {
+        if (teamUsers.contains(teamUser))
+            throw new BusinessException(ErrorCode.TEAM_USER_ALREADY_EXIST);
         this.teamUsers.add(teamUser);
     }
 }

--- a/src/main/java/com/gg/server/domain/team/data/Team.java
+++ b/src/main/java/com/gg/server/domain/team/data/Team.java
@@ -2,7 +2,7 @@ package com.gg.server.domain.team.data;
 
 import com.gg.server.domain.game.data.Game;
 import com.gg.server.global.exception.ErrorCode;
-import com.gg.server.global.exception.custom.BusinessException;
+import com.gg.server.global.utils.BusinessChecker;
 import java.util.ArrayList;
 import java.util.List;
 import javax.persistence.CascadeType;
@@ -56,8 +56,9 @@ public class Team {
     }
 
     public void addTeamUser(TeamUser teamUser) {
-        if (teamUsers.contains(teamUser))
-            throw new BusinessException(ErrorCode.TEAM_USER_ALREADY_EXIST);
+        BusinessChecker.mustNotNull(teamUser, ErrorCode.NULL_POINT);
+        BusinessChecker.mustNotExceed(1, teamUsers, ErrorCode.TEAM_USER_EXCEED);
+        BusinessChecker.mustNotContains(teamUser, teamUsers, ErrorCode.TEAM_USER_ALREADY_EXIST);
         this.teamUsers.add(teamUser);
     }
 }

--- a/src/main/java/com/gg/server/domain/tournament/data/Tournament.java
+++ b/src/main/java/com/gg/server/domain/tournament/data/Tournament.java
@@ -3,15 +3,31 @@ package com.gg.server.domain.tournament.data;
 import com.gg.server.domain.tournament.type.TournamentStatus;
 import com.gg.server.domain.tournament.type.TournamentType;
 import com.gg.server.domain.user.data.User;
+import com.gg.server.global.exception.ErrorCode;
+import com.gg.server.global.exception.custom.BusinessException;
 import com.gg.server.global.utils.BaseTimeEntity;
-
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import javax.persistence.*;
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToMany;
+import javax.persistence.OneToOne;
 import javax.validation.constraints.NotNull;
-
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
@@ -89,16 +105,34 @@ public class Tournament extends BaseTimeEntity {
         this.status = status;
     }
 
+    /**
+     * 토너먼트 관련 연관관계 편의 메소드는 토너먼트에서 모두 관리
+     */
     public void addTournamentGame(TournamentGame tournamentGame) {
+        if (tournamentGames.contains(tournamentGame)) {
+            throw new BusinessException(ErrorCode.TOURNAMENT_GAME_DUPLICATION);
+        }
         this.tournamentGames.add(tournamentGame);
+        tournamentGame.setTournament(this);
     }
 
     public void addTournamentUser(@NotNull TournamentUser tournamentUser) {
+        if (tournamentUsers.contains(tournamentUser)) {
+            throw new BusinessException(ErrorCode.TOURNAMENT_USER_DUPLICATION);
+        }
         this.tournamentUsers.add(tournamentUser);
+        tournamentUser.setTournament(this);
     }
 
+    /**
+     * not null 제약조건을 이용해서 실수를 방지
+     */
     public void deleteTournamentUser(@NotNull TournamentUser tournamentUser) {
+        if (!tournamentUsers.contains(tournamentUser)) {
+            throw new BusinessException(ErrorCode.TOURNAMENT_USER_NOT_FOUND);
+        }
         this.tournamentUsers.remove(tournamentUser);
+        tournamentUser.setTournament(null);
     }
 
     public void updateWinner(User winner) {

--- a/src/main/java/com/gg/server/domain/tournament/data/Tournament.java
+++ b/src/main/java/com/gg/server/domain/tournament/data/Tournament.java
@@ -117,9 +117,8 @@ public class Tournament extends BaseTimeEntity {
     }
 
     public void addTournamentUser(@NotNull TournamentUser tournamentUser) {
-        if (tournamentUsers.contains(tournamentUser)) {
+        if (tournamentUsers.contains(tournamentUser))
             throw new BusinessException(ErrorCode.TOURNAMENT_USER_DUPLICATION);
-        }
         this.tournamentUsers.add(tournamentUser);
         tournamentUser.setTournament(this);
     }
@@ -128,9 +127,8 @@ public class Tournament extends BaseTimeEntity {
      * not null 제약조건을 이용해서 실수를 방지
      */
     public void deleteTournamentUser(@NotNull TournamentUser tournamentUser) {
-        if (!tournamentUsers.contains(tournamentUser)) {
+        if (!tournamentUsers.contains(tournamentUser))
             throw new BusinessException(ErrorCode.TOURNAMENT_USER_NOT_FOUND);
-        }
         this.tournamentUsers.remove(tournamentUser);
         tournamentUser.setTournament(null);
     }

--- a/src/main/java/com/gg/server/domain/tournament/data/Tournament.java
+++ b/src/main/java/com/gg/server/domain/tournament/data/Tournament.java
@@ -65,19 +65,22 @@ public class Tournament extends BaseTimeEntity {
     @OneToMany(mappedBy = "tournament", cascade = CascadeType.ALL)
     private List<TournamentUser> tournamentUsers = new ArrayList<>();
 
+    /**
+     * winner는 생성시점에 존재하지 않음.
+     */
     @Builder
-    public Tournament(String title, String contents, LocalDateTime startTime, LocalDateTime endTime, TournamentType type, TournamentStatus status, User winner, List<TournamentGame> tournamentGames, List<TournamentUser> tournamentUsers) {
+    public Tournament(String title, String contents, LocalDateTime startTime, LocalDateTime endTime,
+        TournamentType type, TournamentStatus status) {
         this.title = title;
         this.contents = contents;
         this.startTime = startTime;
         this.endTime = endTime;
         this.type = type;
         this.status = status;
-        this.tournamentGames = tournamentGames != null ? tournamentGames : new ArrayList<>();
-        this.tournamentUsers = tournamentUsers != null ? tournamentUsers : new ArrayList<>();
     }
 
-    public void update(String title, String contents, LocalDateTime startTime, LocalDateTime endTime, TournamentType type, TournamentStatus status) {
+    public void update(String title, String contents, LocalDateTime startTime,
+        LocalDateTime endTime, TournamentType type, TournamentStatus status) {
         this.title = title;
         this.contents = contents;
         this.startTime = startTime;

--- a/src/main/java/com/gg/server/domain/tournament/data/Tournament.java
+++ b/src/main/java/com/gg/server/domain/tournament/data/Tournament.java
@@ -1,10 +1,14 @@
 package com.gg.server.domain.tournament.data;
 
+import static com.gg.server.global.utils.BusinessChecker.mustContains;
+import static com.gg.server.global.utils.BusinessChecker.mustNotContains;
+import static com.gg.server.global.utils.BusinessChecker.mustNotExceed;
+import static com.gg.server.global.utils.BusinessChecker.mustNotNull;
+
 import com.gg.server.domain.tournament.type.TournamentStatus;
 import com.gg.server.domain.tournament.type.TournamentType;
 import com.gg.server.domain.user.data.User;
 import com.gg.server.global.exception.ErrorCode;
-import com.gg.server.global.exception.custom.BusinessException;
 import com.gg.server.global.utils.BaseTimeEntity;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -109,16 +113,17 @@ public class Tournament extends BaseTimeEntity {
      * 토너먼트 관련 연관관계 편의 메소드는 토너먼트에서 모두 관리
      */
     public void addTournamentGame(TournamentGame tournamentGame) {
-        if (tournamentGames.contains(tournamentGame)) {
-            throw new BusinessException(ErrorCode.TOURNAMENT_GAME_DUPLICATION);
-        }
+        mustNotNull(tournamentGame, ErrorCode.NULL_POINT);
+        mustNotExceed(ALLOWED_JOINED_NUMBER - 2, tournamentGames,
+            ErrorCode.TOURNAMENT_GAME_EXCEED);
+        mustNotContains(tournamentGame, tournamentGames, ErrorCode.TOURNAMENT_GAME_DUPLICATION);
         this.tournamentGames.add(tournamentGame);
         tournamentGame.setTournament(this);
     }
 
     public void addTournamentUser(@NotNull TournamentUser tournamentUser) {
-        if (tournamentUsers.contains(tournamentUser))
-            throw new BusinessException(ErrorCode.TOURNAMENT_USER_DUPLICATION);
+        mustNotNull(tournamentUser, ErrorCode.NULL_POINT);
+        mustNotContains(tournamentUser, tournamentUsers, ErrorCode.TOURNAMENT_USER_DUPLICATION);
         this.tournamentUsers.add(tournamentUser);
         tournamentUser.setTournament(this);
     }
@@ -126,18 +131,20 @@ public class Tournament extends BaseTimeEntity {
     /**
      * not null 제약조건을 이용해서 실수를 방지
      */
-    public void deleteTournamentUser(@NotNull TournamentUser tournamentUser) {
-        if (!tournamentUsers.contains(tournamentUser))
-            throw new BusinessException(ErrorCode.TOURNAMENT_USER_NOT_FOUND);
+    public void deleteTournamentUser(TournamentUser tournamentUser) {
+        mustNotNull(tournamentUser, ErrorCode.NULL_POINT);
+        mustContains(tournamentUser, tournamentUsers, ErrorCode.TOURNAMENT_USER_NOT_FOUND);
         this.tournamentUsers.remove(tournamentUser);
         tournamentUser.setTournament(null);
     }
 
     public void updateWinner(User winner) {
+        mustNotNull(winner, ErrorCode.NULL_POINT);
         this.winner = winner;
     }
 
     public void updateStatus(TournamentStatus status) {
+        mustNotNull(status, ErrorCode.NULL_POINT);
         this.status = status;
     }
 }

--- a/src/main/java/com/gg/server/domain/tournament/data/Tournament.java
+++ b/src/main/java/com/gg/server/domain/tournament/data/Tournament.java
@@ -35,7 +35,6 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 @Getter
 @Entity
 @ToString
@@ -98,6 +97,7 @@ public class Tournament extends BaseTimeEntity {
         this.endTime = endTime;
         this.type = type;
         this.status = status;
+        this.winner = null;
     }
 
     public void update(String title, String contents, LocalDateTime startTime,

--- a/src/main/java/com/gg/server/domain/tournament/data/Tournament.java
+++ b/src/main/java/com/gg/server/domain/tournament/data/Tournament.java
@@ -113,7 +113,7 @@ public class Tournament extends BaseTimeEntity {
     /**
      * TournamentGame 에서 호출하는 연관관계 편의 메서드, 기타 호출 금지.
      */
-    public void addTournamentGame(TournamentGame tournamentGame) {
+    protected void addTournamentGame(TournamentGame tournamentGame) {
         mustNotNull(tournamentGame, NULL_POINT);
         mustNotExceed(ALLOWED_JOINED_NUMBER - 2, tournamentGames, TOURNAMENT_GAME_EXCEED);
         mustNotContains(tournamentGame, tournamentGames, TOURNAMENT_GAME_DUPLICATION);

--- a/src/main/java/com/gg/server/domain/tournament/data/Tournament.java
+++ b/src/main/java/com/gg/server/domain/tournament/data/Tournament.java
@@ -1,5 +1,7 @@
 package com.gg.server.domain.tournament.data;
 
+import static com.gg.server.global.exception.ErrorCode.*;
+import static com.gg.server.global.exception.ErrorCode.TOURNAMENT_GAME_EXCEED;
 import static com.gg.server.global.utils.BusinessChecker.mustContains;
 import static com.gg.server.global.utils.BusinessChecker.mustNotContains;
 import static com.gg.server.global.utils.BusinessChecker.mustNotExceed;
@@ -113,17 +115,16 @@ public class Tournament extends BaseTimeEntity {
      * 토너먼트 관련 연관관계 편의 메소드는 토너먼트에서 모두 관리
      */
     public void addTournamentGame(TournamentGame tournamentGame) {
-        mustNotNull(tournamentGame, ErrorCode.NULL_POINT);
-        mustNotExceed(ALLOWED_JOINED_NUMBER - 2, tournamentGames,
-            ErrorCode.TOURNAMENT_GAME_EXCEED);
-        mustNotContains(tournamentGame, tournamentGames, ErrorCode.TOURNAMENT_GAME_DUPLICATION);
+        mustNotNull(tournamentGame, NULL_POINT);
+        mustNotExceed(ALLOWED_JOINED_NUMBER - 2, tournamentGames, TOURNAMENT_GAME_EXCEED);
+        mustNotContains(tournamentGame, tournamentGames, TOURNAMENT_GAME_DUPLICATION);
         this.tournamentGames.add(tournamentGame);
         tournamentGame.setTournament(this);
     }
 
     public void addTournamentUser(@NotNull TournamentUser tournamentUser) {
-        mustNotNull(tournamentUser, ErrorCode.NULL_POINT);
-        mustNotContains(tournamentUser, tournamentUsers, ErrorCode.TOURNAMENT_USER_DUPLICATION);
+        mustNotNull(tournamentUser, NULL_POINT);
+        mustNotContains(tournamentUser, tournamentUsers, TOURNAMENT_USER_DUPLICATION);
         this.tournamentUsers.add(tournamentUser);
         tournamentUser.setTournament(this);
     }
@@ -132,19 +133,19 @@ public class Tournament extends BaseTimeEntity {
      * not null 제약조건을 이용해서 실수를 방지
      */
     public void deleteTournamentUser(TournamentUser tournamentUser) {
-        mustNotNull(tournamentUser, ErrorCode.NULL_POINT);
-        mustContains(tournamentUser, tournamentUsers, ErrorCode.TOURNAMENT_USER_NOT_FOUND);
+        mustNotNull(tournamentUser, NULL_POINT);
+        mustContains(tournamentUser, tournamentUsers, TOURNAMENT_USER_NOT_FOUND);
         this.tournamentUsers.remove(tournamentUser);
         tournamentUser.setTournament(null);
     }
 
     public void updateWinner(User winner) {
-        mustNotNull(winner, ErrorCode.NULL_POINT);
+        mustNotNull(winner, NULL_POINT);
         this.winner = winner;
     }
 
     public void updateStatus(TournamentStatus status) {
-        mustNotNull(status, ErrorCode.NULL_POINT);
+        mustNotNull(status, NULL_POINT);
         this.status = status;
     }
 }

--- a/src/main/java/com/gg/server/domain/tournament/data/Tournament.java
+++ b/src/main/java/com/gg/server/domain/tournament/data/Tournament.java
@@ -10,7 +10,6 @@ import static com.gg.server.global.utils.BusinessChecker.mustNotNull;
 import com.gg.server.domain.tournament.type.TournamentStatus;
 import com.gg.server.domain.tournament.type.TournamentType;
 import com.gg.server.domain.user.data.User;
-import com.gg.server.global.exception.ErrorCode;
 import com.gg.server.global.utils.BaseTimeEntity;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -112,31 +111,31 @@ public class Tournament extends BaseTimeEntity {
     }
 
     /**
-     * 토너먼트 관련 연관관계 편의 메소드는 토너먼트에서 모두 관리
+     * TournamentGame 에서 호출하는 연관관계 편의 메서드, 기타 호출 금지.
      */
     public void addTournamentGame(TournamentGame tournamentGame) {
         mustNotNull(tournamentGame, NULL_POINT);
         mustNotExceed(ALLOWED_JOINED_NUMBER - 2, tournamentGames, TOURNAMENT_GAME_EXCEED);
         mustNotContains(tournamentGame, tournamentGames, TOURNAMENT_GAME_DUPLICATION);
         this.tournamentGames.add(tournamentGame);
-        tournamentGame.setTournament(this);
-    }
-
-    public void addTournamentUser(@NotNull TournamentUser tournamentUser) {
-        mustNotNull(tournamentUser, NULL_POINT);
-        mustNotContains(tournamentUser, tournamentUsers, TOURNAMENT_USER_DUPLICATION);
-        this.tournamentUsers.add(tournamentUser);
-        tournamentUser.setTournament(this);
     }
 
     /**
-     * not null 제약조건을 이용해서 실수를 방지
+     * TournamentUser 에서 호출하는 연관관계 편의 메서드, 기타 호출 금지.
      */
-    public void deleteTournamentUser(TournamentUser tournamentUser) {
+    protected void addTournamentUser(@NotNull TournamentUser tournamentUser) {
+        mustNotNull(tournamentUser, NULL_POINT);
+        mustNotContains(tournamentUser, tournamentUsers, TOURNAMENT_USER_DUPLICATION);
+        this.tournamentUsers.add(tournamentUser);
+    }
+
+    /**
+     * TournamentGame 에서 호출하는 연관관계 편의 메서드, 기타 호출 금지.
+     */
+    protected void deleteTournamentUser(TournamentUser tournamentUser) {
         mustNotNull(tournamentUser, NULL_POINT);
         mustContains(tournamentUser, tournamentUsers, TOURNAMENT_USER_NOT_FOUND);
         this.tournamentUsers.remove(tournamentUser);
-        tournamentUser.setTournament(null);
     }
 
     public void updateWinner(User winner) {

--- a/src/main/java/com/gg/server/domain/tournament/data/TournamentGame.java
+++ b/src/main/java/com/gg/server/domain/tournament/data/TournamentGame.java
@@ -10,9 +10,9 @@ import javax.validation.constraints.NotNull;
 import lombok.*;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 @Getter
 @Entity
+@AllArgsConstructor
 public class TournamentGame extends BaseTimeEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -34,13 +34,17 @@ public class TournamentGame extends BaseTimeEntity {
 
 
     /**
-     * id 값 제외한 생성자
+     * id 값 제외한 생성자.
+     * <p>
+     *  생성에 따른 Tournament 연관관계 설정을 담당
+     * </p>
      * @param game
      * @param tournament
      * @param tournamentRound
      */
     @Builder
     public TournamentGame(Game game, Tournament tournament, TournamentRound tournamentRound) {
+        tournament.addTournamentGame(this);
         this.game = game;
         this.tournament = tournament;
         this.tournamentRound = tournamentRound;
@@ -54,7 +58,4 @@ public class TournamentGame extends BaseTimeEntity {
         this.game = game;
     }
 
-    public void setTournament(Tournament tournament) {
-        this.tournament = tournament;
-    }
 }

--- a/src/main/java/com/gg/server/domain/tournament/data/TournamentGame.java
+++ b/src/main/java/com/gg/server/domain/tournament/data/TournamentGame.java
@@ -53,4 +53,8 @@ public class TournamentGame extends BaseTimeEntity {
     public void updateGame(Game game) {
         this.game = game;
     }
+
+    public void setTournament(Tournament tournament) {
+        this.tournament = tournament;
+    }
 }

--- a/src/main/java/com/gg/server/domain/tournament/data/TournamentGame.java
+++ b/src/main/java/com/gg/server/domain/tournament/data/TournamentGame.java
@@ -12,7 +12,6 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Entity
-@AllArgsConstructor
 public class TournamentGame extends BaseTimeEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/gg/server/domain/tournament/data/TournamentUser.java
+++ b/src/main/java/com/gg/server/domain/tournament/data/TournamentUser.java
@@ -52,4 +52,8 @@ public class TournamentUser extends BaseTimeEntity {
     public void updateIsJoined(boolean isJoined) {
         this.isJoined = isJoined;
     }
+
+    public void setTournament(Tournament tournament) {
+        this.tournament = tournament;
+    }
 }

--- a/src/main/java/com/gg/server/domain/tournament/data/TournamentUser.java
+++ b/src/main/java/com/gg/server/domain/tournament/data/TournamentUser.java
@@ -12,11 +12,12 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.validation.constraints.NotNull;
-
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 @Getter
 @Entity
 public class TournamentUser extends BaseTimeEntity {
@@ -41,19 +42,27 @@ public class TournamentUser extends BaseTimeEntity {
     @Column(name = "register_time")
     private LocalDateTime registerTime;
 
+    /**
+     * 생성자이며, 빌더이자, 생성 연관관계를 담당한다.
+     */
     @Builder
     public TournamentUser(User user, Tournament tournament, boolean isJoined, LocalDateTime registerTime) {
+        tournament.addTournamentUser(this);
         this.user = user;
         this.tournament = tournament;
         this.isJoined = isJoined;
         this.registerTime = registerTime;
     }
 
-    public void updateIsJoined(boolean isJoined) {
-        this.isJoined = isJoined;
+    /**
+     * 연관관계 편의 메서드, 삭제 책임을 가진다.
+     */
+    public void deleteTournament() {
+        tournament.deleteTournamentUser(this);
+        this.tournament = null;
     }
 
-    public void setTournament(Tournament tournament) {
-        this.tournament = tournament;
+    public void updateIsJoined(boolean isJoined) {
+        this.isJoined = isJoined;
     }
 }

--- a/src/main/java/com/gg/server/domain/tournament/service/TournamentService.java
+++ b/src/main/java/com/gg/server/domain/tournament/service/TournamentService.java
@@ -147,7 +147,6 @@ public class TournamentService {
             .ifPresent(a->{throw new TournamentConflictException("이미 신청한 토너먼트가 존재합니다.", ErrorCode.TOURNAMENT_CONFLICT);});
         TournamentUser tournamentUser = new TournamentUser(loginUser, targetTournament,
             tournamentUserList.size() < Tournament.ALLOWED_JOINED_NUMBER, LocalDateTime.now());
-        targetTournament.addTournamentUser(tournamentUser);
         TournamentUserStatus tournamentUserStatus = tournamentUser.getIsJoined() ? TournamentUserStatus.PLAYER : TournamentUserStatus.WAIT;
         return new TournamentUserRegistrationResponseDto(tournamentUserStatus);
     }

--- a/src/main/java/com/gg/server/global/exception/ErrorCode.java
+++ b/src/main/java/com/gg/server/global/exception/ErrorCode.java
@@ -81,6 +81,7 @@ public enum ErrorCode {
      * team_user
      */
     TEAM_USER_ALREADY_EXIST(500, "TU201", "중복된 TEAM_USER"),
+    TEAM_USER_EXCEED(500, "TU202", "TeamUser 최대 인원의 수(2)를 초과하였습니다."),
 
     /** game **/
     GAME_DB_NOT_VALID(500, "GM201", "GAME DB NOT CONSISTENCY"),

--- a/src/main/java/com/gg/server/global/exception/ErrorCode.java
+++ b/src/main/java/com/gg/server/global/exception/ErrorCode.java
@@ -141,6 +141,7 @@ public enum ErrorCode {
     TOURNAMENT_GAME_DUPLICATION(500, "TN008", "중복된 토너먼트 게임입니다!"),
     TOURNAMENT_USER_DUPLICATION(500, "TN009", "중복된 토너먼트 유저입니다!"),
     TOURNAMENT_USER_NOT_FOUND(404, "TN010", "target tournament user not found"),
+    TOURNAMENT_GAME_EXCEED(500, "TN011", "토너먼트 게임 최대 사이즈를 초과하였습니다!"),
     ;
     private int status;
     private String errCode;

--- a/src/main/java/com/gg/server/global/exception/ErrorCode.java
+++ b/src/main/java/com/gg/server/global/exception/ErrorCode.java
@@ -6,6 +6,8 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 public enum ErrorCode {
+    //common
+    NULL_POINT(500, "G100", "NULL POINT EXCEPTION"),
 
     //user
     USER_NOT_FOUND(404, "UR100", "USER NOT FOUND"),
@@ -72,7 +74,8 @@ public enum ErrorCode {
 
     /** team **/
     TEAM_ID_NOT_MATCH(400, "TM201", "TEAM id 가 일치하지 않습니다."),
-    TEAM_DUPLICATION(500, "TM202", "중복된 TEAM"),
+    TEAM_DUPLICATION(500, "TM202", "중복된 Team 이 한 Game 에 존재할 수 없습니다."),
+    TEAM_SIZE_EXCEED(500, "TM203", "게임 최대 Team 의 수(2)를 초과하였습니다."),
 
     /**
      * team_user

--- a/src/main/java/com/gg/server/global/exception/ErrorCode.java
+++ b/src/main/java/com/gg/server/global/exception/ErrorCode.java
@@ -128,6 +128,9 @@ public enum ErrorCode {
     TOURNAMENT_NOT_LIVE(400, "TN005", "tournament status is not live"),
     TOURNAMENT_GAME_NOT_FOUND(404, "TN006", "tournament game not found"),
     TOURNAMENT_CANT_UPDATE(400, "TN007", "tournament can't update"),
+    TOURNAMENT_GAME_DUPLICATION(500, "TN008", "중복된 토너먼트 게임입니다!"),
+    TOURNAMENT_USER_DUPLICATION(500, "TN008", "중복된 토너먼트 유저입니다!"),
+    TOURNAMENT_USER_NOT_FOUND(404, "TN009", "target tournament user not found"),
     ;
     private int status;
     private String errCode;

--- a/src/main/java/com/gg/server/global/exception/ErrorCode.java
+++ b/src/main/java/com/gg/server/global/exception/ErrorCode.java
@@ -72,6 +72,12 @@ public enum ErrorCode {
 
     /** team **/
     TEAM_ID_NOT_MATCH(400, "TM201", "TEAM id 가 일치하지 않습니다."),
+    TEAM_DUPLICATION(500, "TM202", "중복된 TEAM"),
+
+    /**
+     * team_user
+     */
+    TEAM_USER_ALREADY_EXIST(500, "TU201", "중복된 TEAM_USER"),
 
     /** game **/
     GAME_DB_NOT_VALID(500, "GM201", "GAME DB NOT CONSISTENCY"),
@@ -129,8 +135,8 @@ public enum ErrorCode {
     TOURNAMENT_GAME_NOT_FOUND(404, "TN006", "tournament game not found"),
     TOURNAMENT_CANT_UPDATE(400, "TN007", "tournament can't update"),
     TOURNAMENT_GAME_DUPLICATION(500, "TN008", "중복된 토너먼트 게임입니다!"),
-    TOURNAMENT_USER_DUPLICATION(500, "TN008", "중복된 토너먼트 유저입니다!"),
-    TOURNAMENT_USER_NOT_FOUND(404, "TN009", "target tournament user not found"),
+    TOURNAMENT_USER_DUPLICATION(500, "TN009", "중복된 토너먼트 유저입니다!"),
+    TOURNAMENT_USER_NOT_FOUND(404, "TN010", "target tournament user not found"),
     ;
     private int status;
     private String errCode;

--- a/src/main/java/com/gg/server/global/exception/ErrorCode.java
+++ b/src/main/java/com/gg/server/global/exception/ErrorCode.java
@@ -74,13 +74,13 @@ public enum ErrorCode {
 
     /** team **/
     TEAM_ID_NOT_MATCH(400, "TM201", "TEAM id 가 일치하지 않습니다."),
-    TEAM_DUPLICATION(500, "TM202", "중복된 Team 이 한 Game 에 존재할 수 없습니다."),
+    TEAM_DUPLICATION(409, "TM202", "중복된 Team 이 한 Game 에 존재할 수 없습니다."),
     TEAM_SIZE_EXCEED(500, "TM203", "게임 최대 Team 의 수(2)를 초과하였습니다."),
 
     /**
      * team_user
      */
-    TEAM_USER_ALREADY_EXIST(500, "TU201", "중복된 TEAM_USER"),
+    TEAM_USER_ALREADY_EXIST(409, "TU201", "중복된 TEAM_USER"),
     TEAM_USER_EXCEED(500, "TU202", "TeamUser 최대 인원의 수(2)를 초과하였습니다."),
 
     /** game **/
@@ -138,8 +138,8 @@ public enum ErrorCode {
     TOURNAMENT_NOT_LIVE(400, "TN005", "tournament status is not live"),
     TOURNAMENT_GAME_NOT_FOUND(404, "TN006", "tournament game not found"),
     TOURNAMENT_CANT_UPDATE(400, "TN007", "tournament can't update"),
-    TOURNAMENT_GAME_DUPLICATION(500, "TN008", "중복된 토너먼트 게임입니다!"),
-    TOURNAMENT_USER_DUPLICATION(500, "TN009", "중복된 토너먼트 유저입니다!"),
+    TOURNAMENT_GAME_DUPLICATION(409, "TN008", "중복된 토너먼트 게임입니다!"),
+    TOURNAMENT_USER_DUPLICATION(409, "TN009", "중복된 토너먼트 유저입니다!"),
     TOURNAMENT_USER_NOT_FOUND(404, "TN010", "target tournament user not found"),
     TOURNAMENT_GAME_EXCEED(500, "TN011", "토너먼트 게임 최대 사이즈를 초과하였습니다!"),
     ;

--- a/src/main/java/com/gg/server/global/exception/custom/BusinessException.java
+++ b/src/main/java/com/gg/server/global/exception/custom/BusinessException.java
@@ -6,4 +6,8 @@ public class BusinessException extends CustomRuntimeException{
     public BusinessException(String message, ErrorCode errorCode) {
         super(message, errorCode);
     }
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage(), errorCode);
+    }
 }

--- a/src/main/java/com/gg/server/global/exception/custom/CustomRuntimeException.java
+++ b/src/main/java/com/gg/server/global/exception/custom/CustomRuntimeException.java
@@ -12,4 +12,9 @@ public class CustomRuntimeException extends RuntimeException {
         this.errorCode = errorCode;
         errorCode.setMessage(message);
     }
+
+    public CustomRuntimeException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
 }

--- a/src/main/java/com/gg/server/global/utils/BusinessChecker.java
+++ b/src/main/java/com/gg/server/global/utils/BusinessChecker.java
@@ -3,6 +3,8 @@ package com.gg.server.global.utils;
 import com.gg.server.global.exception.ErrorCode;
 import com.gg.server.global.exception.custom.BusinessException;
 import java.util.Collection;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 
 /**
  * Checker.
@@ -12,7 +14,8 @@ import java.util.Collection;
  * </p>
  *
  */
-public class BusinessChecker {
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class BusinessChecker {
   public static void mustNotNull(Object object, ErrorCode errorCode) {
     if (object == null) {
       throw new BusinessException(errorCode);

--- a/src/main/java/com/gg/server/global/utils/BusinessChecker.java
+++ b/src/main/java/com/gg/server/global/utils/BusinessChecker.java
@@ -19,6 +19,12 @@ public class BusinessChecker {
     }
   }
 
+  public static void mustContains(Object object, Collection<?> collection, ErrorCode errorCode) {
+    if (!collection.contains(object)) {
+      throw new BusinessException(errorCode);
+    }
+  }
+
   public static void mustNotContains(Object object, Collection<?> collection, ErrorCode errorCode) {
     if (collection.contains(object)) {
       throw new BusinessException(errorCode);

--- a/src/main/java/com/gg/server/global/utils/BusinessChecker.java
+++ b/src/main/java/com/gg/server/global/utils/BusinessChecker.java
@@ -1,0 +1,33 @@
+package com.gg.server.global.utils;
+
+import com.gg.server.global.exception.ErrorCode;
+import com.gg.server.global.exception.custom.BusinessException;
+import java.util.Collection;
+
+/**
+ * Checker.
+ *
+ * <p>
+ *  비즈니스 로직 체크용 check 유틸리티 클래스
+ * </p>
+ *
+ */
+public class BusinessChecker {
+  public static void mustNotNull(Object object, ErrorCode errorCode) {
+    if (object == null) {
+      throw new BusinessException(errorCode);
+    }
+  }
+
+  public static void mustNotContains(Object object, Collection<?> collection, ErrorCode errorCode) {
+    if (collection.contains(object)) {
+      throw new BusinessException(errorCode);
+    }
+  }
+
+  public static void mustNotExceed(int size, Collection<?> collection, ErrorCode errorCode) {
+    if (collection.size() > size) {
+      throw new BusinessException(errorCode);
+    }
+  }
+}

--- a/src/test/java/com/gg/server/admin/tournament/controller/TournamentAdminControllerTest.java
+++ b/src/test/java/com/gg/server/admin/tournament/controller/TournamentAdminControllerTest.java
@@ -870,9 +870,8 @@ class TournamentAdminControllerTest {
                 if (tournamentRound == TournamentRound.THE_FINAL) {
                     TournamentGame tournamentGame = new TournamentGame(null, tournament, tournamentRound);
                     tournamentGameRepository.save(tournamentGame);
-                    tournament.addTournamentGame(tournamentGame);
                 }else {
-                    tournament.addTournamentGame(testDataUtils.createTournamentGame(tournament, tournamentRound, game));
+                    testDataUtils.createTournamentGame(tournament, tournamentRound, game);
                 }
             }
         }

--- a/src/test/java/com/gg/server/admin/tournament/service/TournamentAdminServiceTest.java
+++ b/src/test/java/com/gg/server/admin/tournament/service/TournamentAdminServiceTest.java
@@ -358,7 +358,6 @@ class TournamentAdminServiceTest {
             Tournament tournament = tournamentList.get(0);
             TournamentAdminAddUserRequestDto requestDto = new TournamentAdminAddUserRequestDto("testUser");
             User user = createUser("testUser");
-            TournamentUser tournamentUser = new TournamentUser(user, tournament, true, LocalDateTime.now());
             given(tournamentRepository.findById(1L)).willReturn(Optional.of(tournament));
             given(userRepository.findByIntraId("testUser")).willReturn(Optional.of(user));
 
@@ -420,7 +419,6 @@ class TournamentAdminServiceTest {
             TournamentAdminAddUserRequestDto requestDto = new TournamentAdminAddUserRequestDto("testUser");
             User user = createUser("testUser");
             TournamentUser tournamentUser = new TournamentUser(user, tournament, true, LocalDateTime.now());
-            tournament.addTournamentUser(tournamentUser);
             given(tournamentRepository.findById(1L)).willReturn(Optional.of(tournament));
             given(userRepository.findByIntraId("testUser")).willReturn(Optional.of(user));
 

--- a/src/test/java/com/gg/server/admin/tournament/service/TournamentAdminServiceTest.java
+++ b/src/test/java/com/gg/server/admin/tournament/service/TournamentAdminServiceTest.java
@@ -29,6 +29,7 @@ import com.gg.server.domain.user.type.RacketType;
 import com.gg.server.domain.user.type.RoleType;
 import com.gg.server.domain.user.type.SnsType;
 import com.gg.server.global.exception.custom.InvalidParameterException;
+import com.gg.server.utils.ReflectionUtilsForUnitTest;
 import com.gg.server.utils.annotation.UnitTest;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -58,6 +59,8 @@ class TournamentAdminServiceTest {
     GameRepository gameRepository;
     @InjectMocks
     TournamentAdminService tournamentAdminService;
+
+    ReflectionUtilsForUnitTest reflectionUtilsForUnitTest = new ReflectionUtilsForUnitTest();
 
     // 토너먼트 생성 서비스 테스트
     @Nested
@@ -311,7 +314,6 @@ class TournamentAdminServiceTest {
             int tournamentGameCnt = 7;
             Tournament tournament = createTournament(1L, TournamentStatus.BEFORE,
                 getTargetTime(2, 1), getTargetTime(2, 3));
-            List<TournamentGame> tournamentGameList = createTournamentGames(1L, tournament, tournamentGameCnt);
             given(tournamentRepository.findById(1L)).willReturn(Optional.of(tournament));
             // when, then
             tournamentAdminService.deleteTournament(tournament.getId());
@@ -493,18 +495,16 @@ class TournamentAdminServiceTest {
      * @return
      */
     private Tournament createTournament(Long id, TournamentStatus status, LocalDateTime startTime, LocalDateTime endTime) {
-        return new Tournament(
-            id,
-            id + "st tournament",
-            "",
-            startTime,
-            endTime,
-            TournamentType.ROOKIE,
-            status,
-            null,
-            new ArrayList<>(),
-            new ArrayList<>()
-            );
+        Tournament tournament =  Tournament.builder()
+            .title(id + "st tournament")
+            .contents("")
+            .startTime(startTime)
+            .endTime(endTime)
+            .type(TournamentType.ROOKIE)
+            .status(status)
+            .build();
+        reflectionUtilsForUnitTest.setFieldWithReflection(tournament, "id", id);
+        return tournament;
     }
 
     /**
@@ -554,21 +554,5 @@ class TournamentAdminServiceTest {
             .roleType(RoleType.USER)
             .totalExp(1000)
             .build();
-    }
-
-    /**
-     * cnt 사이즈의 토너먼트 게임 리스트 생성
-     * @param id 토너먼트 게임 id
-     * @param tournament 해당 토너먼트
-     * @param cnt 토너먼트 게임 수
-     * @return
-     */
-    private List<TournamentGame> createTournamentGames(Long id, Tournament tournament, int cnt) {
-        List<TournamentGame> tournamentGameList = new ArrayList<>();
-        TournamentRound [] values = TournamentRound.values();
-        while (--cnt >= 0) {
-            tournamentGameList.add(new TournamentGame(id, null, tournament, values[cnt]));
-        }
-        return tournamentGameList;
     }
 }

--- a/src/test/java/com/gg/server/domain/game/data/GameUnitTest.java
+++ b/src/test/java/com/gg/server/domain/game/data/GameUnitTest.java
@@ -1,0 +1,121 @@
+package com.gg.server.domain.game.data;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+import com.gg.server.domain.team.data.Team;
+import com.gg.server.global.exception.ErrorCode;
+import com.gg.server.global.exception.custom.BusinessException;
+import com.gg.server.utils.annotation.UnitTest;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@UnitTest
+@DisplayName("GameUnitTest")
+class GameUnitTest {
+  List<Team> mockTeams;
+  List<Game> games;
+
+  @BeforeEach
+  void setUp() {
+    mockTeams = IntStream.range(0, 10)
+        .mapToObj(i -> mock(Team.class))
+        .collect(Collectors.toCollection(ArrayList::new));
+    games = IntStream.range(0, 10)
+        .mapToObj(i -> new Game())
+        .collect(Collectors.toCollection(ArrayList::new));
+  }
+
+  @Nested
+  @DisplayName("AddTeam")
+  class AddTeam {
+    @Test
+    @DisplayName("단일 Team 추가 성공")
+    public void addSingleTeamSuccess() {
+      //given
+      Game game = games.get(0);
+      Team mockTeam = mockTeams.get(0);
+
+      //when
+      game.addTeam(mockTeam);
+
+      //then
+      assertEquals(1, game.getTeams().size());
+      assertEquals(mockTeam, game.getTeams().get(0));
+    }
+
+    @Test
+    @DisplayName("두개 Team 추가 성공")
+    void addMultiTeamSuccess() {
+      //given
+      Game game = games.get(0);
+
+      //when
+      game.addTeam(mockTeams.get(0));
+      game.addTeam(mockTeams.get(1));
+
+      //then
+      assertEquals(2, game.getTeams().size());
+      assertEquals(mockTeams.get(0), game.getTeams().get(0));
+      assertEquals(mockTeams.get(1), game.getTeams().get(1));
+    }
+
+    @Test
+    @DisplayName("두개 이상의 Team 추가 실패")
+    void addExceedTeamFailed() {
+      //given
+      Game game = games.get(0);
+
+      //when
+      game.addTeam(mockTeams.get(0));
+      game.addTeam(mockTeams.get(1));
+
+      //then
+      BusinessException businessException = assertThrows(BusinessException.class,
+          () -> game.addTeam(mockTeams.get(2)));
+      assertEquals(ErrorCode.TEAM_SIZE_EXCEED, businessException.getErrorCode());
+      assertEquals(ErrorCode.TEAM_SIZE_EXCEED.getMessage(), businessException.getMessage());
+    }
+
+    @Test
+    @DisplayName("동일한 Team 추가 실패")
+    void duplicatedTeamAddFailed() {
+      //given
+      Game game = games.get(0);
+
+      //when
+      game.addTeam(mockTeams.get(0));
+
+      //then
+      BusinessException businessException = assertThrows(BusinessException.class,
+          () -> game.addTeam(mockTeams.get(0)));
+      assertEquals(ErrorCode.TEAM_DUPLICATION, businessException.getErrorCode());
+      assertEquals(ErrorCode.TEAM_DUPLICATION.getMessage(), businessException.getMessage());
+    }
+
+    @Test
+    @DisplayName("null 포인터 전달 시 실패")
+    void nullAddFailed() {
+      //given
+      Game game = games.get(0);
+
+      //when
+      Team team = null;
+
+      //then
+      BusinessException businessException = assertThrows(BusinessException.class,
+          () -> game.addTeam(team));
+      assertEquals(ErrorCode.NULL_POINT, businessException.getErrorCode());
+      assertEquals(ErrorCode.NULL_POINT.getMessage(), businessException.getMessage());
+    }
+  }
+
+
+}

--- a/src/test/java/com/gg/server/domain/game/data/GameUnitTest.java
+++ b/src/test/java/com/gg/server/domain/game/data/GameUnitTest.java
@@ -116,6 +116,4 @@ class GameUnitTest {
       assertEquals(ErrorCode.NULL_POINT.getMessage(), businessException.getMessage());
     }
   }
-
-
 }

--- a/src/test/java/com/gg/server/domain/team/data/TeamUnitTest.java
+++ b/src/test/java/com/gg/server/domain/team/data/TeamUnitTest.java
@@ -1,0 +1,120 @@
+package com.gg.server.domain.team.data;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+import com.gg.server.global.exception.ErrorCode;
+import com.gg.server.global.exception.custom.BusinessException;
+import com.gg.server.utils.annotation.UnitTest;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@UnitTest
+@DisplayName("TeamUnitTest")
+class TeamUnitTest {
+
+  List<TeamUser> mockTeamUsers;
+  List<Team> teams;
+
+  @BeforeEach
+  void setUp() {
+    mockTeamUsers = IntStream.range(0, 10)
+        .mapToObj(i -> mock(TeamUser.class))
+        .collect(Collectors.toCollection(ArrayList::new));
+    teams = IntStream.range(0, 10)
+        .mapToObj(i -> new Team())
+        .collect(Collectors.toCollection(ArrayList::new));
+  }
+
+  @Nested
+  @DisplayName("AddTeamUser")
+  class AddTeam {
+
+    @Test
+    @DisplayName("단일 TeamUser 추가 성공")
+    public void addSingleTeamSuccess() {
+      //given
+      Team team = teams.get(0);
+      TeamUser mockTeamUser = mockTeamUsers.get(0);
+
+      //when
+      team.addTeamUser(mockTeamUser);
+
+      //then
+      assertEquals(1, team.getTeamUsers().size());
+      assertEquals(mockTeamUser, team.getTeamUsers().get(0));
+    }
+
+    @Test
+    @DisplayName("두개 TeamUser 추가 성공")
+    void addMultiTeamSuccess() {
+      //given
+      Team team = teams.get(0);
+
+      //when
+      team.addTeamUser(mockTeamUsers.get(0));
+      team.addTeamUser(mockTeamUsers.get(1));
+
+      //then
+      assertEquals(2, team.getTeamUsers().size());
+      assertEquals(mockTeamUsers.get(0), team.getTeamUsers().get(0));
+      assertEquals(mockTeamUsers.get(1), team.getTeamUsers().get(1));
+    }
+
+    @Test
+    @DisplayName("두개 이상의 TeamUser 추가 실패")
+    void addExceedTeamFailed() {
+      //given
+      Team team = teams.get(0);
+
+      //when
+      team.addTeamUser(mockTeamUsers.get(0));
+      team.addTeamUser(mockTeamUsers.get(1));
+
+      //then
+      BusinessException businessException = assertThrows(BusinessException.class,
+          () -> team.addTeamUser(mockTeamUsers.get(2)));
+      assertEquals(ErrorCode.TEAM_USER_EXCEED, businessException.getErrorCode());
+      assertEquals(ErrorCode.TEAM_USER_EXCEED.getMessage(), businessException.getMessage());
+    }
+
+    @Test
+    @DisplayName("동일한 TeamUser 추가 실패")
+    void duplicatedTeamAddFailed() {
+      //given
+      Team team = teams.get(0);
+
+      //when
+      team.addTeamUser(mockTeamUsers.get(0));
+
+      //then
+      BusinessException businessException = assertThrows(BusinessException.class,
+          () -> team.addTeamUser(mockTeamUsers.get(0)));
+      assertEquals(ErrorCode.TEAM_USER_ALREADY_EXIST, businessException.getErrorCode());
+      assertEquals(ErrorCode.TEAM_USER_ALREADY_EXIST.getMessage(), businessException.getMessage());
+    }
+
+    @Test
+    @DisplayName("null 포인터 전달 시 실패")
+    void nullAddFailed() {
+      //given
+      Team team = teams.get(0);
+
+      //when
+      TeamUser teamUser = null;
+
+      //then
+      BusinessException businessException = assertThrows(BusinessException.class,
+          () -> team.addTeamUser(teamUser));
+      assertEquals(ErrorCode.NULL_POINT, businessException.getErrorCode());
+      assertEquals(ErrorCode.NULL_POINT.getMessage(), businessException.getMessage());
+    }
+  }
+}

--- a/src/test/java/com/gg/server/domain/tournament/controller/TournamentSchedulerTest.java
+++ b/src/test/java/com/gg/server/domain/tournament/controller/TournamentSchedulerTest.java
@@ -44,9 +44,6 @@ public class TournamentSchedulerTest {
         // BEFORE로 토너먼트 생성
         Tournament tournament = testDataUtils.createTournamentWithUser(Tournament.ALLOWED_JOINED_NUMBER, 4, "test");
         List<TournamentGame> tournamentGameList = testDataUtils.createTournamentGameList(tournament, 7);
-        for (TournamentGame tournamentGame : tournamentGameList) {
-            tournament.addTournamentGame(tournamentGame);
-        }
         SlotManagement slotManagement = SlotManagement.builder()
             .pastSlotTime(0)
             .futureSlotTime(0)

--- a/src/test/java/com/gg/server/domain/tournament/data/TournamentUnitTest.java
+++ b/src/test/java/com/gg/server/domain/tournament/data/TournamentUnitTest.java
@@ -1,0 +1,328 @@
+package com.gg.server.domain.tournament.data;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+
+import com.gg.server.domain.tournament.type.TournamentStatus;
+import com.gg.server.domain.user.data.User;
+import com.gg.server.global.exception.ErrorCode;
+import com.gg.server.global.exception.custom.BusinessException;
+import com.gg.server.utils.annotation.UnitTest;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+
+@UnitTest
+@DisplayName("TournamentUnitTest")
+class TournamentUnitTest {
+
+  List<TournamentGame> mockTournamentGames;
+  List<TournamentUser> mockTournamentUsers;
+  List<Tournament> tournaments;
+
+  @BeforeEach
+  void setUp() {
+    mockTournamentGames = IntStream.range(0, 10)
+        .mapToObj(i -> {
+          TournamentGame tournamentGame = mock(TournamentGame.class);
+          doNothing().when(tournamentGame).setTournament(Mockito.any(Tournament.class));
+          return tournamentGame;
+        })
+        .collect(Collectors.toCollection(ArrayList::new));
+
+    mockTournamentUsers = IntStream.range(0, 10)
+        .mapToObj(i -> {
+          TournamentUser tournamentUser = mock(TournamentUser.class);
+          doNothing().when(tournamentUser).setTournament(Mockito.any(Tournament.class));
+          return tournamentUser;
+        })
+        .collect(Collectors.toCollection(ArrayList::new));
+
+    tournaments = IntStream.range(0, 10)
+        .mapToObj(i -> new Tournament())
+        .collect(Collectors.toCollection(ArrayList::new));
+  }
+
+  @Nested
+  @DisplayName("AddTournamentGame")
+  class AddTournamentGame {
+
+    @Test
+    @DisplayName("단일 TournamentGame 추가 성공")
+    public void addSingleTournamentGameSuccess() {
+      //given
+      Tournament tournament = tournaments.get(0);
+      TournamentGame mockTournamentGame = mockTournamentGames.get(0);
+
+      //when
+      tournament.addTournamentGame(mockTournamentGame);
+
+      //then
+      assertEquals(1, tournament.getTournamentGames().size());
+      assertEquals(mockTournamentGame, tournament.getTournamentGames().get(0));
+    }
+
+    @Test
+    @DisplayName("최대 TournamentGame 추가 성공")
+    void addMultiTournamentGameSuccess() {
+      //given
+      Tournament tournament = tournaments.get(0);
+
+      //when
+      IntStream.range(0, 7).forEach(i -> tournament.addTournamentGame(mockTournamentGames.get(i)));
+
+      //then
+      assertEquals(7, tournament.getTournamentGames().size());
+      IntStream.range(0, 7).forEach(i ->
+          assertEquals(mockTournamentGames.get(i), tournament.getTournamentGames().get(i)));
+    }
+
+    @Test
+    @DisplayName("최대 이상의 TournamentGame 추가 실패")
+    void addExceedTournamentGameFailed() {
+      //given
+      Tournament tournament = tournaments.get(0);
+
+      //when
+      IntStream.range(0, 7).forEach(i -> tournament.addTournamentGame(mockTournamentGames.get(i)));
+
+      //then
+      BusinessException businessException = assertThrows(BusinessException.class,
+          () -> tournament.addTournamentGame(mockTournamentGames.get(7)));
+      assertEquals(ErrorCode.TOURNAMENT_GAME_EXCEED, businessException.getErrorCode());
+      assertEquals(ErrorCode.TOURNAMENT_GAME_EXCEED.getMessage(), businessException.getMessage());
+    }
+
+    @Test
+    @DisplayName("동일한 TournamentGame 추가 실패")
+    void duplicatedTournamentGameAddFailed() {
+      //given
+      Tournament tournament = tournaments.get(0);
+
+      //when
+      tournament.addTournamentGame(mockTournamentGames.get(0));
+
+      //then
+      BusinessException businessException = assertThrows(BusinessException.class,
+          () -> tournament.addTournamentGame(mockTournamentGames.get(0)));
+      assertEquals(ErrorCode.TOURNAMENT_GAME_DUPLICATION, businessException.getErrorCode());
+      assertEquals(ErrorCode.TOURNAMENT_GAME_DUPLICATION.getMessage(),
+          businessException.getMessage());
+    }
+
+    @Test
+    @DisplayName("null 포인터 전달 시 실패")
+    void nullAddFailed() {
+      //given
+      Tournament tournament = tournaments.get(0);
+
+      //when
+      TournamentGame tournamentGame = null;
+
+      //then
+      BusinessException businessException = assertThrows(BusinessException.class,
+          () -> tournament.addTournamentGame(tournamentGame));
+      assertEquals(ErrorCode.NULL_POINT, businessException.getErrorCode());
+      assertEquals(ErrorCode.NULL_POINT.getMessage(), businessException.getMessage());
+    }
+  }
+
+  @Nested
+  @DisplayName("AddTournamentUser")
+  class AddTournamentUser {
+
+    @Test
+    @DisplayName("단일 TournamentUser 추가 성공")
+    public void addSingleTournamentGameSuccess() {
+      //given
+      Tournament tournament = tournaments.get(0);
+      TournamentUser mockTournamentUser = mockTournamentUsers.get(0);
+
+      //when
+      tournament.addTournamentUser(mockTournamentUser);
+
+      //then
+      assertEquals(1, tournament.getTournamentUsers().size());
+      assertEquals(mockTournamentUser, tournament.getTournamentUsers().get(0));
+    }
+
+    @Test
+    @DisplayName("여러 TournamentUser 추가 성공")
+    void addMultiTournamentGameSuccess() {
+      //given
+      Tournament tournament = tournaments.get(0);
+
+      //when
+      IntStream.range(0, mockTournamentUsers.size()).forEach(i ->
+          tournament.addTournamentUser(mockTournamentUsers.get(i)));
+
+      //then
+      assertEquals(mockTournamentUsers.size(), tournament.getTournamentUsers().size());
+      IntStream.range(0, mockTournamentUsers.size()).forEach(i ->
+          assertEquals(mockTournamentUsers.get(i), tournament.getTournamentUsers().get(i)));
+    }
+
+    @Test
+    @DisplayName("동일한 TournamentUser 추가 실패")
+    void duplicatedTournamentGameAddFailed() {
+      //given
+      Tournament tournament = tournaments.get(0);
+
+      //when
+      tournament.addTournamentUser(mockTournamentUsers.get(0));
+
+      //then
+      BusinessException businessException = assertThrows(BusinessException.class,
+          () -> tournament.addTournamentUser(mockTournamentUsers.get(0)));
+      assertEquals(ErrorCode.TOURNAMENT_USER_DUPLICATION, businessException.getErrorCode());
+      assertEquals(ErrorCode.TOURNAMENT_USER_DUPLICATION.getMessage(),
+          businessException.getMessage());
+    }
+
+    @Test
+    @DisplayName("null 포인터 전달 시 실패")
+    void nullAddFailed() {
+      //given
+      Tournament tournament = tournaments.get(0);
+
+      //when
+      TournamentUser tournamentUser = null;
+
+      //then
+      BusinessException businessException = assertThrows(BusinessException.class,
+          () -> tournament.addTournamentUser(tournamentUser));
+      assertEquals(ErrorCode.NULL_POINT, businessException.getErrorCode());
+      assertEquals(ErrorCode.NULL_POINT.getMessage(), businessException.getMessage());
+    }
+  }
+
+  @Nested
+  @DisplayName("DeleteTournamentUser")
+  class DeleteTournamentUser {
+
+    @Test
+    @DisplayName("TournamentUser 삭제 성공")
+    public void addSingleTournamentGameSuccess() {
+      //given
+      Tournament tournament = tournaments.get(0);
+      TournamentUser mockTournamentUser = mockTournamentUsers.get(0);
+      tournament.addTournamentUser(mockTournamentUser);
+
+      //when
+      tournament.deleteTournamentUser(mockTournamentUser);
+
+      //then
+      assertEquals(0, tournament.getTournamentUsers().size());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 TournamentUser 삭제 실패")
+    void duplicatedTournamentGameAddFailed() {
+      //given
+      Tournament tournament = tournaments.get(0);
+
+      //when
+      tournament.addTournamentUser(mockTournamentUsers.get(0));
+
+      //then
+      BusinessException businessException = assertThrows(BusinessException.class,
+          () -> tournament.deleteTournamentUser(mockTournamentUsers.get(1)));
+      assertEquals(ErrorCode.TOURNAMENT_USER_NOT_FOUND, businessException.getErrorCode());
+      assertEquals(ErrorCode.TOURNAMENT_USER_NOT_FOUND.getMessage(),
+          businessException.getMessage());
+    }
+
+    @Test
+    @DisplayName("null 포인터 전달 시 실패")
+    void nullAddFailed() {
+      //given
+      Tournament tournament = tournaments.get(0);
+
+      //when
+      TournamentUser tournamentUser = null;
+
+      //then
+      BusinessException businessException = assertThrows(BusinessException.class,
+          () -> tournament.deleteTournamentUser(tournamentUser));
+      assertEquals(ErrorCode.NULL_POINT, businessException.getErrorCode());
+      assertEquals(ErrorCode.NULL_POINT.getMessage(), businessException.getMessage());
+    }
+  }
+
+  @Nested
+  @DisplayName("UpdateWinner")
+  class UpdateWinner {
+    @Test
+    @DisplayName("null 포인터 전달 시 실패")
+    void nullAddFailed() {
+      //given
+      Tournament tournament = tournaments.get(0);
+
+      //when
+      User user = null;
+
+      //then
+      BusinessException businessException = assertThrows(BusinessException.class,
+          () -> tournament.updateWinner(user));
+      assertEquals(ErrorCode.NULL_POINT, businessException.getErrorCode());
+      assertEquals(ErrorCode.NULL_POINT.getMessage(), businessException.getMessage());
+    }
+
+    @Test
+    @DisplayName("승자 업데이트 성공")
+    void updateSuccess() {
+      //given
+      Tournament tournament = tournaments.get(0);
+      User user = mock(User.class);
+
+      //when
+      tournament.updateWinner(user);
+
+      //then
+      assertEquals(user, tournament.getWinner());
+    }
+  }
+
+  @Nested
+  @DisplayName("UpdateStatus")
+  class UpdateStatus {
+    @Test
+    @DisplayName("null 포인터 전달 시 실패")
+    void nullAddFailed() {
+      //given
+      Tournament tournament = tournaments.get(0);
+
+      //when
+      TournamentStatus status = null;
+
+      //then
+      BusinessException businessException = assertThrows(BusinessException.class,
+          () -> tournament.updateStatus(status));
+      assertEquals(ErrorCode.NULL_POINT, businessException.getErrorCode());
+      assertEquals(ErrorCode.NULL_POINT.getMessage(), businessException.getMessage());
+    }
+
+    @Test
+    @DisplayName("상태 업데이트 성공")
+    void updateSuccess() {
+      //given
+      Tournament tournament = tournaments.get(0);
+      TournamentStatus status = TournamentStatus.LIVE;
+
+      //when
+      tournament.updateStatus(status);
+
+      //then
+      assertEquals(status, tournament.getStatus());
+    }
+  }
+}

--- a/src/test/java/com/gg/server/domain/tournament/data/TournamentUnitTest.java
+++ b/src/test/java/com/gg/server/domain/tournament/data/TournamentUnitTest.java
@@ -40,11 +40,7 @@ class TournamentUnitTest {
         .collect(Collectors.toCollection(ArrayList::new));
 
     mockTournamentUsers = IntStream.range(0, 10)
-        .mapToObj(i -> {
-          TournamentUser tournamentUser = mock(TournamentUser.class);
-          doNothing().when(tournamentUser).setTournament(Mockito.any(Tournament.class));
-          return tournamentUser;
-        })
+        .mapToObj(i -> mock(TournamentUser.class))
         .collect(Collectors.toCollection(ArrayList::new));
 
     tournaments = IntStream.range(0, 10)

--- a/src/test/java/com/gg/server/domain/tournament/data/TournamentUnitTest.java
+++ b/src/test/java/com/gg/server/domain/tournament/data/TournamentUnitTest.java
@@ -32,11 +32,7 @@ class TournamentUnitTest {
   @BeforeEach
   void setUp() {
     mockTournamentGames = IntStream.range(0, 10)
-        .mapToObj(i -> {
-          TournamentGame tournamentGame = mock(TournamentGame.class);
-          doNothing().when(tournamentGame).setTournament(Mockito.any(Tournament.class));
-          return tournamentGame;
-        })
+        .mapToObj(i -> mock(TournamentGame.class))
         .collect(Collectors.toCollection(ArrayList::new));
 
     mockTournamentUsers = IntStream.range(0, 10)

--- a/src/test/java/com/gg/server/domain/tournament/service/TournamentServiceTest.java
+++ b/src/test/java/com/gg/server/domain/tournament/service/TournamentServiceTest.java
@@ -157,6 +157,22 @@ class TournamentServiceTest {
     @DisplayName("토너먼트_유저_참가_취소_테스트")
     class cancelTournamentUserRegistration {
         @Test
+        @DisplayName("유저_참가_취소_성공")
+        @Disabled
+        void success() {
+            // given
+            Tournament tournament = createTournament(1L, TournamentStatus.BEFORE,
+                LocalDateTime.now(), LocalDateTime.now().plusHours(2));
+            User user = createUser("testUser");
+            TournamentUser tournamentUser = new TournamentUser(user, tournament, true, LocalDateTime.now());
+            given(tournamentRepository.findById(tournament.getId())).willReturn(Optional.of(tournament));
+            given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
+
+            // when, then
+            tournamentService.cancelTournamentUserRegistration(tournament.getId(), UserDto.from(user));
+        }
+
+        @Test
         @DisplayName("찾을_수_없는_토너먼트")
         void tournamentNotFound() {
             // given

--- a/src/test/java/com/gg/server/domain/tournament/service/TournamentServiceTest.java
+++ b/src/test/java/com/gg/server/domain/tournament/service/TournamentServiceTest.java
@@ -25,6 +25,7 @@ import com.gg.server.domain.user.exception.UserNotFoundException;
 import com.gg.server.domain.user.type.RacketType;
 import com.gg.server.domain.user.type.RoleType;
 import com.gg.server.domain.user.type.SnsType;
+import com.gg.server.utils.ReflectionUtilsForUnitTest;
 import com.gg.server.utils.annotation.UnitTest;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -52,6 +53,7 @@ class TournamentServiceTest {
     UserRepository userRepository;
     @InjectMocks
     TournamentService tournamentService;
+    ReflectionUtilsForUnitTest reflectionUtilsForUnitTest = new ReflectionUtilsForUnitTest();
 
     @Nested
     @DisplayName("토너먼트_유저_상태_테스트")
@@ -223,27 +225,17 @@ class TournamentServiceTest {
         return LocalDateTime.now().plusDays(days).plusHours(hours);
     }
 
-    /**
-     * 각 매개변수로 초기화 된 토너먼트를 반환
-     * @param id
-     * @param status
-     * @param startTime
-     * @param endTime
-     * @return
-     */
     private Tournament createTournament(Long id, TournamentStatus status, LocalDateTime startTime, LocalDateTime endTime) {
-        return new Tournament(
-            id,
-            id + "st tournament",
-            "",
-            startTime,
-            endTime,
-            TournamentType.ROOKIE,
-            status,
-            null,
-            new ArrayList<>(),
-            new ArrayList<>()
-            );
+      Tournament tournament = Tournament.builder()
+          .title(id + "st tournament")
+          .contents("")
+          .startTime(startTime)
+          .endTime(endTime)
+          .type(TournamentType.ROOKIE)
+          .status(status)
+          .build();
+      reflectionUtilsForUnitTest.setFieldWithReflection(tournament, "id", id);
+      return tournament;
     }
 
     /**
@@ -293,21 +285,5 @@ class TournamentServiceTest {
             .roleType(RoleType.USER)
             .totalExp(1000)
             .build();
-    }
-
-    /**
-     * cnt 사이즈의 토너먼트 게임 리스트 생성
-     * @param id 토너먼트 게임 id
-     * @param tournament 해당 토너먼트
-     * @param cnt 토너먼트 게임 수
-     * @return
-     */
-    private List<TournamentGame> createTournamentGames(Long id, Tournament tournament, int cnt) {
-        List<TournamentGame> tournamentGameList = new ArrayList<>();
-        TournamentRound [] values = TournamentRound.values();
-        while (--cnt >= 0) {
-            tournamentGameList.add(new TournamentGame(id, null, tournament, values[cnt]));
-        }
-        return tournamentGameList;
     }
 }

--- a/src/test/java/com/gg/server/utils/ReflectionUtilsForUnitTest.java
+++ b/src/test/java/com/gg/server/utils/ReflectionUtilsForUnitTest.java
@@ -1,0 +1,29 @@
+package com.gg.server.utils;
+
+import com.gg.server.global.exception.ErrorCode;
+import com.gg.server.global.exception.custom.BusinessException;
+import java.lang.reflect.Field;
+
+/**
+ * ReflectionUtilsForUnitTest.
+ *
+ * <p>
+ *  유닛 테스트를 위한 리플렉션 유틸리티
+ * </p>
+ *
+ */
+public class ReflectionUtilsForUnitTest {
+
+  /**
+   * 리플렉션을 사용해서 필드값을 설정한다.
+   */
+  public void setFieldWithReflection(Object object, String fieldName, Object value) {
+    try {
+      Field field = object.getClass().getDeclaredField(fieldName);
+      field.setAccessible(true);
+      field.set(object, value);
+    } catch (NoSuchFieldException | IllegalAccessException e) {
+      throw new BusinessException(ErrorCode.BAD_REQUEST);
+    }
+  }
+}

--- a/src/test/java/com/gg/server/utils/TestDataUtils.java
+++ b/src/test/java/com/gg/server/utils/TestDataUtils.java
@@ -519,7 +519,6 @@ public class TestDataUtils {
      */
     public TournamentUser createTournamentUser(User user, Tournament tournament, boolean isJoined) {
         TournamentUser tournamentUser = new TournamentUser(user, tournament, isJoined, LocalDateTime.now());
-        tournament.addTournamentUser(tournamentUser);
         return tournamentUserRepository.save(tournamentUser);
     }
 

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -274,46 +274,52 @@ CREATE TABLE `team_user` (
 
 DROP TABLE IF EXISTS `tournament`;
 CREATE TABLE tournament (
-id                  BIGINT NOT NULL AUTO_INCREMENT,
-title               VARCHAR(30) NOT NULL,
-contents            VARCHAR(1000) NOT NULL,
-start_time          DATETIME NOT NULL,
-end_time            DATETIME NOT NULL,
-type                VARCHAR(15) NOT NULL,
-status              VARCHAR(10) NOT NULL DEFAULT 'BEFORE',
-created_at          DATETIME NOT NULL,
-modified_at         DATETIME NOT NULL,
-winner_id           BIGINT,
-PRIMARY KEY (id),
-FOREIGN KEY (winner_id) REFERENCES user(id)
-);
+    id                  BIGINT NOT NULL AUTO_INCREMENT,
+    title               VARCHAR(30) NOT NULL,
+    contents            VARCHAR(1000) NOT NULL,
+    start_time          DATETIME NOT NULL,
+    end_time            DATETIME NOT NULL,
+    type                VARCHAR(15) NOT NULL,
+    status              VARCHAR(10) NOT NULL DEFAULT 'BEFORE',
+    created_at          DATETIME NOT NULL,
+    modified_at         DATETIME NOT NULL,
+    winner_id           BIGINT,
+    PRIMARY KEY (id),
+    FOREIGN KEY (winner_id) REFERENCES user(id)
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
 
 DROP TABLE IF EXISTS `tournament_user`;
 CREATE TABLE tournament_user (
- id              BIGINT NOT NULL AUTO_INCREMENT,
- user_id         BIGINT NOT NULL,
- tournament_id   BIGINT NOT NULL,
- is_joined       BOOLEAN NOT NULL DEFAULT FALSE,
- register_time   DATETIME NOT NULL,
- created_at      DATETIME NOT NULL,
- modified_at      DATETIME NOT NULL,
- PRIMARY KEY (id),
- FOREIGN KEY (tournament_id) REFERENCES tournament(id),
- FOREIGN KEY (user_id)       REFERENCES user(id)
-) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;;
+     id              BIGINT NOT NULL AUTO_INCREMENT,
+     user_id         BIGINT NOT NULL,
+     tournament_id   BIGINT NOT NULL,
+     is_joined       BOOLEAN NOT NULL DEFAULT FALSE,
+     register_time   DATETIME NOT NULL,
+     created_at      DATETIME NOT NULL,
+     modified_at      DATETIME NOT NULL,
+     PRIMARY KEY (id),
+     FOREIGN KEY (tournament_id) REFERENCES tournament(id)
+         ON UPDATE CASCADE
+         ON DELETE CASCADE ,
+     FOREIGN KEY (user_id)       REFERENCES user(id)
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
 
 DROP TABLE IF EXISTS `tournament_game`;
 CREATE TABLE tournament_game (
- id                  BIGINT NOT NULL AUTO_INCREMENT,
- tournament_id       BIGINT NOT NULL,
- game_id             BIGINT,
- round               VARCHAR(20) NOT NULL,
- created_at          DATETIME NOT NULL,
- modified_at          DATETIME NOT NULL,
- PRIMARY KEY (id),
- FOREIGN KEY (tournament_id) REFERENCES tournament(id),
- FOREIGN KEY (game_id)       REFERENCES game(id)
-) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;;
+     id                  BIGINT NOT NULL AUTO_INCREMENT,
+     tournament_id       BIGINT NOT NULL,
+     game_id             BIGINT,
+     round               VARCHAR(20) NOT NULL,
+     created_at          DATETIME NOT NULL,
+     modified_at          DATETIME NOT NULL,
+     PRIMARY KEY (id),
+     FOREIGN KEY (tournament_id) REFERENCES tournament(id)
+         ON UPDATE CASCADE
+         ON DELETE CASCADE ,
+     FOREIGN KEY (game_id)       REFERENCES game(id)
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 
 
 DROP TABLE IF EXISTS `user_image`;


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 토너먼트 도메인에 연관관계 편의 메서드를 적용합니다.
  - 테스트 코드 작성시 오동작이 발생하는 경우가 많아 예외를 바로 파악할 수 있게 검증 로직들을 추가했습니다.
  - 모든 연관관계 관리는 연관관의 주인, fk를 가진 쪽에서 수행합니다.
  
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - 토너먼트 연관관계 메서드 작성
  - Game 연관관계 메서드 개선 
  - 메서드 파라미터 단 @ NotNull은 기능이 없어 제거
  - 토너먼트 엔티티의 연관관계 필드 변경 및 검증 메서드를 fk를 가지고 있는 엔티티가 아닌 외부(기타 서비스 코드)에서 호출하지 못하도록 protected 레벨로 선언.
  - 개발자 로직 정상작성 체크용 검증 static 유틸리티 추가
  - schema.sql 최신화 (Cascade 추가) 
  - Tournament, Game, Team 단위테스트 추가
  - Builder가 존재하는 클래스에 존재하는 AllArgConstructor는 서비스 일관성을 해치게 됩니다. 따라서 제거합니다.
  - 유닛 테스트에서 private id 필드 값을 조정하기 위해 reflection을 사용해서 처리하는 것으로 대체

## 연관관계 편의 메서드와 필드 검증의 책임 분리
- 여기서 정의된 연관관계 편의 메서드란 양방향 매핑 관계의 있는 엔티티들을 일치시키는 역할을 말합니다.
- 필드 변경 및 검증 메소드는 토너먼트에 존재하는 addTournamentGame, addTournamentUser, deleteTournamentUser 가 해당합니다. 연관관계 일치 책임은 fk를 가진 엔티티가 가지지만 필드 검증은 해당 필드를 가진 엔티티가 담당해야 하기 때문에 해당 메소드가 존재합니다.

 ## 💡Issue 번호 <!-- issue number을 link 시켜주세요 (ex. "- close #4242") -->
 - #378 