### PR TITLE
🐛 [Fix] 토너먼트 시간에 매칭 block 에러 수정

### DIFF
--- a/src/main/java/com/gg/server/domain/match/service/MatchService.java
+++ b/src/main/java/com/gg/server/domain/match/service/MatchService.java
@@ -202,19 +202,16 @@ public class MatchService {
      */
     private boolean isExistTournamentNotEnded(LocalDateTime time) {
         List<Tournament> tournamentList = tournamentRepository.findAllByStatusIsNot(TournamentStatus.END);
-        if (tournamentList.isEmpty()) {
-            return false;
-        }
         for (Tournament tournament : tournamentList) {
             if (time.isAfter(tournament.getStartTime()) &&
                 time.isBefore(tournament.getEndTime())) {
-                return false;
+                return true;
             }
             if (time.isEqual(tournament.getStartTime()) ||
                 time.isEqual(tournament.getEndTime())) {
-                return false;
+                return true;
             }
         }
-        return true;
+        return false;
     }
 }

--- a/src/main/java/com/gg/server/domain/match/service/MatchService.java
+++ b/src/main/java/com/gg/server/domain/match/service/MatchService.java
@@ -21,6 +21,7 @@ import com.gg.server.domain.rank.redis.RankRedisRepository;
 import com.gg.server.domain.rank.redis.RedisKeyManager;
 import com.gg.server.domain.season.data.Season;
 import com.gg.server.domain.season.service.SeasonFindService;
+import com.gg.server.domain.slotmanagement.data.SlotManagementRepository;
 import com.gg.server.domain.tournament.data.Tournament;
 import com.gg.server.domain.tournament.data.TournamentRepository;
 import com.gg.server.domain.tournament.exception.TournamentConflictException;
