### PR TITLE
:bug: [Fix] tournament contents에 대한 길이 valid 수정

### DIFF
--- a/src/main/java/com/gg/server/admin/tournament/dto/TournamentAdminCreateRequestDto.java
+++ b/src/main/java/com/gg/server/admin/tournament/dto/TournamentAdminCreateRequestDto.java
@@ -19,7 +19,7 @@ public class TournamentAdminCreateRequestDto {
     private String title;
 
     @NotNull(message = "내용이 필요합니다.")
-    @Length(max = 1000, message = "내용은 1000자 이내로 작성해주세요.")
+    @Length(max = 3000, message = "내용은 3000자 이내로 작성해주세요.")
     private String contents;
 
     @NotNull(message = "시작 시간이 필요합니다.")

--- a/src/main/java/com/gg/server/admin/tournament/dto/TournamentAdminUpdateRequestDto.java
+++ b/src/main/java/com/gg/server/admin/tournament/dto/TournamentAdminUpdateRequestDto.java
@@ -22,7 +22,7 @@ public class TournamentAdminUpdateRequestDto {
     private String title;
 
     @NotNull(message = "내용이 필요합니다.")
-    @Length(max = 1000, message = "내용은 1000자 이내로 작성해주세요.")
+    @Length(max = 3000, message = "내용은 3000자 이내로 작성해주세요.")
     private String contents;
 
     @NotNull(message = "시작 시간이 필요합니다.")

--- a/src/main/java/com/gg/server/domain/tournament/data/Tournament.java
+++ b/src/main/java/com/gg/server/domain/tournament/data/Tournament.java
@@ -56,7 +56,7 @@ public class Tournament extends BaseTimeEntity {
     private String title;
 
     @NotNull
-    @Column(name = "contents", length = 1000)
+    @Column(name = "contents", length = 3000)
     private String contents;
 
     @NotNull


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - Dto에서 valid check에서 잘못된 길이 제한 수정

 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - 토너먼트 생성/수정 API에 사용되는 DTO의 contents 길이 제한 1000 -> 3000으로 수정