### PR TITLE
🐛  [Fix] 관리자 게임 전체 조회에서 토너먼트 보이는 문제

### DIFF
--- a/src/main/java/com/gg/server/admin/game/data/GameAdminRepository.java
+++ b/src/main/java/com/gg/server/admin/game/data/GameAdminRepository.java
@@ -2,6 +2,7 @@ package com.gg.server.admin.game.data;
 
 import com.gg.server.domain.game.data.Game;
 import com.gg.server.domain.game.dto.GameTeamUser;
+import com.gg.server.domain.game.type.Mode;
 import com.gg.server.domain.game.type.StatusType;
 import com.gg.server.domain.season.data.Season;
 import java.util.Optional;
@@ -16,6 +17,10 @@ import java.util.List;
 public interface GameAdminRepository extends JpaRepository<Game, Long> {
 
     Page<Game> findBySeason(Pageable pageable, Season season);
+
+    Page<Game> findBySeasonAndModeIn(Pageable pageable, Season season, List<Mode> modes);
+
+    Page<Game> findAllByModeIn(Pageable pageable, List<Mode> modes);
 
     @Query(value = "select t1.gameId, t1.startTime, t1.endTime, t1.status, t1.mode, " +
             "t1.teamId t1TeamId, t1.intraId t1IntraId, t1.win t1IsWin, t1.score t1Score, t1.image t1Image, t1.total_exp t1Exp, t1.wins t1Wins, t1.losses t1Losses, " +

--- a/src/main/java/com/gg/server/admin/game/service/GameAdminService.java
+++ b/src/main/java/com/gg/server/admin/game/service/GameAdminService.java
@@ -78,7 +78,7 @@ public class GameAdminService {
     }
 
     /**
-     * 특정 유저의 게임 목록 조회
+     * 특정 유저의 게임 목록 조회 (토너먼트 게임 제외)
      * @param intraId 조회할 유저의 intraId
      * @param pageable page size
      * @return GameLogListAdminResponseDto
@@ -87,7 +87,7 @@ public class GameAdminService {
     @Transactional(readOnly = true)
     public GameLogListAdminResponseDto findGamesByIntraId(String intraId, Pageable pageable){
         User user = userAdminRepository.findByIntraId(intraId).orElseThrow(UserNotFoundException::new);
-        List<PChange> pChangeList = pChangeRepository.findAllByUserId(user.getId());
+        List<PChange> pChangeList = pChangeRepository.findAllByUserIdGameModeIn(user.getId(), List.of(Mode.NORMAL, Mode.RANK));
         List<Game> gameList = new ArrayList<>();
 
         for(PChange pChange : pChangeList)

--- a/src/main/java/com/gg/server/domain/pchange/data/PChangeRepository.java
+++ b/src/main/java/com/gg/server/domain/pchange/data/PChangeRepository.java
@@ -1,5 +1,6 @@
 package com.gg.server.domain.pchange.data;
 
+import com.gg.server.domain.game.type.Mode;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -15,6 +16,8 @@ public interface PChangeRepository extends JpaRepository<PChange, Long> , PChang
     @Query(value = "SELECT pc FROM PChange pc join fetch pc.user WHERE pc.user.id =:userId order by pc.id desc")
     List<PChange> findAllByUserId(@Param("userId") Long userId);
 
+    @Query(value = "SELECT pc FROM PChange pc join fetch pc.user join fetch pc.game WHERE pc.user.id = :userId and pc.game.mode in :modes order by pc.id desc")
+    List<PChange> findAllByUserIdGameModeIn(@Param("userId") Long userId, List<Mode> modes);
     Optional<PChange> findByUserIdAndGameId(Long userId, Long gameId);
 
     Optional<PChange> findPChangeByUserIdAndGameId(Long userId, Long gameId);

--- a/src/test/java/com/gg/server/admin/game/controller/GameAdminControllerTest.java
+++ b/src/test/java/com/gg/server/admin/game/controller/GameAdminControllerTest.java
@@ -92,7 +92,7 @@ class GameAdminControllerTest {
         Season season;
 
         static final int TOTAL_PAGE_SIZE = 18;
-
+        static final int TOURNAMENT_GAME_SIZE = 4;
         static final String INTRA_ID = "nheo";
 
         @BeforeEach
@@ -104,6 +104,10 @@ class GameAdminControllerTest {
             testDataUtils.createUserRank(user, "status message", season);
             for (int i = 0; i < TOTAL_PAGE_SIZE; i++) {
                 testDataUtils.createMockMatchWithMockRank(user, season, LocalDateTime.now().minusMinutes(20 + i * 15), LocalDateTime.now().minusMinutes(5 + i * 15));
+            }
+            for (int i = TOTAL_PAGE_SIZE; i< TOTAL_PAGE_SIZE + TOURNAMENT_GAME_SIZE; i++) {
+                testDataUtils.createMockMatch(testDataUtils.createNewUser("testUser"+i), season,
+                    LocalDateTime.now().minusMinutes(20 + i * 15), LocalDateTime.now().minusMinutes(5 + i * 15), Mode.TOURNAMENT);
             }
         }
         private GameLogListAdminResponseDto getPageResult(int currentPage, int pageSize)
@@ -126,7 +130,7 @@ class GameAdminControllerTest {
             //given
             int pageSize = 5;
             //when
-            GameLogListAdminResponseDto result = getPageResult(1, 5);
+            GameLogListAdminResponseDto result = getPageResult(1, pageSize);
             //then
             assertThat(result.getGameLogList().size()).isEqualTo(pageSize);
         }
@@ -138,7 +142,7 @@ class GameAdminControllerTest {
             //given
             int pageSize = 5;
             //when
-            GameLogListAdminResponseDto result = getPageResult(2, 5);
+            GameLogListAdminResponseDto result = getPageResult(2, pageSize);
             //then
             assertThat(result.getGameLogList().size()).isEqualTo(pageSize);
         }
@@ -150,7 +154,7 @@ class GameAdminControllerTest {
             //given
             int pageSize = 5;
             //when
-            GameLogListAdminResponseDto result = getPageResult(4, 5);
+            GameLogListAdminResponseDto result = getPageResult(4, pageSize);
             //then
             assertThat(result.getGameLogList().size()).isEqualTo(TOTAL_PAGE_SIZE % pageSize);
         }


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 기존 게임을 가져오는 data jpa 가 `모든 게임을 가져오는` 매서드여서 `토너먼트를 제외한 게임들`을 가져오도록 수정
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - `GameAdminRepository`
    - `findBySeasonAndModeIn`: 해당 모드와 시즌의 모든 게임
    - `findAllByModeIn`: 해당 모드의 모든게임
  - `GameAdminService` : data jpa 변경 매서드로 수정
  - `GameAdminControllerTest` : 테스트 코드 추가
 ## ✅ 변경로직 <!-- 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
  -
 ## 💡Issue 번호 <!-- issue number을 link 시켜주세요 (ex. "- close #4242") -->
 - close #399 