### PR TITLE
🧪 [Test] tournamentGame, tournamentUser Entity 단위 테스트 코드 작성

### DIFF
--- a/src/test/java/com/gg/server/domain/tournament/data/TournamentGameUnitTest.java
+++ b/src/test/java/com/gg/server/domain/tournament/data/TournamentGameUnitTest.java
@@ -1,0 +1,31 @@
+package com.gg.server.domain.tournament.data;
+
+import com.gg.server.domain.game.data.Game;
+import com.gg.server.utils.annotation.UnitTest;
+import org.junit.jupiter.api.*;
+import org.mockito.Mockito;
+
+@UnitTest
+@DisplayName("TournamentGameUnitTest")
+public class TournamentGameUnitTest {
+
+    TournamentGame tournamentGame;
+
+    @Nested
+    @DisplayName("UpdateGame")
+    class UpdateGame {
+      @Test
+      @DisplayName("TournamentGame의 게임 업데이트 성공")
+      void updateSuccess() {
+          //given
+          tournamentGame = new TournamentGame();
+          Game game = Mockito.mock(Game.class);
+
+          //when
+          tournamentGame.updateGame(game);
+
+          //then
+          Assertions.assertEquals(game, tournamentGame.getGame());
+      }
+    }
+}

--- a/src/test/java/com/gg/server/domain/tournament/data/TournamentUserUnitTest.java
+++ b/src/test/java/com/gg/server/domain/tournament/data/TournamentUserUnitTest.java
@@ -1,0 +1,56 @@
+package com.gg.server.domain.tournament.data;
+
+import com.gg.server.domain.user.data.User;
+import com.gg.server.utils.annotation.UnitTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.time.LocalDateTime;
+
+@UnitTest
+@DisplayName("TournamentUserUnitTest")
+public class TournamentUserUnitTest {
+    Tournament tournament;
+    TournamentUser tournamentUser;
+    User user;
+
+    @Nested
+    @DisplayName("DeleteTournament")
+    class DeleteTournament {
+        @Test
+        @DisplayName("토너먼트 삭제 성공")
+        void deleteSuccess() {
+            //given
+            user = Mockito.mock(User.class);
+            tournament = new Tournament();
+            tournamentUser = new TournamentUser(user, tournament, false, LocalDateTime.now());
+
+            //when
+            tournamentUser.deleteTournament();
+
+            //then
+            Assertions.assertNull(tournamentUser.getTournament());
+        }
+    }
+
+    @Nested
+    @DisplayName("UpdateIsJoined")
+    class UpdateIsJoined {
+        @Test
+        @DisplayName("참가 정보 업데이트 성공")
+        void updateSuccess() {
+            //given
+            tournamentUser = new TournamentUser();
+            boolean isjoined = true;
+
+            //when
+            tournamentUser.updateIsJoined(isjoined);
+
+            //then
+            Assertions.assertEquals(isjoined, tournamentUser.getIsJoined());
+        }
+    }
+}


### PR DESCRIPTION
 ## 📌 개요
  - 토너먼트 게임 및 토너먼트 유저 엔티티 단위 테스트 코드 작성

 ## 💻 작업사항
  - 토너먼트 게임 엔티티의 UpdateGame 메소드 단위 테스트 코드 작성
  - 토너먼트 유저 엔티티의 DeleteTournament 메소드 단위 테스트 코드 작성
  - 토너먼트 유저 엔티티의 UpdateIsJoined 메소드 단위 테스트 코드 작성

 ## ✅ 변경로직
  -

 ## 💡Issue 번호
 - close #419 