### PR TITLE
🧪 [Unit Test] 토너먼트 updateEndTime 매서드 유닛 테스트 추가 및 기존 테스트 코드 수정

### DIFF
--- a/src/main/java/com/gg/server/admin/tournament/service/TournamentAdminService.java
+++ b/src/main/java/com/gg/server/admin/tournament/service/TournamentAdminService.java
@@ -211,9 +211,11 @@ public class TournamentAdminService {
         SlotManagement slotManagement = slotManagementRepository.findCurrent(startTime)
             .orElseThrow(SlotNotFoundException::new);
         int interval = slotManagement.getGameInterval();
+        int startDays = startTime.getDayOfYear() + (startTime.getYear() - LocalDateTime.now().getYear()) * 365;
+        int curDays = LocalDateTime.now().getDayOfYear();
 
         if (startTime.isAfter(endTime) || startTime.isEqual(endTime) ||
-            startTime.getDayOfMonth() - LocalDateTime.now().getDayOfMonth() < constantConfig.getAllowedMinimalStartDays()||
+            startDays - curDays < constantConfig.getAllowedMinimalStartDays() ||
             startTime.plusHours(Tournament.MINIMUM_TOURNAMENT_DURATION).isAfter(endTime) ||
             startTime.getMinute() % interval != 0 || endTime.getMinute() % interval != 0) {
             throw new TournamentUpdateException(ErrorCode.TOURNAMENT_INVALID_TIME);

--- a/src/main/java/com/gg/server/admin/tournament/service/TournamentAdminService.java
+++ b/src/main/java/com/gg/server/admin/tournament/service/TournamentAdminService.java
@@ -27,6 +27,7 @@ import com.gg.server.domain.user.exception.UserNotFoundException;
 import com.gg.server.global.config.ConstantConfig;
 import com.gg.server.global.exception.ErrorCode;
 import com.gg.server.global.exception.custom.InvalidParameterException;
+import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -211,11 +212,9 @@ public class TournamentAdminService {
         SlotManagement slotManagement = slotManagementRepository.findCurrent(startTime)
             .orElseThrow(SlotNotFoundException::new);
         int interval = slotManagement.getGameInterval();
-        int startDays = startTime.getDayOfYear() + (startTime.getYear() - LocalDateTime.now().getYear()) * 365;
-        int curDays = LocalDateTime.now().getDayOfYear();
 
         if (startTime.isAfter(endTime) || startTime.isEqual(endTime) ||
-            startDays - curDays < constantConfig.getAllowedMinimalStartDays() ||
+            LocalDate.now().plusDays(constantConfig.getAllowedMinimalStartDays()).isAfter(startTime.toLocalDate()) ||
             startTime.plusHours(Tournament.MINIMUM_TOURNAMENT_DURATION).isAfter(endTime) ||
             startTime.getMinute() % interval != 0 || endTime.getMinute() % interval != 0) {
             throw new TournamentUpdateException(ErrorCode.TOURNAMENT_INVALID_TIME);

--- a/src/test/java/com/gg/server/admin/tournament/service/TournamentAdminServiceTest.java
+++ b/src/test/java/com/gg/server/admin/tournament/service/TournamentAdminServiceTest.java
@@ -67,8 +67,6 @@ class TournamentAdminServiceTest {
     @InjectMocks
     TournamentAdminService tournamentAdminService;
 
-    ReflectionUtilsForUnitTest reflectionUtilsForUnitTest = new ReflectionUtilsForUnitTest();
-
     // 토너먼트 생성 서비스 테스트
     @Nested
     @DisplayName("토너먼트 관리자 생성 서비스 테스트")
@@ -362,7 +360,7 @@ class TournamentAdminServiceTest {
             User user = createUser("testUser");
             given(tournamentRepository.findById(1L)).willReturn(Optional.of(tournament));
             given(userRepository.findByIntraId("testUser")).willReturn(Optional.of(user));
-
+            given(tournamentUserRepository.save(any(TournamentUser.class))).willReturn(null);
             // when, then
             tournamentAdminService.addTournamentUser(1L, requestDto);
         }
@@ -503,7 +501,7 @@ class TournamentAdminServiceTest {
             .type(TournamentType.ROOKIE)
             .status(status)
             .build();
-        reflectionUtilsForUnitTest.setFieldWithReflection(tournament, "id", id);
+        ReflectionUtilsForUnitTest.setFieldWithReflection(tournament, "id", id);
         return tournament;
     }
 

--- a/src/test/java/com/gg/server/domain/tournament/data/TournamentUnitTest.java
+++ b/src/test/java/com/gg/server/domain/tournament/data/TournamentUnitTest.java
@@ -2,7 +2,6 @@ package com.gg.server.domain.tournament.data;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 
 import com.gg.server.domain.tournament.type.TournamentStatus;
@@ -10,6 +9,7 @@ import com.gg.server.domain.user.data.User;
 import com.gg.server.global.exception.ErrorCode;
 import com.gg.server.global.exception.custom.BusinessException;
 import com.gg.server.utils.annotation.UnitTest;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -18,7 +18,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 
 @UnitTest
@@ -315,6 +314,40 @@ class TournamentUnitTest {
 
       //then
       assertEquals(status, tournament.getStatus());
+    }
+  }
+
+  @Nested
+  @DisplayName("UpdateStatus")
+  class UpdateEndTime {
+    @Test
+    @DisplayName("null 포인터 전달 시 실패")
+    void nullAddFailed() {
+      //given
+      Tournament tournament = tournaments.get(0);
+
+      //when
+      LocalDateTime endTime = null;
+
+      //then
+      BusinessException businessException = assertThrows(BusinessException.class,
+          () -> tournament.updateEndTime(endTime));
+      assertEquals(ErrorCode.NULL_POINT, businessException.getErrorCode());
+      assertEquals(ErrorCode.NULL_POINT.getMessage(), businessException.getMessage());
+    }
+
+    @Test
+    @DisplayName("endTime 업데이트 성공")
+    void updateEndTimeSuccess() {
+      //given
+      Tournament tournament = tournaments.get(0);
+      LocalDateTime endTime = LocalDateTime.now().withMinute(0).withNano(0);
+
+      //when
+      tournament.updateEndTime(endTime);
+
+      //then
+      assertEquals(endTime, tournament.getEndTime());
     }
   }
 }

--- a/src/test/java/com/gg/server/domain/tournament/service/TournamentServiceTest.java
+++ b/src/test/java/com/gg/server/domain/tournament/service/TournamentServiceTest.java
@@ -53,7 +53,6 @@ class TournamentServiceTest {
     UserRepository userRepository;
     @InjectMocks
     TournamentService tournamentService;
-    ReflectionUtilsForUnitTest reflectionUtilsForUnitTest = new ReflectionUtilsForUnitTest();
 
     @Nested
     @DisplayName("토너먼트_유저_상태_테스트")
@@ -160,15 +159,14 @@ class TournamentServiceTest {
     class cancelTournamentUserRegistration {
         @Test
         @DisplayName("유저_참가_취소_성공")
-        @Disabled
         void success() {
             // given
             Tournament tournament = createTournament(1L, TournamentStatus.BEFORE,
                 LocalDateTime.now(), LocalDateTime.now().plusHours(2));
             User user = createUser("testUser");
+            ReflectionUtilsForUnitTest.setFieldWithReflection(user, "id", 1L);
             TournamentUser tournamentUser = new TournamentUser(user, tournament, true, LocalDateTime.now());
             given(tournamentRepository.findById(tournament.getId())).willReturn(Optional.of(tournament));
-            given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
 
             // when, then
             tournamentService.cancelTournamentUserRegistration(tournament.getId(), UserDto.from(user));
@@ -234,7 +232,7 @@ class TournamentServiceTest {
           .type(TournamentType.ROOKIE)
           .status(status)
           .build();
-      reflectionUtilsForUnitTest.setFieldWithReflection(tournament, "id", id);
+      ReflectionUtilsForUnitTest.setFieldWithReflection(tournament, "id", id);
       return tournament;
     }
 

--- a/src/test/java/com/gg/server/utils/ReflectionUtilsForUnitTest.java
+++ b/src/test/java/com/gg/server/utils/ReflectionUtilsForUnitTest.java
@@ -17,7 +17,7 @@ public class ReflectionUtilsForUnitTest {
   /**
    * 리플렉션을 사용해서 필드값을 설정한다.
    */
-  public void setFieldWithReflection(Object object, String fieldName, Object value) {
+  static public void setFieldWithReflection(Object object, String fieldName, Object value) {
     try {
       Field field = object.getClass().getDeclaredField(fieldName);
       field.setAccessible(true);


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 토너먼트 updateEndTime 매서드 유닛 테스트 추가
  - 기존 `@Disabled` 테스트 코드 리플렉션 사용해서 돌아가도록 수정
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - `TournamentAdminServiceTest` && `TournamentServiceTest`: `static` 키워드 추가로 인한 수정 및 기존 코드 개선
  - `TournamentUnitTest`: updateEndTime 유닛 테스트 추가
  - ReflectionUtilsForUnitTest : `static` 키워드 추가
 ## ✅ 변경로직 <!-- 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
  - `checkValidTournamentTime` 로직 수정
    - 년도가 넘어갈때 로직이 이상해지는 현상 수정 -> `LocalDate` 사용으로 해결
 ## 💡Issue 번호 <!-- issue number을 link 시켜주세요 (ex. "- close #4242") -->
 - 