### PR TITLE
🧪 [Unit Test] NotiAdminService 단위 테스트

### DIFF
--- a/src/main/java/com/gg/server/admin/noti/service/NotiAdminService.java
+++ b/src/main/java/com/gg/server/admin/noti/service/NotiAdminService.java
@@ -26,6 +26,11 @@ public class NotiAdminService {
 	private final UserAdminRepository userAdminRepository;
 	private final SnsNotiService snsNotiService;
 
+	/**
+	 * 유저에게 알림을 전송합니다.
+	 * @param sendNotiAdminRequestDto 알림 요청 Dto
+	 * @exception UserNotFoundException 유저가 존재하지 않을 경우
+	 */
 	@Transactional
 	public void sendAnnounceNotiToUser(SendNotiAdminRequestDto sendNotiAdminRequestDto) {
 		String message = sendNotiAdminRequestDto.getMessage();
@@ -37,6 +42,11 @@ public class NotiAdminService {
 		snsNotiService.sendSnsNotification(noti, UserDto.from(user));
 	}
 
+	/**
+	 * 전체 알림 목록을 조회합니다.
+	 * @param pageable 알림 목록 페이지
+	 * @return 알림 목록 응답 Dto
+	 */
 	@Transactional(readOnly = true)
 	public NotiListAdminResponseDto getAllNoti(Pageable pageable) {
 		Page<Noti> allNotiPage = notiAdminRepository.findAll(pageable);
@@ -44,6 +54,12 @@ public class NotiAdminService {
 		return new NotiListAdminResponseDto(notiAdminDtoPage.getContent(), notiAdminDtoPage.getTotalPages());
 	}
 
+	/**
+	 * 특정 유저의 알림 목록을 조회합니다.
+	 * @param pageable 유저의 알림 목록 페이지
+	 * @param intraId 인트라 Id
+	 * @return 알림 목록 응답 Dto
+	 */
 	@Transactional(readOnly = true)
 	public NotiListAdminResponseDto getFilteredNotifications(Pageable pageable, String intraId) {
 		Page<Noti> findNotis = notiAdminRepository.findNotisByUserIntraId(pageable, intraId);

--- a/src/test/java/com/gg/server/admin/noti/service/NotiAdminServiceUnitTest.java
+++ b/src/test/java/com/gg/server/admin/noti/service/NotiAdminServiceUnitTest.java
@@ -49,6 +49,7 @@ class NotiAdminServiceUnitTest {
         @DisplayName("성공")
         void success() {
             //given
+            //TODO sendNotiAdminRequestDto 내 메서드 검증 로직 추가
             given(userAdminRepository.findByIntraId(any(String.class))).willReturn(Optional.of(mock(User.class)));
             given(notiAdminRepository.save(any(Noti.class))).willReturn(new Noti());
             willDoNothing().given(snsNotiService).sendSnsNotification(any(Noti.class), any(UserDto.class));
@@ -79,6 +80,7 @@ class NotiAdminServiceUnitTest {
         void success() {
             //given
             given(notiAdminRepository.findAll(any(Pageable.class))).willReturn(new PageImpl<>(Collections.emptyList()));
+            //TODO Page 내 map 메서드 검증 로직 추가
 
             //when
             notiAdminService.getAllNoti(mock(org.springframework.data.domain.Pageable.class));
@@ -97,6 +99,7 @@ class NotiAdminServiceUnitTest {
             //given
             given(notiAdminRepository.findNotisByUserIntraId(any(org.springframework.data.domain.Pageable.class), any(String.class)))
                     .willReturn(new PageImpl<>(Collections.emptyList()));
+            //TODO Page 내 map 메서드 검증 로직 추가
 
             //when
             notiAdminService.getFilteredNotifications(PageRequest.of(1, 1), "TestUser");

--- a/src/test/java/com/gg/server/admin/noti/service/NotiAdminServiceUnitTest.java
+++ b/src/test/java/com/gg/server/admin/noti/service/NotiAdminServiceUnitTest.java
@@ -1,0 +1,108 @@
+package com.gg.server.admin.noti.service;
+
+import com.gg.server.admin.noti.data.NotiAdminRepository;
+import com.gg.server.admin.noti.dto.SendNotiAdminRequestDto;
+import com.gg.server.admin.user.data.UserAdminRepository;
+import com.gg.server.domain.noti.data.Noti;
+import com.gg.server.domain.noti.service.SnsNotiService;
+import com.gg.server.domain.user.data.User;
+import com.gg.server.domain.user.dto.UserDto;
+import com.gg.server.domain.user.exception.UserNotFoundException;
+import com.gg.server.utils.annotation.UnitTest;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Mockito.*;
+
+@UnitTest
+@ExtendWith(MockitoExtension.class)
+@DisplayName("NotiAdminServiceUnitTest")
+class NotiAdminServiceUnitTest {
+    @Mock
+    UserAdminRepository userAdminRepository;
+    @Mock
+    NotiAdminRepository notiAdminRepository;
+    @Mock
+    SnsNotiService snsNotiService;
+    @Mock
+    SendNotiAdminRequestDto sendNotiAdminRequestDto;
+    @InjectMocks
+    NotiAdminService notiAdminService;
+
+    @Nested
+    @DisplayName("sendAnnounceNotiToUser_메서드_unitTest")
+    class SendAnnounceNotiToUserTest {
+        @Test
+        @DisplayName("성공")
+        void success() {
+            //given
+            given(userAdminRepository.findByIntraId(any(String.class))).willReturn(Optional.of(mock(User.class)));
+            given(notiAdminRepository.save(any(Noti.class))).willReturn(new Noti());
+            willDoNothing().given(snsNotiService).sendSnsNotification(any(Noti.class), any(UserDto.class));
+
+            //when
+            notiAdminService.sendAnnounceNotiToUser(new SendNotiAdminRequestDto("TestUser", "Message"));
+
+            //then
+            verify(userAdminRepository, times(1)).findByIntraId(any(String.class));
+            verify(notiAdminRepository, times(1)).save(any(Noti.class));
+            verify(snsNotiService, times(1)).sendSnsNotification(any(Noti.class), any(UserDto.class));
+        }
+
+        @Test
+        @DisplayName("user_not_found")
+        void UserNotFound() {
+            //when, then
+            assertThatThrownBy(() -> notiAdminService.sendAnnounceNotiToUser(mock(SendNotiAdminRequestDto.class)))
+                    .isInstanceOf(UserNotFoundException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("getAllNoti_메서드_unitTest")
+    class GetAllNotiTest {
+        @Test
+        @DisplayName("성공")
+        void success() {
+            //given
+            given(notiAdminRepository.findAll(any(Pageable.class))).willReturn(new PageImpl<>(Collections.emptyList()));
+
+            //when
+            notiAdminService.getAllNoti(mock(org.springframework.data.domain.Pageable.class));
+
+            //then
+            verify(notiAdminRepository, times(1)).findAll(any(Pageable.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("getFilteredNotifications_메서드_unitTest")
+    class GetFilteredNotificationsTest {
+        @Test
+        @DisplayName("성공")
+        void success() {
+            //given
+            given(notiAdminRepository.findNotisByUserIntraId(any(org.springframework.data.domain.Pageable.class), any(String.class)))
+                    .willReturn(new PageImpl<>(Collections.emptyList()));
+
+            //when
+            notiAdminService.getFilteredNotifications(PageRequest.of(1, 1), "TestUser");
+
+            //then
+            verify(notiAdminRepository, times(1)).findNotisByUserIntraId(any(org.springframework.data.domain.Pageable.class), any(String.class));
+        }
+    }
+}

--- a/src/test/java/com/gg/server/admin/noti/service/NotiAdminServiceUnitTest.java
+++ b/src/test/java/com/gg/server/admin/noti/service/NotiAdminServiceUnitTest.java
@@ -66,9 +66,15 @@ class NotiAdminServiceUnitTest {
 		@Test
 		@DisplayName("user_not_found")
 		void userNotFound() {
+			//given
+			SendNotiAdminRequestDto requestDto = new SendNotiAdminRequestDto("testIntraId", "TestMessage");
+			when(userAdminRepository.findByIntraId(any(String.class))).thenThrow(new UserNotFoundException());
+
 			//when, then
-			assertThatThrownBy(() -> notiAdminService.sendAnnounceNotiToUser(mock(SendNotiAdminRequestDto.class)))
+			assertThatThrownBy(() -> notiAdminService.sendAnnounceNotiToUser(requestDto))
 				.isInstanceOf(UserNotFoundException.class);
+			verify(notiAdminRepository, never()).save(any(Noti.class));
+			verify(snsNotiService, never()).sendSnsNotification(any(Noti.class), any(UserDto.class));
 		}
 	}
 

--- a/src/test/java/com/gg/server/admin/noti/service/NotiAdminServiceUnitTest.java
+++ b/src/test/java/com/gg/server/admin/noti/service/NotiAdminServiceUnitTest.java
@@ -1,5 +1,23 @@
 package com.gg.server.admin.noti.service;
 
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.Collections;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
 import com.gg.server.admin.noti.data.NotiAdminRepository;
 import com.gg.server.admin.noti.dto.SendNotiAdminRequestDto;
 import com.gg.server.admin.user.data.UserAdminRepository;
@@ -9,103 +27,85 @@ import com.gg.server.domain.user.data.User;
 import com.gg.server.domain.user.dto.UserDto;
 import com.gg.server.domain.user.exception.UserNotFoundException;
 import com.gg.server.utils.annotation.UnitTest;
-import org.junit.jupiter.api.*;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-
-import java.util.Collections;
-import java.util.Optional;
-
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.willDoNothing;
-import static org.mockito.Mockito.*;
 
 @UnitTest
 @ExtendWith(MockitoExtension.class)
 @DisplayName("NotiAdminServiceUnitTest")
 class NotiAdminServiceUnitTest {
-    @Mock
-    UserAdminRepository userAdminRepository;
-    @Mock
-    NotiAdminRepository notiAdminRepository;
-    @Mock
-    SnsNotiService snsNotiService;
-    @Mock
-    SendNotiAdminRequestDto sendNotiAdminRequestDto;
-    @InjectMocks
-    NotiAdminService notiAdminService;
+	@Mock
+	UserAdminRepository userAdminRepository;
+	@Mock
+	NotiAdminRepository notiAdminRepository;
+	@Mock
+	SnsNotiService snsNotiService;
+	@Mock
+	SendNotiAdminRequestDto sendNotiAdminRequestDto;
+	@InjectMocks
+	NotiAdminService notiAdminService;
 
-    @Nested
-    @DisplayName("sendAnnounceNotiToUser_메서드_unitTest")
-    class SendAnnounceNotiToUserTest {
-        @Test
-        @DisplayName("성공")
-        void success() {
-            //given
-            //TODO sendNotiAdminRequestDto 내 메서드 검증 로직 추가
-            given(userAdminRepository.findByIntraId(any(String.class))).willReturn(Optional.of(mock(User.class)));
-            given(notiAdminRepository.save(any(Noti.class))).willReturn(new Noti());
-            willDoNothing().given(snsNotiService).sendSnsNotification(any(Noti.class), any(UserDto.class));
+	@Nested
+	@DisplayName("sendAnnounceNotiToUser_메서드_unitTest")
+	class SendAnnounceNotiToUserTest {
+		@Test
+		@DisplayName("성공")
+		void success() {
+			//given
+			given(userAdminRepository.findByIntraId(any(String.class))).willReturn(Optional.of(mock(User.class)));
+			given(notiAdminRepository.save(any(Noti.class))).willReturn(new Noti());
+			willDoNothing().given(snsNotiService).sendSnsNotification(any(Noti.class), any(UserDto.class));
 
-            //when
-            notiAdminService.sendAnnounceNotiToUser(new SendNotiAdminRequestDto("TestUser", "Message"));
+			//when
+			notiAdminService.sendAnnounceNotiToUser(new SendNotiAdminRequestDto("TestUser", "Message"));
 
-            //then
-            verify(userAdminRepository, times(1)).findByIntraId(any(String.class));
-            verify(notiAdminRepository, times(1)).save(any(Noti.class));
-            verify(snsNotiService, times(1)).sendSnsNotification(any(Noti.class), any(UserDto.class));
-        }
+			//then
+			verify(userAdminRepository, times(1)).findByIntraId(any(String.class));
+			verify(notiAdminRepository, times(1)).save(any(Noti.class));
+			verify(snsNotiService, times(1)).sendSnsNotification(any(Noti.class), any(UserDto.class));
+		}
 
-        @Test
-        @DisplayName("user_not_found")
-        void UserNotFound() {
-            //when, then
-            assertThatThrownBy(() -> notiAdminService.sendAnnounceNotiToUser(mock(SendNotiAdminRequestDto.class)))
-                    .isInstanceOf(UserNotFoundException.class);
-        }
-    }
+		@Test
+		@DisplayName("user_not_found")
+		void userNotFound() {
+			//when, then
+			assertThatThrownBy(() -> notiAdminService.sendAnnounceNotiToUser(mock(SendNotiAdminRequestDto.class)))
+				.isInstanceOf(UserNotFoundException.class);
+		}
+	}
 
-    @Nested
-    @DisplayName("getAllNoti_메서드_unitTest")
-    class GetAllNotiTest {
-        @Test
-        @DisplayName("성공")
-        void success() {
-            //given
-            given(notiAdminRepository.findAll(any(Pageable.class))).willReturn(new PageImpl<>(Collections.emptyList()));
-            //TODO Page 내 map 메서드 검증 로직 추가
+	@Nested
+	@DisplayName("getAllNoti_메서드_unitTest")
+	class GetAllNotiTest {
+		@Test
+		@DisplayName("성공")
+		void success() {
+			//given
+			given(notiAdminRepository.findAll(any(Pageable.class))).willReturn(new PageImpl<>(Collections.emptyList()));
 
-            //when
-            notiAdminService.getAllNoti(mock(org.springframework.data.domain.Pageable.class));
+			//when
+			notiAdminService.getAllNoti(mock(org.springframework.data.domain.Pageable.class));
 
-            //then
-            verify(notiAdminRepository, times(1)).findAll(any(Pageable.class));
-        }
-    }
+			//then
+			verify(notiAdminRepository, times(1)).findAll(any(Pageable.class));
+		}
+	}
 
-    @Nested
-    @DisplayName("getFilteredNotifications_메서드_unitTest")
-    class GetFilteredNotificationsTest {
-        @Test
-        @DisplayName("성공")
-        void success() {
-            //given
-            given(notiAdminRepository.findNotisByUserIntraId(any(org.springframework.data.domain.Pageable.class), any(String.class)))
-                    .willReturn(new PageImpl<>(Collections.emptyList()));
-            //TODO Page 내 map 메서드 검증 로직 추가
+	@Nested
+	@DisplayName("getFilteredNotifications_메서드_unitTest")
+	class GetFilteredNotificationsTest {
+		@Test
+		@DisplayName("성공")
+		void success() {
+			//given
+			given(notiAdminRepository.findNotisByUserIntraId(any(org.springframework.data.domain.Pageable.class),
+				any(String.class)))
+				.willReturn(new PageImpl<>(Collections.emptyList()));
 
-            //when
-            notiAdminService.getFilteredNotifications(PageRequest.of(1, 1), "TestUser");
+			//when
+			notiAdminService.getFilteredNotifications(PageRequest.of(1, 1), "TestUser");
 
-            //then
-            verify(notiAdminRepository, times(1)).findNotisByUserIntraId(any(org.springframework.data.domain.Pageable.class), any(String.class));
-        }
-    }
+			//then
+			verify(notiAdminRepository, times(1)).findNotisByUserIntraId(
+				any(org.springframework.data.domain.Pageable.class), any(String.class));
+		}
+	}
 }


### PR DESCRIPTION
## 📌 개요
  - `NotiAdminService` 단위 테스트 코드입니다.

 ## 💻 작업사항
  - `sendAnnounceNotiToUser`, `getAllNoti`, `getFilteredNotifications` 세 개의 메서드에 대한 단위 테스트 코드를 작성하였습니다.
    - `dto`와 `page` 내에 존재하는 메서드 검증에 대해서는 `todo`로 적어두었는데, 이는 Noti의 다른 단위 테스트를 추가할 때 수정하도록 하겠습니다.

 ## ✅ 변경로직
  - `SendAnnounceNotiToUserTest` 메서드 내 `UserNotFoundException`의 전제 조건 코드를 추가하였습니다.
 ## 💡Issue 번호
 - #469 