### PR TITLE
🐛 [Fix] 토너먼트 게임 결과 등록할 때 pchange 생성 안 되는 문제 해결

### DIFF
--- a/src/main/java/com/gg/server/admin/tournament/service/TournamentAdminService.java
+++ b/src/main/java/com/gg/server/admin/tournament/service/TournamentAdminService.java
@@ -335,12 +335,12 @@ public class TournamentAdminService {
      * @return 수정 가능 여부
      */
     private boolean canUpdateScore(TournamentGame tournamentGame, TournamentGameUpdateRequestDto reqDto) {
-        if (reqDto.getNextTournamentGameId() == null &&
-                tournamentGame.getTournamentRound() == TournamentRound.THE_FINAL) {
-            return true;
-        }
+        System.out.println("sgotest tournamentgame status : " + tournamentGame.getGame().getStatus());
         if (tournamentGame.getGame().getStatus() == StatusType.BEFORE) {
             return false;
+        }
+        if (reqDto.getNextTournamentGameId() == null){
+            return tournamentGame.getTournamentRound() == TournamentRound.THE_FINAL;
         }
         TournamentGame nextTournamentGame = tournamentGameRepository.findById(reqDto.getNextTournamentGameId())
                 .orElseThrow(TournamentGameNotFoundException::new);

--- a/src/main/java/com/gg/server/admin/tournament/service/TournamentAdminService.java
+++ b/src/main/java/com/gg/server/admin/tournament/service/TournamentAdminService.java
@@ -335,7 +335,6 @@ public class TournamentAdminService {
      * @return 수정 가능 여부
      */
     private boolean canUpdateScore(TournamentGame tournamentGame, TournamentGameUpdateRequestDto reqDto) {
-        System.out.println("sgotest tournamentgame status : " + tournamentGame.getGame().getStatus());
         if (tournamentGame.getGame().getStatus() == StatusType.BEFORE) {
             return false;
         }

--- a/src/main/java/com/gg/server/domain/game/GameController.java
+++ b/src/main/java/com/gg/server/domain/game/GameController.java
@@ -109,7 +109,7 @@ public class GameController {
             throw new InvalidParameterException("점수를 잘못 입력했습니다.", ErrorCode.VALID_FAILED);
         }
         gameService.createTournamentGameResult(reqDto, user.getId());
-        return new ResponseEntity<Void>(HttpStatus.CREATED);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
     @GetMapping("/{gameId}/result/normal")

--- a/src/main/java/com/gg/server/domain/game/service/GameService.java
+++ b/src/main/java/com/gg/server/domain/game/service/GameService.java
@@ -211,7 +211,7 @@ public class GameService {
                 });
     }
 
-    private void savePChange(Game game, List<TeamUser> teamUsers, Long loginUserId) {
+    public void savePChange(Game game, List<TeamUser> teamUsers, Long loginUserId) {
         Long team1UserId = teamUsers.get(0).getUser().getId();
         Long team2UserId = teamUsers.get(1).getUser().getId();
         pChangeService.addPChange(game, teamUsers.get(0).getUser(),
@@ -283,6 +283,7 @@ public class GameService {
             setTeamScore(myTeam, scoreDto.getMyTeamScore(), scoreDto.getMyTeamScore() > scoreDto.getEnemyTeamScore());
             setTeamScore(enemyTeam, scoreDto.getEnemyTeamScore(), scoreDto.getMyTeamScore() < scoreDto.getEnemyTeamScore());
             expUpdates(game, teams);
+            savePChange(game, teams, userId);
         } else {
             // score 가 이미 입력됨
             throw new ScoreAlreadyEnteredException(ErrorCode.SCORE_ALREADY_ENTERED.getMessage(), ErrorCode.SCORE_ALREADY_ENTERED);

--- a/src/test/java/com/gg/server/admin/tournament/controller/TournamentAdminControllerTest.java
+++ b/src/test/java/com/gg/server/admin/tournament/controller/TournamentAdminControllerTest.java
@@ -11,6 +11,7 @@ import com.gg.server.admin.tournament.dto.TournamentAdminUpdateRequestDto;
 import com.gg.server.admin.tournament.dto.TournamentGameUpdateRequestDto;
 import com.gg.server.admin.tournament.service.TournamentAdminService;
 import com.gg.server.domain.game.type.Mode;
+import com.gg.server.domain.pchange.data.PChangeRepository;
 import com.gg.server.utils.MatchTestUtils;
 import com.gg.server.utils.annotation.IntegrationTest;
 import com.gg.server.domain.tournament.data.Tournament;
@@ -72,6 +73,12 @@ class TournamentAdminControllerTest {
 
     @Autowired
     TournamentGameRepository tournamentGameRepository;
+
+    @Autowired
+    PChangeRepository pChangeRepository;
+
+    @Autowired
+    private MatchTestUtils matchTestUtils;
 
     @Nested
     @DisplayName("토너먼트_관리_수정_컨트롤러_테스트")
@@ -849,8 +856,6 @@ class TournamentAdminControllerTest {
     @Nested
     @DisplayName("[Patch] /pingpong/admin/tournaments/{tournamentId}/games")
     class AdminUpdateTournamentGameTest {
-        @Autowired
-        private MatchTestUtils matchTestUtils;
         private String accessToken;
         private Tournament tournament;
         private List<TournamentGame> allTournamentGames;
@@ -896,6 +901,10 @@ class TournamentAdminControllerTest {
             TournamentGame resTournamentGame = tournamentGameRepository.findById(tournamentGame.getId()).orElseThrow();
             assertThat(resTournamentGame.getGame().getTeams().get(0).getScore()).isEqualTo(myTeamScore);
             assertThat(resTournamentGame.getGame().getTeams().get(1).getScore()).isEqualTo(otherTeamScore);
+            User user1 = tournamentGame.getGame().getTeams().get(0).getTeamUsers().get(0).getUser();
+            User user2 = tournamentGame.getGame().getTeams().get(1).getTeamUsers().get(0).getUser();
+            assertThat(pChangeRepository.findByUserIdAndGameId(user1.getId(), tournamentGame.getGame().getId())).isNotEmpty();
+            assertThat(pChangeRepository.findByUserIdAndGameId(user2.getId(), tournamentGame.getGame().getId())).isNotEmpty();
         }
         @Test
         @DisplayName("토너먼트_게임_수정_불가능")

--- a/src/test/java/com/gg/server/admin/tournament/controller/TournamentAdminControllerTest.java
+++ b/src/test/java/com/gg/server/admin/tournament/controller/TournamentAdminControllerTest.java
@@ -12,6 +12,7 @@ import com.gg.server.admin.tournament.dto.TournamentGameUpdateRequestDto;
 import com.gg.server.admin.tournament.service.TournamentAdminService;
 import com.gg.server.domain.game.type.Mode;
 import com.gg.server.domain.pchange.data.PChangeRepository;
+import com.gg.server.domain.season.data.Season;
 import com.gg.server.utils.MatchTestUtils;
 import com.gg.server.utils.annotation.IntegrationTest;
 import com.gg.server.domain.tournament.data.Tournament;
@@ -859,10 +860,11 @@ class TournamentAdminControllerTest {
         private String accessToken;
         private Tournament tournament;
         private List<TournamentGame> allTournamentGames;
+        Season season;
         @BeforeEach
         void setUp() {
             // 토너먼트 생성하고 8강 & 4강은 게임 점수 입력하고 종료된 상태이고 결승전 매칭된 상태로 초기화
-            testDataUtils.createSeason();
+            season = testDataUtils.createSeason();
             testDataUtils.createSlotManagement(15);
             tournament = testDataUtils.createTournamentWithUser(Tournament.ALLOWED_JOINED_NUMBER, 4, "test");
             allTournamentGames = testDataUtils.createTournamentGameList(tournament, 7);
@@ -885,6 +887,10 @@ class TournamentAdminControllerTest {
             int otherTeamScore = 1;
             TournamentGame tournamentGame = allTournamentGames.stream().filter(tg -> tg.getTournamentRound() == TournamentRound.SEMI_FINAL_1).findAny().orElseThrow();
             TournamentGame nextTournamentGame = allTournamentGames.stream().filter(tg -> tg.getTournamentRound() == TournamentRound.THE_FINAL).findAny().orElseThrow();
+            User user1 = tournamentGame.getGame().getTeams().get(0).getTeamUsers().get(0).getUser();
+            User user2 = tournamentGame.getGame().getTeams().get(1).getTeamUsers().get(0).getUser();
+            testDataUtils.createUserRank(user1, "" ,season);
+            testDataUtils.createUserRank(user2, "" ,season);
 
             TournamentGameUpdateRequestDto requestDto = new TournamentGameUpdateRequestDto(tournamentGame.getId(), nextTournamentGame.getId(),
                     new TeamReqDto(tournamentGame.getGame().getTeams().get(0).getId(), myTeamScore),
@@ -901,8 +907,6 @@ class TournamentAdminControllerTest {
             TournamentGame resTournamentGame = tournamentGameRepository.findById(tournamentGame.getId()).orElseThrow();
             assertThat(resTournamentGame.getGame().getTeams().get(0).getScore()).isEqualTo(myTeamScore);
             assertThat(resTournamentGame.getGame().getTeams().get(1).getScore()).isEqualTo(otherTeamScore);
-            User user1 = tournamentGame.getGame().getTeams().get(0).getTeamUsers().get(0).getUser();
-            User user2 = tournamentGame.getGame().getTeams().get(1).getTeamUsers().get(0).getUser();
             assertThat(pChangeRepository.findByUserIdAndGameId(user1.getId(), tournamentGame.getGame().getId())).isNotEmpty();
             assertThat(pChangeRepository.findByUserIdAndGameId(user2.getId(), tournamentGame.getGame().getId())).isNotEmpty();
         }

--- a/src/test/java/com/gg/server/domain/game/GameControllerTest.java
+++ b/src/test/java/com/gg/server/domain/game/GameControllerTest.java
@@ -445,7 +445,6 @@ public class GameControllerTest {
 
         // TODO : 랭크 게임 결과 입력 실패 테스트 (잘못된 점수 입력할 경우 InvalidParameterException 발생)
     }
-
     @Nested
     @DisplayName("토너먼트 게임 점수 결과 입력")
     class CreateTournamentResultTest {
@@ -482,6 +481,8 @@ public class GameControllerTest {
 
             //then
             assertThat(game.getStatus()).isEqualTo(StatusType.END);
+            assertThat(pChangeRepository.findByUserIdAndGameId(team1.getTeamUsers().get(0).getUser().getId(), game.getId())).isNotEmpty();
+            assertThat(pChangeRepository.findByUserIdAndGameId(team2.getTeamUsers().get(0).getUser().getId(), game.getId())).isNotEmpty();
             System.out.println(contentAsString);
         }
 

--- a/src/test/java/com/gg/server/domain/game/GameControllerTest.java
+++ b/src/test/java/com/gg/server/domain/game/GameControllerTest.java
@@ -468,6 +468,10 @@ public class GameControllerTest {
                 gameRepository.save(game);
                 tournamentGameList.get(i).updateGame(game);
             }
+
+            testDataUtils.createUserRank(team1.getTeamUsers().get(0).getUser(), "", season);
+            testDataUtils.createUserRank(team2.getTeamUsers().get(0).getUser(), "", season);
+
             String ac1 = tokenProvider.createToken(team1.getTeamUsers().get(0).getUser().getId());
             String content = objectMapper.writeValueAsString(new TournamentResultReqDto(game.getId(), team1.getId(), 1, team2.getId(), 2));
 


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 토너먼트 게임 점수 수정시 pchange를 추가하지 않아 생기는 버그 수정
  - 토너먼트 게임 점수를 개인이 수정할때, 관리자가 수정할 떄 pchange를 추가하도록 함
  - 토너먼트 게임이 Before 상태일때 점수정되던 부분 수정 안되도록 수정
 ## 💡Issue 번호 <!-- issue number을 link 시켜주세요 (ex. "- close #4242") -->
 - close #408
 - close #409 