### PR TITLE
🐛 [Fix] GUEST 토너먼트 참가 불가능하도록 수정

### DIFF
--- a/src/main/java/com/gg/server/admin/tournament/dto/TournamentAdminCreateRequestDto.java
+++ b/src/main/java/com/gg/server/admin/tournament/dto/TournamentAdminCreateRequestDto.java
@@ -5,6 +5,7 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
 import org.springframework.format.annotation.DateTimeFormat;
 import javax.validation.constraints.NotNull;
 import java.time.LocalDateTime;
@@ -14,9 +15,11 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 public class TournamentAdminCreateRequestDto {
     @NotNull(message = "제목이 필요합니다.")
+    @Length(max = 30, message = "제목은 30자 이내로 작성해주세요.")
     private String title;
 
     @NotNull(message = "내용이 필요합니다.")
+    @Length(max = 1000, message = "내용은 1000자 이내로 작성해주세요.")
     private String contents;
 
     @NotNull(message = "시작 시간이 필요합니다.")

--- a/src/main/java/com/gg/server/admin/tournament/dto/TournamentAdminUpdateRequestDto.java
+++ b/src/main/java/com/gg/server/admin/tournament/dto/TournamentAdminUpdateRequestDto.java
@@ -9,6 +9,7 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.format.annotation.DateTimeFormat.ISO;
 
@@ -17,9 +18,11 @@ import org.springframework.format.annotation.DateTimeFormat.ISO;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TournamentAdminUpdateRequestDto {
     @NotNull(message = "제목이 필요합니다.")
+    @Length(max = 30, message = "제목은 30자 이내로 작성해주세요.")
     private String title;
 
     @NotNull(message = "내용이 필요합니다.")
+    @Length(max = 1000, message = "내용은 1000자 이내로 작성해주세요.")
     private String contents;
 
     @NotNull(message = "시작 시간이 필요합니다.")

--- a/src/main/java/com/gg/server/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/gg/server/global/security/config/SecurityConfig.java
@@ -53,7 +53,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                         .antMatchers("/pingpong/admin/**").hasRole("ADMIN")
                         .antMatchers(HttpMethod.PUT, "/pingpong/users/{intraId}").hasAnyRole("USER", "ADMIN")
                         .antMatchers(HttpMethod.POST, "/pingpong/match").hasAnyRole("USER", "ADMIN")
-                    .antMatchers("/login", "/oauth2/authorization/**", "/","/pingpong/users/oauth/**",
+                .antMatchers(HttpMethod.POST, "/pingpong/tournaments/{tournamentId}/users").hasAnyRole("USER", "ADMIN")
+                .antMatchers("/login", "/oauth2/authorization/**", "/","/pingpong/users/oauth/**",
                             "/pingpong/users/accesstoken", "/actuator/**",
                             "/swagger-ui/**", "/swagger-ui**", "/v3/api-docs/**", "/v3/api-docs**", "/api-docs").permitAll()
                         .anyRequest().authenticated()

--- a/src/main/resources/db/migration/V3.1__update_tournament_content_column.sql
+++ b/src/main/resources/db/migration/V3.1__update_tournament_content_column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE tournament MODIFY COLUMN contents VARCHAR(3000);


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - `GUEST` 유저는 토너먼트 참가 불가능하도록 수정

 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - spring security config에서 토너먼트 참가 신청 API는 `USER`, `ADMIN`만 허용하도록 설정 추가
  - `tournament` 테이블의 `contents` 컬럼을 `VARCHAR(3000)`으로 수정
  - 토너먼트 생성 API, 토너먼트 수정 API Request DTO에서 `@Length`로 길이 제한
