### PR TITLE
🧪 [Unit Test] Announcement 단위 테스트 추가

### DIFF
--- a/src/main/java/com/gg/server/admin/announcement/controller/AnnouncementAdminController.java
+++ b/src/main/java/com/gg/server/admin/announcement/controller/AnnouncementAdminController.java
@@ -41,17 +41,18 @@ public class AnnouncementAdminController {
 			.body(announcementAdminService.findAllAnnouncement(pageable));
 	}
 
-	@PostMapping("/announcement")
-	public ResponseEntity addaAnnouncement(@Valid @RequestBody AnnouncementAdminAddDto addDto) {
-		announcementAdminService.addAnnouncement(addDto);
+    @PostMapping("/announcement")
+    public ResponseEntity<Void> addAnnouncement(@Valid @RequestBody AnnouncementAdminAddDto addDto){
+        announcementAdminService.addAnnouncement(addDto);
 
-		return new ResponseEntity(HttpStatus.CREATED);
-	}
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
 
-	@DeleteMapping("/announcement/{deleterIntraId}")
-	public ResponseEntity announcementModify(@PathVariable String deleterIntraId) {
-		announcementAdminService.modifyAnnouncementIsDel(deleterIntraId);
 
-		return new ResponseEntity(HttpStatus.NO_CONTENT);
-	}
+    @DeleteMapping("/announcement/{deleterIntraId}")
+    public ResponseEntity<Void> announcementModify(@PathVariable String deleterIntraId) {
+        announcementAdminService.modifyAnnouncementIsDel(deleterIntraId);
+
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
 }

--- a/src/main/java/com/gg/server/admin/announcement/controller/AnnouncementAdminController.java
+++ b/src/main/java/com/gg/server/admin/announcement/controller/AnnouncementAdminController.java
@@ -41,18 +41,17 @@ public class AnnouncementAdminController {
 			.body(announcementAdminService.findAllAnnouncement(pageable));
 	}
 
-    @PostMapping("/announcement")
-    public ResponseEntity<Void> addAnnouncement(@Valid @RequestBody AnnouncementAdminAddDto addDto){
-        announcementAdminService.addAnnouncement(addDto);
+	@PostMapping("/announcement")
+	public ResponseEntity<Void> addAnnouncement(@Valid @RequestBody AnnouncementAdminAddDto addDto) {
+		announcementAdminService.addAnnouncement(addDto);
 
-        return ResponseEntity.status(HttpStatus.CREATED).build();
-    }
+		return ResponseEntity.status(HttpStatus.CREATED).build();
+	}
 
+	@DeleteMapping("/announcement/{deleterIntraId}")
+	public ResponseEntity<Void> announcementModify(@PathVariable String deleterIntraId) {
+		announcementAdminService.modifyAnnouncementIsDel(deleterIntraId);
 
-    @DeleteMapping("/announcement/{deleterIntraId}")
-    public ResponseEntity<Void> announcementModify(@PathVariable String deleterIntraId) {
-        announcementAdminService.modifyAnnouncementIsDel(deleterIntraId);
-
-        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
-    }
+		return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+	}
 }

--- a/src/main/java/com/gg/server/admin/announcement/service/AnnouncementAdminService.java
+++ b/src/main/java/com/gg/server/admin/announcement/service/AnnouncementAdminService.java
@@ -16,12 +16,6 @@ import com.gg.server.domain.announcement.exception.AnnounceDupException;
 import com.gg.server.domain.announcement.exception.AnnounceNotFoundException;
 
 import lombok.AllArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDateTime;
 
 @Service
 @AllArgsConstructor
@@ -37,24 +31,24 @@ public class AnnouncementAdminService {
 			responseDtos.getTotalPages());
 	}
 
-    @Transactional
-    public void addAnnouncement(AnnouncementAdminAddDto addDto){
-        Announcement announcement = announcementAdminRepository.findFirstByOrderByIdDesc()
-            .orElseThrow(AnnounceNotFoundException::new);
-        if (announcement.getDeletedAt() == null) {
-            throw new AnnounceDupException();
-        }
+	@Transactional
+	public void addAnnouncement(AnnouncementAdminAddDto addDto) {
+		Announcement announcement = announcementAdminRepository.findFirstByOrderByIdDesc()
+			.orElseThrow(AnnounceNotFoundException::new);
+		if (announcement.getDeletedAt() == null) {
+			throw new AnnounceDupException();
+		}
 
-        announcementAdminRepository.save(Announcement.from(addDto));
-    }
+		announcementAdminRepository.save(Announcement.from(addDto));
+	}
 
-    @Transactional
-    public void modifyAnnouncementIsDel(String deleterIntraId) {
-        Announcement announcement = announcementAdminRepository.findFirstByOrderByIdDesc()
-            .orElseThrow(AnnounceNotFoundException::new);
-        if (announcement.getDeletedAt() != null) {
-            throw new AnnounceNotFoundException();
-        }
-        announcement.update(deleterIntraId, LocalDateTime.now());
-    }
+	@Transactional
+	public void modifyAnnouncementIsDel(String deleterIntraId) {
+		Announcement announcement = announcementAdminRepository.findFirstByOrderByIdDesc()
+			.orElseThrow(AnnounceNotFoundException::new);
+		if (announcement.getDeletedAt() != null) {
+			throw new AnnounceNotFoundException();
+		}
+		announcement.update(deleterIntraId, LocalDateTime.now());
+	}
 }