@@ -50,6 +51,7 @@ public class MatchService {
     private final GameUpdateService gameUpdateService;
     private final UserRepository userRepository;
     private final TournamentRepository tournamentRepository;
+    private final SlotManagementRepository slotManagementRepository;
 
     /**
      * 1) 매칭 가능한 유저 있을 경우 : 게임 생성
@@ -79,8 +81,6 @@ public class MatchService {
      * 1) 매칭되어 게임 생성된 후 : 게임 삭제하고 알림 전송, 취소한 유저 패널티 부과
      * 복귀 유저는 매칭 가능한 상대 존재하면 다시 매칭해주고 아니면 취소 알림 보내고 큐에 등록 시킴
      * 2) 매칭 전 : 큐에서 유저 삭제
-     * */
-    /**
      * game 매칭된 user 이외에 다른 user가 취소할 경우, 에러 발생
      */
     @Transactional
@@ -92,13 +92,13 @@ public class MatchService {
                 throw new SlotNotFoundException();
             }
             cancelGame(userDto, startTime, game.get(), enemyTeam);
-        }else {
+        } else {
             deleteUserFromQueue(userDto, startTime);
-        };
+        }
     }
 
     private void cancelGame(UserDto userDto, LocalDateTime startTime, Game game, List<User> enemyTeam) {
-        /**취소한 유저 큐에서 삭제 후 패널티 부과*/
+        /*취소한 유저 큐에서 삭제 후 패널티 부과*/
         Long recoveredUserId = enemyTeam.get(0).getId();
         List<RedisMatchUser> allMatchUsers = redisMatchTimeRepository.getAllMatchUsers(startTime);
         RedisMatchUser penaltyUser = allMatchUsers.stream()
@@ -111,7 +111,7 @@ public class MatchService {
                 .orElseThrow(UserNotFoundException::new);
         redisMatchTimeRepository.deleteMatchUser(startTime, penaltyUser);
         penaltyService.givePenalty(userDto, 30);
-        /**취소 당한 유저 매칭 상대 찾고 있으면 다시 게임 생성 아니면 취소 알림*/
+        /*취소 당한 유저 매칭 상대 찾고 있으면 다시 게임 생성 아니면 취소 알림*/
         Season season = seasonFindService.findCurrentSeason(startTime);
         MatchCalculator matchCalculator = new MatchCalculator(season.getPppGap(), recoveredUser);
         List<RedisMatchUser> targetPlayers = allMatchUsers.stream()
@@ -176,7 +176,7 @@ public class MatchService {
                     .stream()
                     .filter(ele -> !ele.getStartTime().equals(targetTIme))
                     .collect(Collectors.toSet());
-            matchTimes.stream().forEach(ele -> redisMatchTimeRepository.deleteMatchUser(ele.getStartTime(), player));
+            matchTimes.forEach(ele -> redisMatchTimeRepository.deleteMatchUser(ele.getStartTime(), player));
             redisMatchUserRepository.deleteMatchUser(player.getUserId());
         }
     }
@@ -197,18 +197,23 @@ public class MatchService {
 
     /**
      * LIVE, BEFORE 상태인 토너먼트와 진행 시간이 겹치지 않으면 true, 겹치면 false
-     * @param time 현재 시간
+     * @param startTime 현재 시간
      * @return 종료되지 않은 토너먼트 있으면 true, 없으면 false
+     * @throws SlotNotFoundException 현재 시간에 해당하는 슬롯이 없을 경우
      */
-    private boolean isExistTournamentNotEnded(LocalDateTime time) {
+    private boolean isExistTournamentNotEnded(LocalDateTime startTime) {
         List<Tournament> tournamentList = tournamentRepository.findAllByStatusIsNot(TournamentStatus.END);
+        int gameInterval = slotManagementRepository.findCurrent(startTime)
+            .orElseThrow(SlotNotFoundException::new)
+            .getGameInterval();
+        LocalDateTime endTime = startTime.plusMinutes(gameInterval);
         for (Tournament tournament : tournamentList) {
-            if (time.isAfter(tournament.getStartTime()) &&
-                time.isBefore(tournament.getEndTime())) {
+            if (startTime.isAfter(tournament.getStartTime()) && startTime.isBefore(tournament.getEndTime()) ||
+                    endTime.isAfter(tournament.getStartTime()) && endTime.isBefore(tournament.getEndTime())) {
                 return true;
             }
-            if (time.isEqual(tournament.getStartTime()) ||
-                time.isEqual(tournament.getEndTime())) {
+            if (startTime.isEqual(tournament.getStartTime()) || endTime.isEqual(tournament.getEndTime()) ||
+                    endTime.isEqual(tournament.getStartTime()) || startTime.isEqual(tournament.getEndTime())) {
                 return true;
             }
         }

--- a/src/main/java/com/gg/server/domain/match/utils/SlotGenerator.java
+++ b/src/main/java/com/gg/server/domain/match/utils/SlotGenerator.java
@@ -69,9 +69,11 @@ public class SlotGenerator {
             LocalDateTime startTime = tournament.getStartTime();
             int startTimeMinute = startTime.getMinute();
             startTimeMinute = startTimeMinute - (startTimeMinute % interval);
+            startTime = startTime.withMinute(startTimeMinute);
             LocalDateTime endTime = tournament.getEndTime();
             int endTimeMinute = endTime.getMinute();
             endTimeMinute = endTimeMinute + (interval - (endTimeMinute % interval));
+            endTime = endTime.withMinute(endTimeMinute);
             for (LocalDateTime time = startTime; time.isBefore(endTime); time = time.plusMinutes(interval)) {
                 slots.put(time, new SlotStatusDto(time, SlotStatus.CLOSE, interval));
             }

--- a/src/test/java/com/gg/server/domain/match/service/MatchServiceTest.java
+++ b/src/test/java/com/gg/server/domain/match/service/MatchServiceTest.java
@@ -252,7 +252,6 @@ class MatchServiceTest {
 
         @DisplayName("토너먼트 시간과 겹칠 경우 게임 생성 안됨")
         @Test
-        @Disabled
         void addMatchTournamentTime() {
             // given
             Tournament tournament = Tournament.builder()


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 토너먼트 시간에 게임 매칭 요청에 대한 block 에러 수정

 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - 현재 매칭 시도한 시간에 토너먼트 진행시간과 겹치는지 확인하는 `isExistTournamentNotEnded` 함수의 boolean return을 잘못하고 있었습니다.
  - 리턴값 수정과 `매칭 요청한 시간 + interval(15분)` 종료시간도 확인하는 로직을 추가했습니다.
  - 로직 수정 후 정상적으로 테스트코드 돌아가서 `@Disabled` 삭제했습니다.
  - 추가로 warning 메세지를 없애기 위해 약간의 수정이 포함되어 있습니다.

 ## 💡Issue 번호 <!-- issue number을 link 시켜주세요 (ex. "- close #4242") -->
 - close #373 