### PR TITLE
[Refactoring] 토너먼트 게임 조회시 점수 없는 게임은 score 필드 삭제

### DIFF
--- a/src/main/java/com/gg/server/admin/tournament/service/TournamentAdminService.java
+++ b/src/main/java/com/gg/server/admin/tournament/service/TournamentAdminService.java
@@ -280,8 +280,8 @@ public class TournamentAdminService {
         }
         Tournament tournament = tournamentRepository.findById(tournamentId)
             .orElseThrow(TournamentNotFoundException::new);
-        if (tournament.getStatus() != TournamentStatus.LIVE) {
-            throw new TournamentUpdateException(ErrorCode.TOURNAMENT_NOT_LIVE);
+        if (tournament.getStatus() == TournamentStatus.BEFORE) {
+            throw new TournamentUpdateException(ErrorCode.TOURNAMENT_IS_BEFORE);
         }
         TournamentGame tournamentGame = tournament.getTournamentGames().stream().
                 filter(t->t.getId().equals(reqDto.getTournamentGameId())).findAny()

--- a/src/main/java/com/gg/server/domain/game/service/GameService.java
+++ b/src/main/java/com/gg/server/domain/game/service/GameService.java
@@ -212,6 +212,10 @@ public class GameService {
     }
 
     public void savePChange(Game game, List<TeamUser> teamUsers, Long loginUserId) {
+        if (pChangeRepository.findByUserIdAndGameId(teamUsers.get(0).getUser().getId(), game.getId()).isPresent() ||
+                pChangeRepository.findByUserIdAndGameId(teamUsers.get(1).getUser().getId(), game.getId()).isPresent()) {
+            return ;
+        }
         Long team1UserId = teamUsers.get(0).getUser().getId();
         Long team2UserId = teamUsers.get(1).getUser().getId();
         pChangeService.addPChange(game, teamUsers.get(0).getUser(),

--- a/src/main/java/com/gg/server/domain/game/service/GameService.java
+++ b/src/main/java/com/gg/server/domain/game/service/GameService.java
@@ -212,8 +212,7 @@ public class GameService {
     }
 
     public void savePChange(Game game, List<TeamUser> teamUsers, Long loginUserId) {
-        if (pChangeRepository.findByUserIdAndGameId(teamUsers.get(0).getUser().getId(), game.getId()).isPresent() ||
-                pChangeRepository.findByUserIdAndGameId(teamUsers.get(1).getUser().getId(), game.getId()).isPresent()) {
+        if (pChangeRepository.findPChangeByGameId(game.getId()).isPresent()){
             return ;
         }
         Long team1UserId = teamUsers.get(0).getUser().getId();

--- a/src/main/java/com/gg/server/domain/pchange/data/PChangeRepository.java
+++ b/src/main/java/com/gg/server/domain/pchange/data/PChangeRepository.java
@@ -21,4 +21,6 @@ public interface PChangeRepository extends JpaRepository<PChange, Long> , PChang
     Optional<PChange> findByUserIdAndGameId(Long userId, Long gameId);
 
     Optional<PChange> findPChangeByUserIdAndGameId(Long userId, Long gameId);
+
+    Optional<PChange> findPChangeByGameId(Long gameId);
 }

--- a/src/main/java/com/gg/server/domain/team/dto/TeamUserListDto.java
+++ b/src/main/java/com/gg/server/domain/team/dto/TeamUserListDto.java
@@ -29,7 +29,7 @@ public class TeamUserListDto {
         this.teamId = teamId;
         this.players = players;
         this.isWin = isWin;
-        this.score = score;
+        this.score = score == -1? null : score;
     }
 
     @Override

--- a/src/main/java/com/gg/server/domain/tournament/dto/TournamentGameResDto.java
+++ b/src/main/java/com/gg/server/domain/tournament/dto/TournamentGameResDto.java
@@ -15,13 +15,13 @@ public class TournamentGameResDto {
 
     private Long tournamentGameId;
     private Long nextTournamentGameId;
-    private String tournamentRound;
+    private TournamentRound tournamentRound;
     private GameResultResDto game;
 
     public TournamentGameResDto(TournamentGame tournamentGame, GameTeamUser game, TournamentRound tournamentRound, TournamentGame nextTournamentGame){
         this.tournamentGameId = tournamentGame.getId();
         this.game = game == null? null : new GameResultResDto(game);
-        this.tournamentRound = tournamentRound.name();
+        this.tournamentRound = tournamentRound;
         this.nextTournamentGameId = nextTournamentGame == null? null : nextTournamentGame.getId();
     }
 

--- a/src/main/java/com/gg/server/domain/tournament/service/TournamentService.java
+++ b/src/main/java/com/gg/server/domain/tournament/service/TournamentService.java
@@ -261,6 +261,15 @@ public class TournamentService {
             }
             tournamentGameResDtoList.add(new TournamentGameResDto(tournamentGame, gameTeamUser, tournamentGame.getTournamentRound(), nextTournamentGame));
         }
+        tournamentGameResDtoList.sort((o1, o2) -> {
+            if (o1.getTournamentRound().getRoundNumber() < o2.getTournamentRound().getRoundNumber()) {
+                return 1;
+            }
+            if (o1.getTournamentRound().getRoundOrder() > o2.getTournamentRound().getRoundOrder()) {
+                return 1;
+            }
+            return -1;
+        });
         return tournamentGameResDtoList;
     }
 

--- a/src/main/java/com/gg/server/domain/tournament/type/TournamentRound.java
+++ b/src/main/java/com/gg/server/domain/tournament/type/TournamentRound.java
@@ -13,17 +13,17 @@ public enum TournamentRound {
     // semi final  -> 4강
     // quarter final -> 8강
     // ordinal()로 sorting 사용되고 있으므로 순서 중요 -> 이후에 리팩토링으로 해결하겠습니다.
-    THE_FINAL("1", null, 2),
-    SEMI_FINAL_1("4-1", THE_FINAL, 4),
-    SEMI_FINAL_2("4-2", THE_FINAL, 4),
-    QUARTER_FINAL_1("8-1", SEMI_FINAL_1, 8),
-    QUARTER_FINAL_2("8-2", SEMI_FINAL_1, 8),
-    QUARTER_FINAL_3("8-3", SEMI_FINAL_2, 8),
-    QUARTER_FINAL_4("8-4", SEMI_FINAL_2, 8);
+    THE_FINAL(null, 2, 1),
+    SEMI_FINAL_1(THE_FINAL, 4, 1),
+    SEMI_FINAL_2(THE_FINAL, 4, 2),
+    QUARTER_FINAL_1(SEMI_FINAL_1, 8, 1),
+    QUARTER_FINAL_2( SEMI_FINAL_1, 8, 2),
+    QUARTER_FINAL_3(SEMI_FINAL_2, 8, 3),
+    QUARTER_FINAL_4(SEMI_FINAL_2, 8, 4);
 
-    private final String round;
     private final TournamentRound nextRound;
     private final int roundNumber;
+    private final int roundOrder;
 
     public static List<TournamentRound> getSameRounds(TournamentRound round) {
         List<TournamentRound> sameRounds = new ArrayList<>();

--- a/src/main/java/com/gg/server/global/exception/ErrorCode.java
+++ b/src/main/java/com/gg/server/global/exception/ErrorCode.java
@@ -150,7 +150,8 @@ public enum ErrorCode {
     TOURNAMENT_CONFLICT_GAME(409, "TN013", "토너먼트 기간 내 대기중인 게임이 존재합니다."),
     TOURNAMENT_GAME_DUPLICATION(409, "TN014", "중복된 토너먼트 게임입니다!"),
     TOURNAMENT_USER_DUPLICATION(409, "TN015", "중복된 토너먼트 유저입니다!"),
-    TOURNAMENT_GAME_EXCEED(500, "TN016", "토너먼트 게임 최대 사이즈를 초과하였습니다!")
+    TOURNAMENT_GAME_EXCEED(500, "TN016", "토너먼트 게임 최대 사이즈를 초과하였습니다!"),
+    TOURNAMENT_IS_BEFORE(403, "TN017", "before인 토너먼트에서 점수 수정할 수 없습니다.")
     ;
     private final int status;
     private final String errCode;

--- a/src/test/java/com/gg/server/domain/tournament/controller/TournamentGameControllerTest.java
+++ b/src/test/java/com/gg/server/domain/tournament/controller/TournamentGameControllerTest.java
@@ -94,7 +94,7 @@ public class TournamentGameControllerTest {
             for (TournamentGameResDto tournamentGameResDto : resp.getGames()) {
                 assertThat(tournamentGameResDto.getTournamentGameId()).isNotNull();
                 assertThat(tournamentGameResDto.getTournamentRound()).isNotNull();
-                if (!Objects.equals(tournamentGameResDto.getTournamentRound(), TournamentRound.THE_FINAL.name())) {
+                if (!Objects.equals(tournamentGameResDto.getTournamentRound(), TournamentRound.THE_FINAL)) {
                     assertThat(tournamentGameResDto.getNextTournamentGameId()).isNotNull();
                 }
             }


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  1. 토너먼트 게임 조회시 점수 없는 게임은 score 필드 삭제
  2. 토너먼트 게임 조회 토너먼트 라운드 기준으로 정렬
  3. 토너먼트 게임 pchange가 이미 있을경우 생성 안되게 수정
  4. 종료된 토너먼트의 결승전 수정 가능하도록 수정
 ## 💡Issue 번호 <!-- issue number을 link 시켜주세요 (ex. "- close #4242") -->
 - close #424 
 - close #421
 - close #420 
 - close #418 