--- a/src/main/java/com/gg/server/domain/announcement/service/AnnouncementService.java
+++ b/src/main/java/com/gg/server/domain/announcement/service/AnnouncementService.java
@@ -15,18 +15,19 @@ import lombok.RequiredArgsConstructor;
 public class AnnouncementService {
 	private final AnnouncementRepository announcementRepository;
 
-    /**
-     * <p>가장 최근 공지를 찾아서 dto로 반환해준다.</p>
-     * <p>만약 가장 최근 공지가 삭제 되었다면 dto에 빈값을 넣어서 반환해준다.</p>
-     * @throws AnnounceNotFoundException 공지 없음
-     * @return AnnouncementDto
-     */
-    @Transactional(readOnly = true)
-    public AnnouncementDto findLastAnnouncement() {
-        Announcement announcement = announcementRepository.findFirstByOrderByIdDesc()
-            .orElseThrow(AnnounceNotFoundException::new);
-        if (announcement.getDeletedAt() != null)
-            return new AnnouncementDto("");
+	/**
+	 * <p>가장 최근 공지를 찾아서 dto로 반환해준다.</p>
+	 * <p>만약 가장 최근 공지가 삭제 되었다면 dto에 빈값을 넣어서 반환해준다.</p>
+	 * @throws AnnounceNotFoundException 공지 없음
+	 * @return AnnouncementDto
+	 */
+	@Transactional(readOnly = true)
+	public AnnouncementDto findLastAnnouncement() {
+		Announcement announcement = announcementRepository.findFirstByOrderByIdDesc()
+			.orElseThrow(AnnounceNotFoundException::new);
+		if (announcement.getDeletedAt() != null) {
+			return new AnnouncementDto("");
+		}
 
 		return AnnouncementDto.from(announcement);
 	}

--- a/src/main/java/com/gg/server/domain/announcement/service/AnnouncementService.java
+++ b/src/main/java/com/gg/server/domain/announcement/service/AnnouncementService.java
@@ -15,13 +15,18 @@ import lombok.RequiredArgsConstructor;
 public class AnnouncementService {
 	private final AnnouncementRepository announcementRepository;
 
-	@Transactional(readOnly = true)
-	public AnnouncementDto findLastAnnouncement() {
-		Announcement announcement = announcementRepository.findFirstByOrderByIdDesc()
-			.orElseThrow(() -> new AnnounceNotFoundException());
-		if (announcement.getDeletedAt() != null) {
-			return new AnnouncementDto("");
-		}
+    /**
+     * <p>가장 최근 공지를 찾아서 dto로 반환해준다.</p>
+     * <p>만약 가장 최근 공지가 삭제 되었다면 dto에 빈값을 넣어서 반환해준다.</p>
+     * @throws AnnounceNotFoundException 공지 없음
+     * @return AnnouncementDto
+     */
+    @Transactional(readOnly = true)
+    public AnnouncementDto findLastAnnouncement() {
+        Announcement announcement = announcementRepository.findFirstByOrderByIdDesc()
+            .orElseThrow(AnnounceNotFoundException::new);
+        if (announcement.getDeletedAt() != null)
+            return new AnnouncementDto("");
 
 		return AnnouncementDto.from(announcement);
 	}

--- a/src/test/java/com/gg/server/admin/announcement/controller/AnnouncementAdminControllerUnitTest.java
+++ b/src/test/java/com/gg/server/admin/announcement/controller/AnnouncementAdminControllerUnitTest.java
@@ -1,0 +1,60 @@
+package com.gg.server.admin.announcement.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import com.gg.server.admin.announcement.dto.AnnouncementAdminAddDto;
+import com.gg.server.admin.announcement.dto.AnnouncementAdminListResponseDto;
+import com.gg.server.admin.announcement.service.AnnouncementAdminService;
+import com.gg.server.global.dto.PageRequestDto;
+import com.gg.server.utils.annotation.UnitTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
+
+@UnitTest
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AnnouncementAdminControllerUnitTest")
+class AnnouncementAdminControllerUnitTest {
+    @Mock
+    AnnouncementAdminService announcementAdminService;
+    @InjectMocks
+    AnnouncementAdminController announcementAdminController;
+
+    @Nested
+    @DisplayName("GetAnnouncementList_메서드_unitTest")
+    class GetAnnouncementList {
+        @Test
+        @DisplayName("성공")
+        void success() {
+            given(announcementAdminService.findAllAnnouncement(any(Pageable.class))).willReturn(new AnnouncementAdminListResponseDto());
+            announcementAdminController.getAnnouncementList(new PageRequestDto(1, 5));
+        }
+    }
+
+    @Nested
+    @DisplayName("AddAnnouncement_메서드_unitTest")
+    class AddAnnouncement {
+        @Test
+        @DisplayName("성공")
+        void success() {
+            announcementAdminController.addAnnouncement(mock(AnnouncementAdminAddDto.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("AnnouncementModify_메서드_unitTest")
+    class AnnouncementModify {
+        @Test
+        @DisplayName("성공")
+        void success() {
+            announcementAdminController.announcementModify("deleterIntraId");
+        }
+    }
+}

--- a/src/test/java/com/gg/server/admin/announcement/controller/AnnouncementAdminControllerUnitTest.java
+++ b/src/test/java/com/gg/server/admin/announcement/controller/AnnouncementAdminControllerUnitTest.java
@@ -1,14 +1,9 @@
 package com.gg.server.admin.announcement.controller;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+import static org.mockito.Mockito.*;
 
-import com.gg.server.admin.announcement.dto.AnnouncementAdminAddDto;
-import com.gg.server.admin.announcement.dto.AnnouncementAdminListResponseDto;
-import com.gg.server.admin.announcement.service.AnnouncementAdminService;
-import com.gg.server.global.dto.PageRequestDto;
-import com.gg.server.utils.annotation.UnitTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -18,43 +13,50 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Pageable;
 
+import com.gg.server.admin.announcement.dto.AnnouncementAdminAddDto;
+import com.gg.server.admin.announcement.dto.AnnouncementAdminListResponseDto;
+import com.gg.server.admin.announcement.service.AnnouncementAdminService;
+import com.gg.server.global.dto.PageRequestDto;
+import com.gg.server.utils.annotation.UnitTest;
+
 @UnitTest
 @ExtendWith(MockitoExtension.class)
 @DisplayName("AnnouncementAdminControllerUnitTest")
 class AnnouncementAdminControllerUnitTest {
-    @Mock
-    AnnouncementAdminService announcementAdminService;
-    @InjectMocks
-    AnnouncementAdminController announcementAdminController;
+	@Mock
+	AnnouncementAdminService announcementAdminService;
+	@InjectMocks
+	AnnouncementAdminController announcementAdminController;
 
-    @Nested
-    @DisplayName("GetAnnouncementList_메서드_unitTest")
-    class GetAnnouncementList {
-        @Test
-        @DisplayName("성공")
-        void success() {
-            given(announcementAdminService.findAllAnnouncement(any(Pageable.class))).willReturn(new AnnouncementAdminListResponseDto());
-            announcementAdminController.getAnnouncementList(new PageRequestDto(1, 5));
-        }
-    }
+	@Nested
+	@DisplayName("GetAnnouncementList_메서드_unitTest")
+	class GetAnnouncementList {
+		@Test
+		@DisplayName("성공")
+		void success() {
+			given(announcementAdminService.findAllAnnouncement(any(Pageable.class))).willReturn(
+				new AnnouncementAdminListResponseDto());
+			announcementAdminController.getAnnouncementList(new PageRequestDto(1, 5));
+		}
+	}
 
-    @Nested
-    @DisplayName("AddAnnouncement_메서드_unitTest")
-    class AddAnnouncement {
-        @Test
-        @DisplayName("성공")
-        void success() {
-            announcementAdminController.addAnnouncement(mock(AnnouncementAdminAddDto.class));
-        }
-    }
+	@Nested
+	@DisplayName("AddAnnouncement_메서드_unitTest")
+	class AddAnnouncement {
+		@Test
+		@DisplayName("성공")
+		void success() {
+			announcementAdminController.addAnnouncement(mock(AnnouncementAdminAddDto.class));
+		}
+	}
 
-    @Nested
-    @DisplayName("AnnouncementModify_메서드_unitTest")
-    class AnnouncementModify {
-        @Test
-        @DisplayName("성공")
-        void success() {
-            announcementAdminController.announcementModify("deleterIntraId");
-        }
-    }
+	@Nested
+	@DisplayName("AnnouncementModify_메서드_unitTest")
+	class AnnouncementModify {
+		@Test
+		@DisplayName("성공")
+		void success() {
+			announcementAdminController.announcementModify("deleterIntraId");
+		}
+	}
 }

--- a/src/test/java/com/gg/server/admin/announcement/service/AnnouncementAdminServiceUnitTest.java
+++ b/src/test/java/com/gg/server/admin/announcement/service/AnnouncementAdminServiceUnitTest.java
@@ -3,7 +3,7 @@ package com.gg.server.admin.announcement.service;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.*;
 
 import com.gg.server.admin.announcement.data.AnnouncementAdminRepository;
 import com.gg.server.admin.announcement.dto.AnnouncementAdminAddDto;
@@ -43,6 +43,7 @@ class AnnouncementAdminServiceUnitTest {
             List<Announcement> announcementList = new ArrayList<>();
             given(announcementAdminRepository.findAll(any(Pageable.class))).willReturn(new PageImpl<>(announcementList));
             announcementAdminService.findAllAnnouncement(mock(Pageable.class));
+            verify(announcementAdminRepository, times(1)).findAll(any(Pageable.class));
         }
     }
 
@@ -58,6 +59,7 @@ class AnnouncementAdminServiceUnitTest {
             announcement.update(IntraId, curTime);
             given(announcementAdminRepository.findFirstByOrderByIdDesc()).willReturn(Optional.of(announcement));
             announcementAdminService.addAnnouncement(new AnnouncementAdminAddDto());
+            verify(announcementAdminRepository, times(1)).findFirstByOrderByIdDesc();
         }
 
         @Test
@@ -66,6 +68,7 @@ class AnnouncementAdminServiceUnitTest {
             given(announcementAdminRepository.findFirstByOrderByIdDesc()).willReturn(Optional.empty());
             assertThatThrownBy(()->announcementAdminService.addAnnouncement(new AnnouncementAdminAddDto()))
                 .isInstanceOf(AnnounceNotFoundException.class);
+            verify(announcementAdminRepository, times(1)).findFirstByOrderByIdDesc();
         }
 
         @Test
@@ -75,6 +78,7 @@ class AnnouncementAdminServiceUnitTest {
             given(announcementAdminRepository.findFirstByOrderByIdDesc()).willReturn(Optional.of(announcement));
             assertThatThrownBy(()->announcementAdminService.addAnnouncement(new AnnouncementAdminAddDto()))
                 .isInstanceOf(AnnounceDupException.class);
+            verify(announcementAdminRepository, times(1)).findFirstByOrderByIdDesc();
         }
     }
 
@@ -88,6 +92,7 @@ class AnnouncementAdminServiceUnitTest {
             Announcement announcement = new Announcement();
             given(announcementAdminRepository.findFirstByOrderByIdDesc()).willReturn(Optional.of(announcement));
             announcementAdminService.modifyAnnouncementIsDel(intraId);
+            verify(announcementAdminRepository, times(1)).findFirstByOrderByIdDesc();
         }
 
         @Test
@@ -96,6 +101,7 @@ class AnnouncementAdminServiceUnitTest {
             given(announcementAdminRepository.findFirstByOrderByIdDesc()).willReturn(Optional.empty());
             assertThatThrownBy(()->announcementAdminService.modifyAnnouncementIsDel(intraId))
                 .isInstanceOf(AnnounceNotFoundException.class);
+            verify(announcementAdminRepository, times(1)).findFirstByOrderByIdDesc();
         }
 
         @Test
@@ -106,6 +112,7 @@ class AnnouncementAdminServiceUnitTest {
             given(announcementAdminRepository.findFirstByOrderByIdDesc()).willReturn(Optional.of(announcement));
             assertThatThrownBy(()->announcementAdminService.modifyAnnouncementIsDel(intraId))
                 .isInstanceOf(AnnounceNotFoundException.class);
+            verify(announcementAdminRepository, times(1)).findFirstByOrderByIdDesc();
         }
     }
 }

--- a/src/test/java/com/gg/server/admin/announcement/service/AnnouncementAdminServiceUnitTest.java
+++ b/src/test/java/com/gg/server/admin/announcement/service/AnnouncementAdminServiceUnitTest.java
@@ -1,0 +1,111 @@
+package com.gg.server.admin.announcement.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import com.gg.server.admin.announcement.data.AnnouncementAdminRepository;
+import com.gg.server.admin.announcement.dto.AnnouncementAdminAddDto;
+import com.gg.server.domain.announcement.data.Announcement;
+import com.gg.server.domain.announcement.exception.AnnounceDupException;
+import com.gg.server.domain.announcement.exception.AnnounceNotFoundException;
+import com.gg.server.utils.annotation.UnitTest;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+@UnitTest
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AnnouncementAdminServiceUnitTest")
+class AnnouncementAdminServiceUnitTest {
+    @Mock
+    AnnouncementAdminRepository announcementAdminRepository;
+    @InjectMocks
+    AnnouncementAdminService announcementAdminService;
+
+    @Nested
+    @DisplayName("findAllAnnouncement_메서드_unitTest")
+    class FindAllAnnouncementTest {
+        @Test
+        @DisplayName("성공")
+        void success() {
+            List<Announcement> announcementList = new ArrayList<>();
+            given(announcementAdminRepository.findAll(any(Pageable.class))).willReturn(new PageImpl<>(announcementList));
+            announcementAdminService.findAllAnnouncement(mock(Pageable.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("addAnnouncement_메서드_unitTest")
+    class AddAnnouncementTest {
+        @Test
+        @DisplayName("성공")
+        void success() {
+            String IntraId = "intraId";
+            LocalDateTime curTime = LocalDateTime.now();
+            Announcement announcement = new Announcement();
+            announcement.update(IntraId, curTime);
+            given(announcementAdminRepository.findFirstByOrderByIdDesc()).willReturn(Optional.of(announcement));
+            announcementAdminService.addAnnouncement(new AnnouncementAdminAddDto());
+        }
+
+        @Test
+        @DisplayName("AnnounceNotFound")
+        void announceNotFound() {
+            given(announcementAdminRepository.findFirstByOrderByIdDesc()).willReturn(Optional.empty());
+            assertThatThrownBy(()->announcementAdminService.addAnnouncement(new AnnouncementAdminAddDto()))
+                .isInstanceOf(AnnounceNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("Announce_삭제_안된_경우")
+        void AnnounceNotDeleted() {
+            Announcement announcement = new Announcement();
+            given(announcementAdminRepository.findFirstByOrderByIdDesc()).willReturn(Optional.of(announcement));
+            assertThatThrownBy(()->announcementAdminService.addAnnouncement(new AnnouncementAdminAddDto()))
+                .isInstanceOf(AnnounceDupException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("modifyAnnouncementIsDel_메서드_unitTest")
+    class ModifyAnnouncementIsDelTest {
+        final String intraId = "intraId";
+        @Test
+        @DisplayName("성공")
+        void success() {
+            Announcement announcement = new Announcement();
+            given(announcementAdminRepository.findFirstByOrderByIdDesc()).willReturn(Optional.of(announcement));
+            announcementAdminService.modifyAnnouncementIsDel(intraId);
+        }
+
+        @Test
+        @DisplayName("AnnounceNotFound")
+        void announceNotFound() {
+            given(announcementAdminRepository.findFirstByOrderByIdDesc()).willReturn(Optional.empty());
+            assertThatThrownBy(()->announcementAdminService.modifyAnnouncementIsDel(intraId))
+                .isInstanceOf(AnnounceNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("삭제된_Announce_삭제")
+        void deleteFail() {
+            Announcement announcement = new Announcement();
+            announcement.update(intraId, LocalDateTime.now());
+            given(announcementAdminRepository.findFirstByOrderByIdDesc()).willReturn(Optional.of(announcement));
+            assertThatThrownBy(()->announcementAdminService.modifyAnnouncementIsDel(intraId))
+                .isInstanceOf(AnnounceNotFoundException.class);
+        }
+    }
+}

--- a/src/test/java/com/gg/server/admin/announcement/service/AnnouncementAdminServiceUnitTest.java
+++ b/src/test/java/com/gg/server/admin/announcement/service/AnnouncementAdminServiceUnitTest.java
@@ -1,20 +1,14 @@
 package com.gg.server.admin.announcement.service;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
 
-import com.gg.server.admin.announcement.data.AnnouncementAdminRepository;
-import com.gg.server.admin.announcement.dto.AnnouncementAdminAddDto;
-import com.gg.server.domain.announcement.data.Announcement;
-import com.gg.server.domain.announcement.exception.AnnounceDupException;
-import com.gg.server.domain.announcement.exception.AnnounceNotFoundException;
-import com.gg.server.utils.annotation.UnitTest;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -25,94 +19,103 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 
+import com.gg.server.admin.announcement.data.AnnouncementAdminRepository;
+import com.gg.server.admin.announcement.dto.AnnouncementAdminAddDto;
+import com.gg.server.domain.announcement.data.Announcement;
+import com.gg.server.domain.announcement.exception.AnnounceDupException;
+import com.gg.server.domain.announcement.exception.AnnounceNotFoundException;
+import com.gg.server.utils.annotation.UnitTest;
+
 @UnitTest
 @ExtendWith(MockitoExtension.class)
 @DisplayName("AnnouncementAdminServiceUnitTest")
 class AnnouncementAdminServiceUnitTest {
-    @Mock
-    AnnouncementAdminRepository announcementAdminRepository;
-    @InjectMocks
-    AnnouncementAdminService announcementAdminService;
+	@Mock
+	AnnouncementAdminRepository announcementAdminRepository;
+	@InjectMocks
+	AnnouncementAdminService announcementAdminService;
 
-    @Nested
-    @DisplayName("findAllAnnouncement_메서드_unitTest")
-    class FindAllAnnouncementTest {
-        @Test
-        @DisplayName("성공")
-        void success() {
-            List<Announcement> announcementList = new ArrayList<>();
-            given(announcementAdminRepository.findAll(any(Pageable.class))).willReturn(new PageImpl<>(announcementList));
-            announcementAdminService.findAllAnnouncement(mock(Pageable.class));
-            verify(announcementAdminRepository, times(1)).findAll(any(Pageable.class));
-        }
-    }
+	@Nested
+	@DisplayName("findAllAnnouncement_메서드_unitTest")
+	class FindAllAnnouncementTest {
+		@Test
+		@DisplayName("성공")
+		void success() {
+			List<Announcement> announcementList = new ArrayList<>();
+			given(announcementAdminRepository.findAll(any(Pageable.class)))
+				.willReturn(new PageImpl<>(announcementList));
+			announcementAdminService.findAllAnnouncement(mock(Pageable.class));
+			verify(announcementAdminRepository, times(1)).findAll(any(Pageable.class));
+		}
+	}
 
-    @Nested
-    @DisplayName("addAnnouncement_메서드_unitTest")
-    class AddAnnouncementTest {
-        @Test
-        @DisplayName("성공")
-        void success() {
-            String IntraId = "intraId";
-            LocalDateTime curTime = LocalDateTime.now();
-            Announcement announcement = new Announcement();
-            announcement.update(IntraId, curTime);
-            given(announcementAdminRepository.findFirstByOrderByIdDesc()).willReturn(Optional.of(announcement));
-            announcementAdminService.addAnnouncement(new AnnouncementAdminAddDto());
-            verify(announcementAdminRepository, times(1)).findFirstByOrderByIdDesc();
-        }
+	@Nested
+	@DisplayName("addAnnouncement_메서드_unitTest")
+	class AddAnnouncementTest {
+		@Test
+		@DisplayName("성공")
+		void success() {
+			String intraId = "intraId";
+			LocalDateTime curTime = LocalDateTime.now();
+			Announcement announcement = new Announcement();
+			announcement.update(intraId, curTime);
+			given(announcementAdminRepository.findFirstByOrderByIdDesc()).willReturn(Optional.of(announcement));
+			announcementAdminService.addAnnouncement(new AnnouncementAdminAddDto());
+			verify(announcementAdminRepository, times(1)).findFirstByOrderByIdDesc();
+		}
 
-        @Test
-        @DisplayName("AnnounceNotFound")
-        void announceNotFound() {
-            given(announcementAdminRepository.findFirstByOrderByIdDesc()).willReturn(Optional.empty());
-            assertThatThrownBy(()->announcementAdminService.addAnnouncement(new AnnouncementAdminAddDto()))
-                .isInstanceOf(AnnounceNotFoundException.class);
-            verify(announcementAdminRepository, times(1)).findFirstByOrderByIdDesc();
-        }
+		@Test
+		@DisplayName("AnnounceNotFound")
+		void announceNotFound() {
+			given(announcementAdminRepository.findFirstByOrderByIdDesc()).willReturn(Optional.empty());
+			assertThatThrownBy(() -> announcementAdminService.addAnnouncement(new AnnouncementAdminAddDto()))
+				.isInstanceOf(AnnounceNotFoundException.class);
+			verify(announcementAdminRepository, times(1)).findFirstByOrderByIdDesc();
+		}
 
-        @Test
-        @DisplayName("Announce_삭제_안된_경우")
-        void AnnounceNotDeleted() {
-            Announcement announcement = new Announcement();
-            given(announcementAdminRepository.findFirstByOrderByIdDesc()).willReturn(Optional.of(announcement));
-            assertThatThrownBy(()->announcementAdminService.addAnnouncement(new AnnouncementAdminAddDto()))
-                .isInstanceOf(AnnounceDupException.class);
-            verify(announcementAdminRepository, times(1)).findFirstByOrderByIdDesc();
-        }
-    }
+		@Test
+		@DisplayName("Announce_삭제_안된_경우")
+		void announceNotDeleted() {
+			Announcement announcement = new Announcement();
+			given(announcementAdminRepository.findFirstByOrderByIdDesc()).willReturn(Optional.of(announcement));
+			assertThatThrownBy(() -> announcementAdminService.addAnnouncement(new AnnouncementAdminAddDto()))
+				.isInstanceOf(AnnounceDupException.class);
+			verify(announcementAdminRepository, times(1)).findFirstByOrderByIdDesc();
+		}
+	}
 
-    @Nested
-    @DisplayName("modifyAnnouncementIsDel_메서드_unitTest")
-    class ModifyAnnouncementIsDelTest {
-        final String intraId = "intraId";
-        @Test
-        @DisplayName("성공")
-        void success() {
-            Announcement announcement = new Announcement();
-            given(announcementAdminRepository.findFirstByOrderByIdDesc()).willReturn(Optional.of(announcement));
-            announcementAdminService.modifyAnnouncementIsDel(intraId);
-            verify(announcementAdminRepository, times(1)).findFirstByOrderByIdDesc();
-        }
+	@Nested
+	@DisplayName("modifyAnnouncementIsDel_메서드_unitTest")
+	class ModifyAnnouncementIsDelTest {
+		final String intraId = "intraId";
 
-        @Test
-        @DisplayName("AnnounceNotFound")
-        void announceNotFound() {
-            given(announcementAdminRepository.findFirstByOrderByIdDesc()).willReturn(Optional.empty());
-            assertThatThrownBy(()->announcementAdminService.modifyAnnouncementIsDel(intraId))
-                .isInstanceOf(AnnounceNotFoundException.class);
-            verify(announcementAdminRepository, times(1)).findFirstByOrderByIdDesc();
-        }
+		@Test
+		@DisplayName("성공")
+		void success() {
+			Announcement announcement = new Announcement();
+			given(announcementAdminRepository.findFirstByOrderByIdDesc()).willReturn(Optional.of(announcement));
+			announcementAdminService.modifyAnnouncementIsDel(intraId);
+			verify(announcementAdminRepository, times(1)).findFirstByOrderByIdDesc();
+		}
 
-        @Test
-        @DisplayName("삭제된_Announce_삭제")
-        void deleteFail() {
-            Announcement announcement = new Announcement();
-            announcement.update(intraId, LocalDateTime.now());
-            given(announcementAdminRepository.findFirstByOrderByIdDesc()).willReturn(Optional.of(announcement));
-            assertThatThrownBy(()->announcementAdminService.modifyAnnouncementIsDel(intraId))
-                .isInstanceOf(AnnounceNotFoundException.class);
-            verify(announcementAdminRepository, times(1)).findFirstByOrderByIdDesc();
-        }
-    }
+		@Test
+		@DisplayName("AnnounceNotFound")
+		void announceNotFound() {
+			given(announcementAdminRepository.findFirstByOrderByIdDesc()).willReturn(Optional.empty());
+			assertThatThrownBy(() -> announcementAdminService.modifyAnnouncementIsDel(intraId))
+				.isInstanceOf(AnnounceNotFoundException.class);
+			verify(announcementAdminRepository, times(1)).findFirstByOrderByIdDesc();
+		}
+
+		@Test
+		@DisplayName("삭제된_Announce_삭제")
+		void deleteFail() {
+			Announcement announcement = new Announcement();
+			announcement.update(intraId, LocalDateTime.now());
+			given(announcementAdminRepository.findFirstByOrderByIdDesc()).willReturn(Optional.of(announcement));
+			assertThatThrownBy(() -> announcementAdminService.modifyAnnouncementIsDel(intraId))
+				.isInstanceOf(AnnounceNotFoundException.class);
+			verify(announcementAdminRepository, times(1)).findFirstByOrderByIdDesc();
+		}
+	}
 }

--- a/src/test/java/com/gg/server/domain/announcement/controller/AnnouncementControllerUnitTest.java
+++ b/src/test/java/com/gg/server/domain/announcement/controller/AnnouncementControllerUnitTest.java
@@ -1,12 +1,8 @@
 package com.gg.server.domain.announcement.controller;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.*;
 
-import com.gg.server.domain.announcement.dto.AnnouncementDto;
-import com.gg.server.domain.announcement.dto.AnnouncementResponseDto;
-import com.gg.server.domain.announcement.service.AnnouncementService;
-import com.gg.server.utils.annotation.UnitTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -15,28 +11,32 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.gg.server.domain.announcement.dto.AnnouncementDto;
+import com.gg.server.domain.announcement.dto.AnnouncementResponseDto;
+import com.gg.server.domain.announcement.service.AnnouncementService;
+import com.gg.server.utils.annotation.UnitTest;
+
 @UnitTest
 @ExtendWith(MockitoExtension.class)
 @DisplayName("AnnouncementControllerUnitTest")
 class AnnouncementControllerUnitTest {
-    @Mock
-    AnnouncementService announcementService;
-    @InjectMocks
-    AnnouncementController announcementController;
+	@Mock
+	AnnouncementService announcementService;
+	@InjectMocks
+	AnnouncementController announcementController;
 
-    @Nested
-    @DisplayName("findLastAnnounceContent_메서드_unitTest")
-    class FindLastAnnounceContentTest {
-        @Test
-        @DisplayName("성공")
-        void success() {
-            //given
-            String content = "content";
-            given(announcementService.findLastAnnouncement()).willReturn(new AnnouncementDto(content));
-            // when, then
-            assertThat(announcementController.findLastAnnounceContent()).isInstanceOf(AnnouncementResponseDto.class);
-            assertThat(announcementController.findLastAnnounceContent().getContent()).isEqualTo(content);
-
-        }
-    }
+	@Nested
+	@DisplayName("findLastAnnounceContent_메서드_unitTest")
+	class FindLastAnnounceContentTest {
+		@Test
+		@DisplayName("성공")
+		void success() {
+			//given
+			String content = "content";
+			given(announcementService.findLastAnnouncement()).willReturn(new AnnouncementDto(content));
+			// when, then
+			assertThat(announcementController.findLastAnnounceContent()).isInstanceOf(AnnouncementResponseDto.class);
+			assertThat(announcementController.findLastAnnounceContent().getContent()).isEqualTo(content);
+		}
+	}
 }

--- a/src/test/java/com/gg/server/domain/announcement/controller/AnnouncementControllerUnitTest.java
+++ b/src/test/java/com/gg/server/domain/announcement/controller/AnnouncementControllerUnitTest.java
@@ -1,0 +1,42 @@
+package com.gg.server.domain.announcement.controller;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+
+import com.gg.server.domain.announcement.dto.AnnouncementDto;
+import com.gg.server.domain.announcement.dto.AnnouncementResponseDto;
+import com.gg.server.domain.announcement.service.AnnouncementService;
+import com.gg.server.utils.annotation.UnitTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@UnitTest
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AnnouncementControllerUnitTest")
+class AnnouncementControllerUnitTest {
+    @Mock
+    AnnouncementService announcementService;
+    @InjectMocks
+    AnnouncementController announcementController;
+
+    @Nested
+    @DisplayName("findLastAnnounceContent_메서드_unitTest")
+    class FindLastAnnounceContentTest {
+        @Test
+        @DisplayName("성공")
+        void success() {
+            //given
+            String content = "content";
+            given(announcementService.findLastAnnouncement()).willReturn(new AnnouncementDto(content));
+            // when, then
+            assertThat(announcementController.findLastAnnounceContent()).isInstanceOf(AnnouncementResponseDto.class);
+            assertThat(announcementController.findLastAnnounceContent().getContent()).isEqualTo(content);
+
+        }
+    }
+}

--- a/src/test/java/com/gg/server/domain/announcement/data/AnnouncementUnitTest.java
+++ b/src/test/java/com/gg/server/domain/announcement/data/AnnouncementUnitTest.java
@@ -1,0 +1,44 @@
+package com.gg.server.domain.announcement.data;
+
+import static org.assertj.core.api.Assertions.*;
+
+import com.gg.server.admin.announcement.dto.AnnouncementAdminAddDto;
+import com.gg.server.utils.annotation.UnitTest;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@UnitTest
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AnnouncementUnitTest")
+class AnnouncementUnitTest {
+    final String content = "content";
+    final String intraId = "intraId";
+
+    @Nested
+    @DisplayName("findLastAnnouncement_메서드_unitTest")
+    class FindLastAnnounceContentTest {
+        @Test
+        @DisplayName("update_메서드_unitTest")
+        void updateTest() {
+            String deleterIntraId = "deleter";
+            LocalDateTime curTime = LocalDateTime.now();
+            Announcement announcement = new Announcement(content, intraId);
+            announcement.update(deleterIntraId, curTime);
+            assertThat(announcement.getDeleterIntraId()).isEqualTo(deleterIntraId);
+            assertThat(announcement.getDeletedAt()).isEqualTo(curTime);
+        }
+
+        @Test
+        @DisplayName("from_메서드_unitTest")
+        void fromTest() {
+            AnnouncementAdminAddDto dto = new AnnouncementAdminAddDto(content, intraId);
+            Announcement announcement = Announcement.from(dto);
+            assertThat(announcement.getContent()).isEqualTo(dto.getContent());
+            assertThat(announcement.getCreatorIntraId()).isEqualTo(dto.getCreatorIntraId());
+        }
+    }
+}

--- a/src/test/java/com/gg/server/domain/announcement/data/AnnouncementUnitTest.java
+++ b/src/test/java/com/gg/server/domain/announcement/data/AnnouncementUnitTest.java
@@ -2,43 +2,45 @@ package com.gg.server.domain.announcement.data;
 
 import static org.assertj.core.api.Assertions.*;
 
-import com.gg.server.admin.announcement.dto.AnnouncementAdminAddDto;
-import com.gg.server.utils.annotation.UnitTest;
 import java.time.LocalDateTime;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.gg.server.admin.announcement.dto.AnnouncementAdminAddDto;
+import com.gg.server.utils.annotation.UnitTest;
+
 @UnitTest
 @ExtendWith(MockitoExtension.class)
 @DisplayName("AnnouncementUnitTest")
 class AnnouncementUnitTest {
-    final String content = "content";
-    final String intraId = "intraId";
+	final String content = "content";
+	final String intraId = "intraId";
 
-    @Nested
-    @DisplayName("findLastAnnouncement_메서드_unitTest")
-    class FindLastAnnounceContentTest {
-        @Test
-        @DisplayName("update_메서드_unitTest")
-        void updateTest() {
-            String deleterIntraId = "deleter";
-            LocalDateTime curTime = LocalDateTime.now();
-            Announcement announcement = new Announcement(content, intraId);
-            announcement.update(deleterIntraId, curTime);
-            assertThat(announcement.getDeleterIntraId()).isEqualTo(deleterIntraId);
-            assertThat(announcement.getDeletedAt()).isEqualTo(curTime);
-        }
+	@Nested
+	@DisplayName("findLastAnnouncement_메서드_unitTest")
+	class FindLastAnnounceContentTest {
+		@Test
+		@DisplayName("update_메서드_unitTest")
+		void updateTest() {
+			String deleterIntraId = "deleter";
+			LocalDateTime curTime = LocalDateTime.now();
+			Announcement announcement = new Announcement(content, intraId);
+			announcement.update(deleterIntraId, curTime);
+			assertThat(announcement.getDeleterIntraId()).isEqualTo(deleterIntraId);
+			assertThat(announcement.getDeletedAt()).isEqualTo(curTime);
+		}
 
-        @Test
-        @DisplayName("from_메서드_unitTest")
-        void fromTest() {
-            AnnouncementAdminAddDto dto = new AnnouncementAdminAddDto(content, intraId);
-            Announcement announcement = Announcement.from(dto);
-            assertThat(announcement.getContent()).isEqualTo(dto.getContent());
-            assertThat(announcement.getCreatorIntraId()).isEqualTo(dto.getCreatorIntraId());
-        }
-    }
+		@Test
+		@DisplayName("from_메서드_unitTest")
+		void fromTest() {
+			AnnouncementAdminAddDto dto = new AnnouncementAdminAddDto(content, intraId);
+			Announcement announcement = Announcement.from(dto);
+			assertThat(announcement.getContent()).isEqualTo(dto.getContent());
+			assertThat(announcement.getCreatorIntraId()).isEqualTo(dto.getCreatorIntraId());
+		}
+	}
 }

--- a/src/test/java/com/gg/server/domain/announcement/service/AnnouncementServiceUnitTest.java
+++ b/src/test/java/com/gg/server/domain/announcement/service/AnnouncementServiceUnitTest.java
@@ -1,15 +1,11 @@
 package com.gg.server.domain.announcement.service;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.*;
+import static org.mockito.BDDMockito.*;
 
-import com.gg.server.domain.announcement.data.Announcement;
-import com.gg.server.domain.announcement.data.AnnouncementRepository;
-import com.gg.server.domain.announcement.exception.AnnounceNotFoundException;
-import com.gg.server.utils.annotation.UnitTest;
 import java.time.LocalDateTime;
 import java.util.Optional;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -18,53 +14,59 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.gg.server.domain.announcement.data.Announcement;
+import com.gg.server.domain.announcement.data.AnnouncementRepository;
+import com.gg.server.domain.announcement.exception.AnnounceNotFoundException;
+import com.gg.server.utils.annotation.UnitTest;
+
 @UnitTest
 @ExtendWith(MockitoExtension.class)
 @DisplayName("AnnouncementServiceUnitTest")
 class AnnouncementServiceUnitTest {
-    @Mock
-    AnnouncementRepository announcementRepository;
-    @InjectMocks
-    AnnouncementService announcementService;
+	@Mock
+	AnnouncementRepository announcementRepository;
+	@InjectMocks
+	AnnouncementService announcementService;
 
-    @Nested
-    @DisplayName("findLastAnnouncement_메서드_unitTest")
-    class FindLastAnnounceContentTest {
-        @Test
-        @DisplayName("성공")
-        void success() {
-            //given
-            String content = "content", intraId = "intraId";
-            Announcement announcement = new Announcement(content, intraId);
-            given(announcementRepository.findFirstByOrderByIdDesc()).willReturn(Optional.of(announcement));
-            // when, then
-            assertThat(announcementService.findLastAnnouncement().getContent()).isEqualTo(content);
-            verify(announcementRepository, times(1)).findFirstByOrderByIdDesc();
-        }
+	@Nested
+	@DisplayName("findLastAnnouncement_메서드_unitTest")
+	class FindLastAnnounceContentTest {
+		@Test
+		@DisplayName("성공")
+		void success() {
+			//given
+			String content = "content";
+			String intraId = "intraId";
+			Announcement announcement = new Announcement(content, intraId);
+			given(announcementRepository.findFirstByOrderByIdDesc()).willReturn(Optional.of(announcement));
+			// when, then
+			assertThat(announcementService.findLastAnnouncement().getContent()).isEqualTo(content);
+			verify(announcementRepository, times(1)).findFirstByOrderByIdDesc();
+		}
 
-        @Test
-        @DisplayName("성공_삭제된_announcement")
-        void successAnnouncementDeleted() {
-            //given
-            String content = "content", intraId = "intraId";
-            Announcement announcement = new Announcement(content, intraId);
-            announcement.update(intraId, LocalDateTime.now());
-            given(announcementRepository.findFirstByOrderByIdDesc()).willReturn(Optional.of(announcement));
-            // when, then
-            assertThat(announcementService.findLastAnnouncement().getContent()).isEqualTo("");
-            verify(announcementRepository, times(1)).findFirstByOrderByIdDesc();
-        }
+		@Test
+		@DisplayName("성공_삭제된_announcement")
+		void successAnnouncementDeleted() {
+			//given
+			String content = "content";
+			String intraId = "intraId";
+			Announcement announcement = new Announcement(content, intraId);
+			announcement.update(intraId, LocalDateTime.now());
+			given(announcementRepository.findFirstByOrderByIdDesc()).willReturn(Optional.of(announcement));
+			// when, then
+			assertThat(announcementService.findLastAnnouncement().getContent()).isEqualTo("");
+			verify(announcementRepository, times(1)).findFirstByOrderByIdDesc();
+		}
 
-        @Test
-        @DisplayName("Announcement_404")
-        void announcementNotFound() {
-            //given
-            given(announcementRepository.findFirstByOrderByIdDesc()).willReturn(Optional.empty());
-            // when, then
-            assertThatThrownBy(()->announcementService.findLastAnnouncement())
-                .isInstanceOf(AnnounceNotFoundException.class);
-            verify(announcementRepository, times(1)).findFirstByOrderByIdDesc();
-
-        }
-    }
+		@Test
+		@DisplayName("Announcement_404")
+		void announcementNotFound() {
+			//given
+			given(announcementRepository.findFirstByOrderByIdDesc()).willReturn(Optional.empty());
+			// when, then
+			assertThatThrownBy(() -> announcementService.findLastAnnouncement())
+				.isInstanceOf(AnnounceNotFoundException.class);
+			verify(announcementRepository, times(1)).findFirstByOrderByIdDesc();
+		}
+	}
 }

--- a/src/test/java/com/gg/server/domain/announcement/service/AnnouncementServiceUnitTest.java
+++ b/src/test/java/com/gg/server/domain/announcement/service/AnnouncementServiceUnitTest.java
@@ -1,0 +1,65 @@
+package com.gg.server.domain.announcement.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+
+import com.gg.server.domain.announcement.data.Announcement;
+import com.gg.server.domain.announcement.data.AnnouncementRepository;
+import com.gg.server.domain.announcement.exception.AnnounceNotFoundException;
+import com.gg.server.utils.annotation.UnitTest;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@UnitTest
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AnnouncementServiceUnitTest")
+class AnnouncementServiceUnitTest {
+    @Mock
+    AnnouncementRepository announcementRepository;
+    @InjectMocks
+    AnnouncementService announcementService;
+
+    @Nested
+    @DisplayName("findLastAnnouncement_메서드_unitTest")
+    class FindLastAnnounceContentTest {
+        @Test
+        @DisplayName("성공")
+        void success() {
+            //given
+            String content = "content", intraId = "intraId";
+            Announcement announcement = new Announcement(content, intraId);
+            given(announcementRepository.findFirstByOrderByIdDesc()).willReturn(Optional.of(announcement));
+            // when, then
+            assertThat(announcementService.findLastAnnouncement().getContent()).isEqualTo(content);
+        }
+
+        @Test
+        @DisplayName("성공_삭제된_announcement")
+        void successAnnouncementDeleted() {
+            //given
+            String content = "content", intraId = "intraId";
+            Announcement announcement = new Announcement(content, intraId);
+            announcement.update(intraId, LocalDateTime.now());
+            given(announcementRepository.findFirstByOrderByIdDesc()).willReturn(Optional.of(announcement));
+            // when, then
+            assertThat(announcementService.findLastAnnouncement().getContent()).isEqualTo("");
+        }
+
+        @Test
+        @DisplayName("Announcement_404")
+        void announcementNotFound() {
+            //given
+            given(announcementRepository.findFirstByOrderByIdDesc()).willReturn(Optional.empty());
+            // when, then
+            assertThatThrownBy(()->announcementService.findLastAnnouncement())
+                .isInstanceOf(AnnounceNotFoundException.class);
+        }
+    }
+}

--- a/src/test/java/com/gg/server/domain/announcement/service/AnnouncementServiceUnitTest.java
+++ b/src/test/java/com/gg/server/domain/announcement/service/AnnouncementServiceUnitTest.java
@@ -2,6 +2,7 @@ package com.gg.server.domain.announcement.service;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
 
 import com.gg.server.domain.announcement.data.Announcement;
 import com.gg.server.domain.announcement.data.AnnouncementRepository;
@@ -38,6 +39,7 @@ class AnnouncementServiceUnitTest {
             given(announcementRepository.findFirstByOrderByIdDesc()).willReturn(Optional.of(announcement));
             // when, then
             assertThat(announcementService.findLastAnnouncement().getContent()).isEqualTo(content);
+            verify(announcementRepository, times(1)).findFirstByOrderByIdDesc();
         }
 
         @Test
@@ -50,6 +52,7 @@ class AnnouncementServiceUnitTest {
             given(announcementRepository.findFirstByOrderByIdDesc()).willReturn(Optional.of(announcement));
             // when, then
             assertThat(announcementService.findLastAnnouncement().getContent()).isEqualTo("");
+            verify(announcementRepository, times(1)).findFirstByOrderByIdDesc();
         }
 
         @Test
@@ -60,6 +63,8 @@ class AnnouncementServiceUnitTest {
             // when, then
             assertThatThrownBy(()->announcementService.findLastAnnouncement())
                 .isInstanceOf(AnnounceNotFoundException.class);
+            verify(announcementRepository, times(1)).findFirstByOrderByIdDesc();
+
         }
     }
 }


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - ~`LF` -> `CRLF` 로 변경~
  - `Announcement 단위 테스트` 추가
  - Announcement 서비스 로직 중 쿼리 두번 날리는 부분 수정
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - `AnnouncementAdminController`: 빌더 패턴으로 반환
  - `AnnouncementAdminService`: announcement 레포에서 똑같은 값을 두번 호출하는 부분 수정
  - `AnnouncementService`: java doc 추가 및 람다식 수정
  - `Announcement 유닛 테스트 `
 ## ✅ 변경로직 <!-- 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
  - mock 사용한 부분들에 대해서 verify 추가
    - 서비스단 테스트들만 일단 마무리하였습니다. 컨트롤러는 추후에 다른 방식으로 수정해야해서 건드리지 않았습니다.
  - naver 컨벤션 적용
 ## 💡Issue 번호 <!-- issue number을 link 시켜주세요 (ex. "- close #4242") -->
 - close #465 