### PR TITLE
 🐛 [Fix] GUEST 토너먼트 참가 불가능하도록 수정

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,18 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Explicitly declare text files you want to always be normalized and converted
+# to native line endings on checkout.
+*.java text=auto
+*.sql text=auto
+*.md text=auto
+*.txt text=auto
+*.gradle text=auto
+Dockerfile text=auto
+*.yml text=auto
+*.yaml text=auto
+*.sh text=auto
+
+# Denote all files that are truly binary and should not be modified.
+*.png binary
+*.jpg binary

--- a/src/main/java/com/gg/server/admin/game/service/GameAdminService.java
+++ b/src/main/java/com/gg/server/admin/game/service/GameAdminService.java
@@ -138,6 +138,7 @@ public class GameAdminService {
             pChangeAdminRepository.delete(pChanges.get(0));
         }
         rankRedisService.updateRankRedis(teamUsers.get(0), teamUsers.get(1), game);
+        rankRedisService.updateAllTier(gameId);
     }
 
     private void rollbackGameResult(RankGamePPPModifyReqDto reqDto, Season season, TeamUser teamUser, List<PChange> pChanges) {

--- a/src/main/java/com/gg/server/admin/tournament/dto/TournamentAdminCreateRequestDto.java
+++ b/src/main/java/com/gg/server/admin/tournament/dto/TournamentAdminCreateRequestDto.java
@@ -5,6 +5,7 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
 import org.springframework.format.annotation.DateTimeFormat;
 import javax.validation.constraints.NotNull;
 import java.time.LocalDateTime;
@@ -14,9 +15,11 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 public class TournamentAdminCreateRequestDto {
     @NotNull(message = "제목이 필요합니다.")
+    @Length(max = 30, message = "제목은 30자 이내로 작성해주세요.")
     private String title;
 
     @NotNull(message = "내용이 필요합니다.")
+    @Length(max = 1000, message = "내용은 1000자 이내로 작성해주세요.")
     private String contents;
 
     @NotNull(message = "시작 시간이 필요합니다.")

--- a/src/main/java/com/gg/server/admin/tournament/dto/TournamentAdminUpdateRequestDto.java
+++ b/src/main/java/com/gg/server/admin/tournament/dto/TournamentAdminUpdateRequestDto.java
@@ -9,6 +9,7 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.format.annotation.DateTimeFormat.ISO;
 
@@ -17,9 +18,11 @@ import org.springframework.format.annotation.DateTimeFormat.ISO;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TournamentAdminUpdateRequestDto {
     @NotNull(message = "제목이 필요합니다.")
+    @Length(max = 30, message = "제목은 30자 이내로 작성해주세요.")
     private String title;
 
     @NotNull(message = "내용이 필요합니다.")
+    @Length(max = 1000, message = "내용은 1000자 이내로 작성해주세요.")
     private String contents;
 
     @NotNull(message = "시작 시간이 필요합니다.")

--- a/src/main/java/com/gg/server/admin/tournament/service/TournamentAdminService.java
+++ b/src/main/java/com/gg/server/admin/tournament/service/TournamentAdminService.java
@@ -27,6 +27,7 @@ import com.gg.server.domain.user.exception.UserNotFoundException;
 import com.gg.server.global.config.ConstantConfig;
 import com.gg.server.global.exception.ErrorCode;
 import com.gg.server.global.exception.custom.InvalidParameterException;
+import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -213,7 +214,7 @@ public class TournamentAdminService {
         int interval = slotManagement.getGameInterval();
 
         if (startTime.isAfter(endTime) || startTime.isEqual(endTime) ||
-            startTime.getDayOfMonth() - LocalDateTime.now().getDayOfMonth() < constantConfig.getAllowedMinimalStartDays()||
+            LocalDate.now().plusDays(constantConfig.getAllowedMinimalStartDays()).isAfter(startTime.toLocalDate()) ||
             startTime.plusHours(Tournament.MINIMUM_TOURNAMENT_DURATION).isAfter(endTime) ||
             startTime.getMinute() % interval != 0 || endTime.getMinute() % interval != 0) {
             throw new TournamentUpdateException(ErrorCode.TOURNAMENT_INVALID_TIME);

--- a/src/main/java/com/gg/server/domain/rank/redis/RankRedisService.java
+++ b/src/main/java/com/gg/server/domain/rank/redis/RankRedisService.java
@@ -66,12 +66,17 @@ public class RankRedisService {
         Rank rank = rankRepository.findByUserIdAndSeasonId(myTeam.getUserId(), seasonId)
                 .orElseThrow(() -> new NotExistException("rank 정보가 없습니다.", ErrorCode.NOT_FOUND));
         Integer changedPpp = EloRating.pppChange(myPPP, enemyPPP,
-                teamuser.getTeam().getWin(), Math.abs(teamuser.getTeam().getScore() - enemyScore) == 2);
+                teamuser.getTeam().getWin(),
+                Math.abs(teamuser.getTeam().getScore() - enemyScore) == 2);
+        log.info("update before: intraId: " + teamuser.getUser().getIntraId() + ", win: db(" + rank.getWins()
+                + "), redis(" + myTeam.getWins() + "), losses: db(" + rank.getLosses()
+                + "), redis(" + myTeam.getLosses() + ")");
         rank.modifyUserRank(rank.getPpp() + changedPpp, win, losses);
-
         myTeam.updateRank(changedPpp,
                 win, losses);
-
+        log.info("update after: intraId: " + teamuser.getUser().getIntraId() + ", win: db(" + rank.getWins()
+                + "), redis(" + myTeam.getWins() + "), losses: db(" + rank.getLosses()
+                + "), redis(" + myTeam.getLosses() + ")");
     }
 
     @Transactional
@@ -130,11 +135,15 @@ public class RankRedisService {
         int losses = !teamUser.getTeam().getWin() ? myTeam.getLosses() - 1: myTeam.getLosses();
         Rank rank = rankRepository.findByUserIdAndSeasonId(myTeam.getUserId(), seasonId)
                 .orElseThrow(RankNotFoundException::new);
-        log.info("Before: userId: " + teamUser.getUser().getIntraId() + ", " + "ppp: rank(" + rank.getPpp() + "), redis(" + myTeam.getPpp() + ")");
+        log.info("Before: userId: " + teamUser.getUser().getIntraId() + ", " + "ppp: rank("
+                + rank.getPpp() + "), redis(" + myTeam.getPpp() + "), win: " + myTeam.getWins()
+                + ", losses: " + myTeam.getLosses());
         rank.modifyUserRank(ppp, win, losses);
         myTeam.changedRank(ppp, win, losses);
         rankRepository.flush();
         updateRankUser(hashkey, RedisKeyManager.getZSetKey(seasonId), teamUser.getUser().getId(), myTeam);
-        log.info("After: userId: " + teamUser.getUser().getIntraId() + ", " + "ppp: rank(" + rank.getPpp() + "), redis(" + myTeam.getPpp() + ")");
+        log.info("After: userId: " + teamUser.getUser().getIntraId() + ", " + "ppp: rank("
+                + rank.getPpp() + "), redis(" + myTeam.getPpp() + "), win: " + myTeam.getWins()
+                + ", losses: " + myTeam.getLosses());
     }
 }

--- a/src/main/java/com/gg/server/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/gg/server/global/security/config/SecurityConfig.java
@@ -53,7 +53,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                         .antMatchers("/pingpong/admin/**").hasRole("ADMIN")
                         .antMatchers(HttpMethod.PUT, "/pingpong/users/{intraId}").hasAnyRole("USER", "ADMIN")
                         .antMatchers(HttpMethod.POST, "/pingpong/match").hasAnyRole("USER", "ADMIN")
-                    .antMatchers("/login", "/oauth2/authorization/**", "/","/pingpong/users/oauth/**",
+                .antMatchers(HttpMethod.POST, "/pingpong/tournaments/{tournamentId}/users").hasAnyRole("USER", "ADMIN")
+                .antMatchers("/login", "/oauth2/authorization/**", "/","/pingpong/users/oauth/**",
                             "/pingpong/users/accesstoken", "/actuator/**",
                             "/swagger-ui/**", "/swagger-ui**", "/v3/api-docs/**", "/v3/api-docs**", "/api-docs").permitAll()
                         .anyRequest().authenticated()

--- a/src/main/resources/db/migration/V3.1__update_tournament_content_column.sql
+++ b/src/main/resources/db/migration/V3.1__update_tournament_content_column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE tournament MODIFY COLUMN contents VARCHAR(3000);

--- a/src/test/java/com/gg/server/admin/game/controller/GameAdminControllerTest.java
+++ b/src/test/java/com/gg/server/admin/game/controller/GameAdminControllerTest.java
@@ -183,10 +183,16 @@ class GameAdminControllerTest {
         gameService.createRankResult(rankResultReqDto, adminUserId);
 
         Rank adminUserRank = rankRepository.findByUserIdAndSeasonId(adminUserId, season.getId()).get();
-        Rank enemyUser1Rank = rankRepository.findByUserIdAndSeasonId(enemyUser1.getId(), season.getId()).get();
-        System.out.println("MANGO ADMIN1 before DB PPP : " + adminUserRank.getPpp());
-        System.out.println("MANGO ENEMY1 before DB PPP : " + enemyUser1Rank.getPpp());
-
+        Rank enemyUser1Rank = rankRepository.findByUserIdAndSeasonId(enemyUser1.getId(),
+                season.getId()).get();
+        // win 1, losses 0, ppp 1020
+//        System.out.println("MANGO ADMIN1 before DB PPP : " + adminUserRank.getPpp());
+        assertThat(adminUserRank.getLosses()).isEqualTo(0);
+        assertThat(adminUserRank.getWins()).isEqualTo(1);
+        // win 0, losses 1, ppp 982
+//        System.out.println("MANGO ENEMY1 before DB PPP : " + enemyUser1Rank.getPpp());
+        assertThat(enemyUser1Rank.getWins()).isEqualTo(0);
+        assertThat(enemyUser1Rank.getLosses()).isEqualTo(1);
 
         RankGamePPPModifyReqDto modifyReqDto = new RankGamePPPModifyReqDto(game1Info.getMyTeamId(), 1, game1Info.getEnemyTeamId(), 0);
         mockMvc.perform(put("/pingpong/admin/games/" + game1Info.getGameId())
@@ -198,10 +204,18 @@ class GameAdminControllerTest {
         GameTeamUser historyGame1 = gameRepository.findTeamsByGameIsIn(List.of(game1Info.getGameId())).get(0);
 
         adminUserRank = rankRepository.findByUserIdAndSeasonId(adminUserId, season.getId()).get();
-        enemyUser1Rank = rankRepository.findByUserIdAndSeasonId(enemyUser1.getId(), season.getId()).get();
-        System.out.println("MANGO ADMIN1 after DB PPP : " + adminUserRank.getPpp());
-        System.out.println("MANGO ENEMY1 after DB PPP : " + enemyUser1Rank.getPpp());
-
+        enemyUser1Rank = rankRepository.findByUserIdAndSeasonId(enemyUser1.getId(), season.getId())
+                .get();
+        // win 1, losses 0, ppp 1020
+        // MANGO ADMIN1 after DB
+        assertThat(adminUserRank.getPpp()).isEqualTo(1020);
+        assertThat(adminUserRank.getWins()).isEqualTo(1);
+        assertThat(adminUserRank.getLosses()).isEqualTo(0);
+        // win 0, losses 1, ppp 982
+        // MANGO ENEMY1 after DB
+        assertThat(enemyUser1Rank.getWins()).isEqualTo(0);
+        assertThat(enemyUser1Rank.getLosses()).isEqualTo(1);
+        assertThat(enemyUser1Rank.getPpp()).isEqualTo(982);
         //////////////////////////////
         sleep(1000);
         //////////////////////////////
@@ -216,12 +230,20 @@ class GameAdminControllerTest {
         gameService.createRankResult(rankResultReqDto, adminUserId);
 
         adminUserRank = rankRepository.findByUserIdAndSeasonId(adminUserId, season.getId()).get();
-        Rank enemyUser2Rank = rankRepository.findByUserIdAndSeasonId(enemyUser2.getId(), season.getId()).get();
-        System.out.println("MANGO ADMIN2 before DB PPP : " + adminUserRank.getPpp());
-        System.out.println("MANGO ENEMY2 before DB PPP : " + enemyUser2Rank.getPpp());
+        Rank enemyUser2Rank = rankRepository.findByUserIdAndSeasonId(enemyUser2.getId(),
+                season.getId()).get();
+        // win 1, losses 1, ppp 1001
+        // MANGO ADMIN2 before DB
+        assertThat(adminUserRank.getWins()).isEqualTo(1);
+        assertThat(adminUserRank.getLosses()).isEqualTo(1);
+        assertThat(adminUserRank.getPpp()).isEqualTo(1001);
+        // win1, losses 0, ppp 1021
+        // MANGO ENEMY2 before DB
+        assertThat(enemyUser2Rank.getWins()).isEqualTo(1);
+        assertThat(enemyUser2Rank.getLosses()).isEqualTo(0);
+        assertThat(enemyUser2Rank.getPpp()).isEqualTo(1021);
 
-
-        modifyReqDto = new RankGamePPPModifyReqDto(game2Info.getMyTeamId(), 0, game2Info.getEnemyTeamId(), 1);
+        modifyReqDto = new RankGamePPPModifyReqDto(game2Info.getMyTeamId(), 2, game2Info.getEnemyTeamId(), 1);
         mockMvc.perform(put("/pingpong/admin/games/" + game2Info.getGameId())
                         .content(objectMapper.writeValueAsString(modifyReqDto))
                         .contentType(MediaType.APPLICATION_JSON)
@@ -231,7 +253,17 @@ class GameAdminControllerTest {
 
         adminUserRank = rankRepository.findByUserIdAndSeasonId(adminUserId, season.getId()).get();
         enemyUser2Rank = rankRepository.findByUserIdAndSeasonId(enemyUser2.getId(), season.getId()).get();
-        System.out.println("MANGO ADMIN2 after DB PPP : " + adminUserRank.getPpp());
-        System.out.println("MANGO ENEMY2 after DB PPP : " + enemyUser2Rank.getPpp());
+        // win 2, losses 0, ppp 1038
+//        System.out.println("MANGO ADMIN2 after DB PPP : " + adminUserRank.getPpp() + ", WIN: "
+//                + adminUserRank.getWins() + ", LOSSES" + adminUserRank.getLosses());
+        assertThat(adminUserRank.getWins()).isEqualTo(2);
+        assertThat(adminUserRank.getLosses()).isEqualTo(0);
+        assertThat(adminUserRank.getPpp()).isEqualTo(1038);
+        // win 0, losses 1, ppp
+        System.out.println("MANGO ENEMY2 after DB PPP : " + enemyUser2Rank.getPpp() + ", WIN: "
+                + enemyUser2Rank.getWins() + ", LOSSES" + enemyUser2Rank.getLosses());
+        assertThat(enemyUser2Rank.getWins()).isEqualTo(0);
+        assertThat(enemyUser2Rank.getLosses()).isEqualTo(1);
+//        assertThat(enemyUser2Rank.getPpp()).isEqualTo()
     }
 }

--- a/src/test/java/com/gg/server/admin/tournament/service/TournamentAdminServiceTest.java
+++ b/src/test/java/com/gg/server/admin/tournament/service/TournamentAdminServiceTest.java
@@ -67,8 +67,6 @@ class TournamentAdminServiceTest {
     @InjectMocks
     TournamentAdminService tournamentAdminService;
 
-    ReflectionUtilsForUnitTest reflectionUtilsForUnitTest = new ReflectionUtilsForUnitTest();
-
     // 토너먼트 생성 서비스 테스트
     @Nested
     @DisplayName("토너먼트 관리자 생성 서비스 테스트")
@@ -362,7 +360,7 @@ class TournamentAdminServiceTest {
             User user = createUser("testUser");
             given(tournamentRepository.findById(1L)).willReturn(Optional.of(tournament));
             given(userRepository.findByIntraId("testUser")).willReturn(Optional.of(user));
-
+            given(tournamentUserRepository.save(any(TournamentUser.class))).willReturn(null);
             // when, then
             tournamentAdminService.addTournamentUser(1L, requestDto);
         }
@@ -503,7 +501,7 @@ class TournamentAdminServiceTest {
             .type(TournamentType.ROOKIE)
             .status(status)
             .build();
-        reflectionUtilsForUnitTest.setFieldWithReflection(tournament, "id", id);
+        ReflectionUtilsForUnitTest.setFieldWithReflection(tournament, "id", id);
         return tournament;
     }
 

--- a/src/test/java/com/gg/server/domain/tournament/data/TournamentUnitTest.java
+++ b/src/test/java/com/gg/server/domain/tournament/data/TournamentUnitTest.java
@@ -2,7 +2,6 @@ package com.gg.server.domain.tournament.data;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 
 import com.gg.server.domain.tournament.type.TournamentStatus;
@@ -10,6 +9,7 @@ import com.gg.server.domain.user.data.User;
 import com.gg.server.global.exception.ErrorCode;
 import com.gg.server.global.exception.custom.BusinessException;
 import com.gg.server.utils.annotation.UnitTest;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -18,7 +18,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 
 @UnitTest
@@ -315,6 +314,40 @@ class TournamentUnitTest {
 
       //then
       assertEquals(status, tournament.getStatus());
+    }
+  }
+
+  @Nested
+  @DisplayName("UpdateStatus")
+  class UpdateEndTime {
+    @Test
+    @DisplayName("null 포인터 전달 시 실패")
+    void nullAddFailed() {
+      //given
+      Tournament tournament = tournaments.get(0);
+
+      //when
+      LocalDateTime endTime = null;
+
+      //then
+      BusinessException businessException = assertThrows(BusinessException.class,
+          () -> tournament.updateEndTime(endTime));
+      assertEquals(ErrorCode.NULL_POINT, businessException.getErrorCode());
+      assertEquals(ErrorCode.NULL_POINT.getMessage(), businessException.getMessage());
+    }
+
+    @Test
+    @DisplayName("endTime 업데이트 성공")
+    void updateEndTimeSuccess() {
+      //given
+      Tournament tournament = tournaments.get(0);
+      LocalDateTime endTime = LocalDateTime.now().withMinute(0).withNano(0);
+
+      //when
+      tournament.updateEndTime(endTime);
+
+      //then
+      assertEquals(endTime, tournament.getEndTime());
     }
   }
 }

--- a/src/test/java/com/gg/server/domain/tournament/service/TournamentServiceTest.java
+++ b/src/test/java/com/gg/server/domain/tournament/service/TournamentServiceTest.java
@@ -53,7 +53,6 @@ class TournamentServiceTest {
     UserRepository userRepository;
     @InjectMocks
     TournamentService tournamentService;
-    ReflectionUtilsForUnitTest reflectionUtilsForUnitTest = new ReflectionUtilsForUnitTest();
 
     @Nested
     @DisplayName("토너먼트_유저_상태_테스트")
@@ -160,15 +159,14 @@ class TournamentServiceTest {
     class cancelTournamentUserRegistration {
         @Test
         @DisplayName("유저_참가_취소_성공")
-        @Disabled
         void success() {
             // given
             Tournament tournament = createTournament(1L, TournamentStatus.BEFORE,
                 LocalDateTime.now(), LocalDateTime.now().plusHours(2));
             User user = createUser("testUser");
+            ReflectionUtilsForUnitTest.setFieldWithReflection(user, "id", 1L);
             TournamentUser tournamentUser = new TournamentUser(user, tournament, true, LocalDateTime.now());
             given(tournamentRepository.findById(tournament.getId())).willReturn(Optional.of(tournament));
-            given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
 
             // when, then
             tournamentService.cancelTournamentUserRegistration(tournament.getId(), UserDto.from(user));
@@ -234,7 +232,7 @@ class TournamentServiceTest {
           .type(TournamentType.ROOKIE)
           .status(status)
           .build();
-      reflectionUtilsForUnitTest.setFieldWithReflection(tournament, "id", id);
+      ReflectionUtilsForUnitTest.setFieldWithReflection(tournament, "id", id);
       return tournament;
     }
 

--- a/src/test/java/com/gg/server/utils/ReflectionUtilsForUnitTest.java
+++ b/src/test/java/com/gg/server/utils/ReflectionUtilsForUnitTest.java
@@ -17,7 +17,7 @@ public class ReflectionUtilsForUnitTest {
   /**
    * 리플렉션을 사용해서 필드값을 설정한다.
    */
-  public void setFieldWithReflection(Object object, String fieldName, Object value) {
+  static public void setFieldWithReflection(Object object, String fieldName, Object value) {
     try {
       Field field = object.getClass().getDeclaredField(fieldName);
       field.setAccessible(true);


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - `GUEST` 유저는 토너먼트 참가 불가능하도록 수정

 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - spring security config에서 토너먼트 참가 신청 API는 `USER`, `ADMIN`만 허용하도록 설정 추가
  - `tournament` 테이블의 `contents` 컬럼을 `VARCHAR(3000)`으로 수정
  - 토너먼트 생성 API, 토너먼트 수정 API Request DTO에서 `@Length`로 길이 제한
