### PR TITLE
✨ [Feature] slack 초대 API

### DIFF
--- a/gg-pingpong-api/src/main/java/gg/party/api/admin/room/controller/RoomAdminController.java
+++ b/gg-pingpong-api/src/main/java/gg/party/api/admin/room/controller/RoomAdminController.java
@@ -12,8 +12,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import gg.auth.UserDto;
-import gg.auth.argumentresolver.Login;
 import gg.data.party.type.RoomType;
 import gg.party.api.admin.room.controller.request.PageReqDto;
 import gg.party.api.admin.room.controller.request.RoomShowChangeReqDto;
@@ -22,7 +20,6 @@ import gg.party.api.admin.room.controller.response.AdminRoomListResDto;
 import gg.party.api.admin.room.service.RoomAdminService;
 import gg.utils.exception.party.RoomNotFoundException;
 import gg.utils.exception.party.RoomStatNotFoundException;
-import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -68,9 +65,8 @@ public class RoomAdminController {
 	 * @return 방 상세정보 (들어와 있지 않은 사람의 intraId 포함)
 	 */
 	@GetMapping("/{room_id}")
-	public ResponseEntity<AdminRoomDetailResDto> adminRoomDetailInfo(@Parameter(hidden = true) @Login UserDto user,
-		@PathVariable("room_id") Long roomId) {
-		AdminRoomDetailResDto adminRoomDetailResDto = roomAdminService.findAdminDetailRoom(user.getId(), roomId);
+	public ResponseEntity<AdminRoomDetailResDto> adminRoomDetailInfo(@PathVariable("room_id") Long roomId) {
+		AdminRoomDetailResDto adminRoomDetailResDto = roomAdminService.findAdminDetailRoom(roomId);
 		return ResponseEntity.status(HttpStatus.OK).body(adminRoomDetailResDto);
 	}
 }

--- a/gg-pingpong-api/src/main/java/gg/party/api/admin/room/controller/response/AdminRoomDetailResDto.java
+++ b/gg-pingpong-api/src/main/java/gg/party/api/admin/room/controller/response/AdminRoomDetailResDto.java
@@ -26,9 +26,8 @@ public class AdminRoomDetailResDto {
 	private List<UserRoomResDto> roomUsers;
 	private List<AdminCommentResDto> comments;
 
-	public AdminRoomDetailResDto(Room room, String myNickname, String hostNickname,
-		List<UserRoomResDto> roomUsers,
-		List<AdminCommentResDto> comments) {
+	public AdminRoomDetailResDto(Room room, String hostNickname,
+		List<UserRoomResDto> roomUsers, List<AdminCommentResDto> comments) {
 		this.roomId = room.getId();
 		this.title = room.getTitle();
 		this.categoryId = room.getCategory().getId();
@@ -38,7 +37,7 @@ public class AdminRoomDetailResDto {
 		this.status = room.getStatus();
 		this.dueDate = room.getDueDate();
 		this.createDate = room.getCreatedAt();
-		this.myNickname = myNickname;
+		this.myNickname = null;
 		this.hostNickname = hostNickname;
 		this.roomUsers = roomUsers;
 		this.comments = comments;

--- a/gg-pingpong-api/src/main/java/gg/party/api/admin/room/service/RoomAdminService.java
+++ b/gg-pingpong-api/src/main/java/gg/party/api/admin/room/service/RoomAdminService.java
@@ -23,7 +23,6 @@ import gg.party.api.user.room.controller.response.UserRoomResDto;
 import gg.repo.party.CommentRepository;
 import gg.repo.party.RoomRepository;
 import gg.repo.party.UserRoomRepository;
-import gg.repo.user.UserRepository;
 import gg.utils.exception.party.RoomNotFoundException;
 import gg.utils.exception.party.RoomSameStatusException;
 import lombok.RequiredArgsConstructor;
@@ -32,7 +31,6 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class RoomAdminService {
 	private final RoomRepository roomRepository;
-	private final UserRepository userRepository;
 	private final UserRoomRepository userRoomRepository;
 	private final CommentRepository commentRepository;
 
@@ -79,22 +77,13 @@ public class RoomAdminService {
 
 	/**
 	 * 방의 상세정보를 조회한다
-	 * @param userId 자신의 id
 	 * @param roomId 방 id
 	 * @exception RoomNotFoundException 유효하지 않은 방 입력
 	 * @return 방 상세정보 dto
 	 */
 	@Transactional
-	public AdminRoomDetailResDto findAdminDetailRoom(Long userId, Long roomId) {
+	public AdminRoomDetailResDto findAdminDetailRoom(Long roomId) {
 		Room room = roomRepository.findById(roomId).orElseThrow(RoomNotFoundException::new);
-
-		Optional<UserRoom> userRoomOptional = userRoomRepository.findByUserIdAndRoomIdAndIsExistTrue(userId, roomId);
-
-		String myNickname = null;
-		if (userRoomOptional.isPresent()) {
-			UserRoom userRoom = userRoomOptional.get();
-			myNickname = userRoom.getNickname();
-		}
 
 		List<AdminCommentResDto> comments = commentRepository.findByRoomId(roomId).stream()
 			.map(AdminCommentResDto::new)
@@ -105,11 +94,10 @@ public class RoomAdminService {
 		String hostNickname = hostUserRoomOptional.get().getNickname();
 
 		List<UserRoomResDto> roomUsers = userRoomRepository.findByRoomId(roomId).stream()
-			.map(userRoom -> new UserRoomResDto(userRoom,
-				userRoom.getUser().getIntraId()))
+			.filter(UserRoom::getIsExist)
+			.map(userRoom -> new UserRoomResDto(userRoom, userRoom.getUser().getIntraId()))
 			.collect(Collectors.toList());
 
-		return new AdminRoomDetailResDto(room, myNickname, hostNickname, roomUsers, comments);
+		return new AdminRoomDetailResDto(room, hostNickname, roomUsers, comments);
 	}
-
 }

--- a/gg-pingpong-api/src/main/java/gg/party/api/admin/room/service/RoomAdminService.java
+++ b/gg-pingpong-api/src/main/java/gg/party/api/admin/room/service/RoomAdminService.java
@@ -105,7 +105,7 @@ public class RoomAdminService {
 		String hostNickname = hostUserRoomOptional.get().getNickname();
 
 		List<UserRoomResDto> roomUsers = userRoomRepository.findByRoomId(roomId).stream()
-			.map(userRoom -> new UserRoomResDto(userRoom.getId(), userRoom.getNickname(),
+			.map(userRoom -> new UserRoomResDto(userRoom,
 				userRoom.getUser().getIntraId()))
 			.collect(Collectors.toList());
 

--- a/gg-pingpong-api/src/main/java/gg/party/api/user/room/controller/response/CommentResDto.java
+++ b/gg-pingpong-api/src/main/java/gg/party/api/user/room/controller/response/CommentResDto.java
@@ -11,13 +11,27 @@ import lombok.NoArgsConstructor;
 public class CommentResDto {
 	private Long commentId;
 	private String nickname;
+	private String intraId;
+	private Boolean isExist;
 	private String content;
 	private Boolean isHidden;
 	private LocalDateTime createDate;
 
+	public CommentResDto(Comment comment, String intraId) {
+		this.commentId = comment.getId();
+		this.nickname = comment.getUserRoom().getNickname();
+		this.intraId = intraId;
+		this.isExist = comment.getUserRoom().getIsExist();
+		this.content = comment.getContent();
+		this.isHidden = comment.isHidden();
+		this.createDate = comment.getCreatedAt();
+	}
+
 	public CommentResDto(Comment comment) {
 		this.commentId = comment.getId();
 		this.nickname = comment.getUserRoom().getNickname();
+		this.intraId = null;
+		this.isExist = comment.getUserRoom().getIsExist();
 		this.content = comment.getContent();
 		this.isHidden = comment.isHidden();
 		this.createDate = comment.getCreatedAt();

--- a/gg-pingpong-api/src/main/java/gg/party/api/user/room/controller/response/UserRoomResDto.java
+++ b/gg-pingpong-api/src/main/java/gg/party/api/user/room/controller/response/UserRoomResDto.java
@@ -1,5 +1,6 @@
 package gg.party.api.user.room.controller.response;
 
+import gg.data.party.UserRoom;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -10,15 +11,15 @@ public class UserRoomResDto {
 	private String nickname;
 	private String intraId;
 
-	public UserRoomResDto(Long id, String nickname) {
-		this.roomUserId = id;
-		this.nickname = nickname;
+	public UserRoomResDto(UserRoom userRoom) {
+		this.roomUserId = userRoom.getId();
+		this.nickname = userRoom.getNickname();
 		this.intraId = null;
 	}
 
-	public UserRoomResDto(Long id, String nickname, String intraId) {
-		this.roomUserId = id;
-		this.nickname = nickname;
+	public UserRoomResDto(UserRoom userRoom, String intraId) {
+		this.roomUserId = userRoom.getId();
+		this.nickname = userRoom.getNickname();
 		this.intraId = intraId;
 	}
 }

--- a/gg-pingpong-api/src/main/java/gg/party/api/user/room/service/RoomService.java
+++ b/gg-pingpong-api/src/main/java/gg/party/api/user/room/service/RoomService.java
@@ -69,7 +69,7 @@ public class RoomService {
 
 		notStartedRooms.addAll(startedRooms);
 		List<RoomResDto> roomListResDto = notStartedRooms.stream()
-			.map(room -> new RoomResDto(room))
+			.map(RoomResDto::new)
 			.collect(Collectors.toList());
 
 		return new RoomListResDto(roomListResDto);
@@ -226,7 +226,7 @@ public class RoomService {
 	 * @param roomId 방 id
 	 * @exception RoomNotFoundException 유효하지 않은 방 입력
 	 * @exception RoomReportedException 신고 받은 방 처리 | 시작한 방도 볼 수 있게 해야하므로 별도처리
-	 * 익명성을 지키기 위해 nickname을 리턴
+	 * 익명성을 지키기 위해 Nickname을 리턴
 	 * @return 방 상세정보 dto
 	 */
 	@Transactional
@@ -300,9 +300,12 @@ public class RoomService {
 		}
 
 		room.updateCurrentPeople(room.getCurrentPeople() + 1);
-		// if (room.getCurrentPeople() + 1 == room.getMaxPeople()) 경우 게임 시작하는 로직 추가
+		if (room.getCurrentPeople().equals(room.getMaxPeople())) {
+			room.updateRoomStatus(RoomType.START);
+			List<User> users = userRoomRepository.findByIsExist(roomId);
+			partyNotiService.sendPartyNotifications(users);
+		}
 		roomRepository.save(room);
-
 		return new RoomJoinResDto(roomId);
 	}
 }

--- a/gg-pingpong-api/src/main/java/gg/party/api/user/room/service/RoomService.java
+++ b/gg-pingpong-api/src/main/java/gg/party/api/user/room/service/RoomService.java
@@ -254,15 +254,14 @@ public class RoomService {
 
 		if (room.getStatus() == RoomType.START && userRoomOptional.isPresent()) {
 			List<UserRoomResDto> roomUsers = userRoomRepository.findByRoomId(roomId).stream()
-				.filter(userRoom -> userRoom.getIsExist())
-				.map(userRoom -> new UserRoomResDto(userRoom.getId(), userRoom.getNickname(),
-					userRoom.getUser().getIntraId()))
+				.filter(UserRoom::getIsExist)
+				.map(userRoom -> new UserRoomResDto(userRoom, userRoom.getUser().getIntraId()))
 				.collect(Collectors.toList());
 			return new RoomDetailResDto(room, myNickname, hostNickname, roomUsers, comments);
 		} else { // if 참여자 && 시작했을경우 intraID || else intraId == null
 			List<UserRoomResDto> roomUsers = userRoomRepository.findByRoomId(roomId).stream()
-				.filter(userRoom -> userRoom.getIsExist())
-				.map(userRoom -> new UserRoomResDto(userRoom.getId(), userRoom.getNickname()))
+				.filter(UserRoom::getIsExist)
+				.map(UserRoomResDto::new)
 				.collect(Collectors.toList());
 			return new RoomDetailResDto(room, myNickname, hostNickname, roomUsers, comments);
 		}

--- a/gg-pingpong-api/src/main/java/gg/party/api/user/room/service/RoomService.java
+++ b/gg-pingpong-api/src/main/java/gg/party/api/user/room/service/RoomService.java
@@ -244,21 +244,25 @@ public class RoomService {
 			myNickname = userRoom.getNickname();
 		}
 
-		List<CommentResDto> comments = commentRepository.findByRoomId(roomId).stream()
-			.map(CommentResDto::new)
-			.collect(Collectors.toList());
-
 		Optional<UserRoom> hostUserRoomOptional = userRoomRepository.findByUserIdAndRoomIdAndIsExistTrue(
 			room.getHost().getId(), roomId);
 		String hostNickname = hostUserRoomOptional.get().getNickname();
 
 		if (room.getStatus() == RoomType.START && userRoomOptional.isPresent()) {
+			List<CommentResDto> comments = commentRepository.findByRoomId(roomId).stream()
+				.map(comment -> new CommentResDto(comment, comment.getUser().getIntraId()))
+				.collect(Collectors.toList());
+
 			List<UserRoomResDto> roomUsers = userRoomRepository.findByRoomId(roomId).stream()
 				.filter(UserRoom::getIsExist)
 				.map(userRoom -> new UserRoomResDto(userRoom, userRoom.getUser().getIntraId()))
 				.collect(Collectors.toList());
 			return new RoomDetailResDto(room, myNickname, hostNickname, roomUsers, comments);
 		} else { // if 참여자 && 시작했을경우 intraID || else intraId == null
+			List<CommentResDto> comments = commentRepository.findByRoomId(roomId).stream()
+				.map(CommentResDto::new)
+				.collect(Collectors.toList());
+
 			List<UserRoomResDto> roomUsers = userRoomRepository.findByRoomId(roomId).stream()
 				.filter(UserRoom::getIsExist)
 				.map(UserRoomResDto::new)

--- a/gg-pingpong-api/src/main/java/gg/party/api/user/room/service/RoomService.java
+++ b/gg-pingpong-api/src/main/java/gg/party/api/user/room/service/RoomService.java
@@ -28,6 +28,7 @@ import gg.party.api.user.room.controller.response.RoomJoinResDto;
 import gg.party.api.user.room.controller.response.RoomListResDto;
 import gg.party.api.user.room.controller.response.RoomResDto;
 import gg.party.api.user.room.controller.response.UserRoomResDto;
+import gg.pingpong.api.user.noti.service.PartyNotiService;
 import gg.repo.party.CategoryRepository;
 import gg.repo.party.CommentRepository;
 import gg.repo.party.RoomRepository;
@@ -52,6 +53,7 @@ public class RoomService {
 	private final CategoryRepository categoryRepository;
 	private final UserRoomRepository userRoomRepository;
 	private final CommentRepository commentRepository;
+	private final PartyNotiService partyNotiService;
 
 	/**
 	 * 시작하지 않은 방과 시작한 방을 모두 조회한다
@@ -211,6 +213,8 @@ public class RoomService {
 			throw new UserNotHostException();
 		}
 		targetRoom.updateRoomStatus(RoomType.START);
+		List<User> users = userRoomRepository.findByIsExist(roomId);
+		partyNotiService.sendPartyNotifications(users);
 		roomRepository.save(targetRoom);
 
 		return roomId;

--- a/gg-pingpong-api/src/main/java/gg/pingpong/api/user/noti/service/PartyNotiService.java
+++ b/gg-pingpong-api/src/main/java/gg/pingpong/api/user/noti/service/PartyNotiService.java
@@ -20,6 +20,6 @@ public class PartyNotiService {
 
 	@Transactional(readOnly = true)
 	public void sendPartyNotifications(List<User> users) {
-		slackPartybotService.send(users);
+		slackPartybotService.partySend(users);
 	}
 }

--- a/gg-pingpong-api/src/main/java/gg/pingpong/api/user/noti/service/PartyNotiService.java
+++ b/gg-pingpong-api/src/main/java/gg/pingpong/api/user/noti/service/PartyNotiService.java
@@ -1,0 +1,25 @@
+package gg.pingpong.api.user.noti.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import gg.data.user.User;
+import gg.pingpong.api.user.noti.service.sns.SlackPartybotService;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+public class PartyNotiService {
+	private final SlackPartybotService slackPartybotService;
+
+	public PartyNotiService(SlackPartybotService slackPartybotService) {
+		this.slackPartybotService = slackPartybotService;
+	}
+
+	@Transactional(readOnly = true)
+	public void sendPartyNotifications(List<User> users) {
+		slackPartybotService.send(users);
+	}
+}

--- a/gg-pingpong-api/src/main/java/gg/pingpong/api/user/noti/service/sns/SlackPartybotService.java
+++ b/gg-pingpong-api/src/main/java/gg/pingpong/api/user/noti/service/sns/SlackPartybotService.java
@@ -1,0 +1,107 @@
+package gg.pingpong.api.user.noti.service.sns;
+
+import static gg.pingpong.api.user.noti.service.sns.SlackbotUtils.*;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+import gg.data.user.User;
+import gg.pingpong.api.global.utils.external.ApiUtil;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class SlackPartybotService {
+	@Value("${slack.xoxbToken}")
+	private String authenticationToken;
+
+	private final ApiUtil apiUtil;
+
+	private String getSlackUserId(String intraId) {
+		String userEmail = intraId + intraEmailSuffix;
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+		headers.add(HttpHeaders.AUTHORIZATION, authenticationPrefix + authenticationToken);
+
+		MultiValueMap<String, String> parameters = new LinkedMultiValueMap<>();
+		parameters.add("email", userEmail);
+
+		SlackPartybotService.SlackUserInfoResponse res = apiUtil.apiCall(userIdGetUrl,
+			SlackPartybotService.SlackUserInfoResponse.class,
+			headers, parameters, HttpMethod.POST);
+		return res.user.getId();
+	}
+
+	private String createGroupChannelId(List<String> slackUserIds) {
+		HttpHeaders httpHeaders = new HttpHeaders();
+		httpHeaders.add(HttpHeaders.AUTHORIZATION, authenticationPrefix + authenticationToken);
+		httpHeaders.setContentType(MediaType.APPLICATION_JSON);
+
+		Map<String, String> bodyMap = new HashMap<>();
+		bodyMap.put("users", String.join(",", slackUserIds));
+
+		SlackPartybotService.ConversationResponse res = apiUtil.apiCall(conversationsUrl,
+			SlackPartybotService.ConversationResponse.class, httpHeaders, bodyMap, HttpMethod.POST);
+
+		return res.channel.getId();
+	}
+
+	@Async("asyncExecutor")
+	public void send(List<User> users) {
+		List<String> slackUserIds = users.stream()
+			.map(User::getIntraId)
+			.map(this::getSlackUserId)
+			.collect(Collectors.toList());
+
+		String slackChannelId = createGroupChannelId(slackUserIds);
+		sendGroupMessage(slackChannelId, "서로 상호간의 예의를 지키며 진행해주세요. 노쇼신고는 42gg에서 하면 됩니다.");
+	}
+
+	private void sendGroupMessage(String channelId, String message) {
+		HttpHeaders headers = new HttpHeaders();
+		headers.add(HttpHeaders.AUTHORIZATION, authenticationPrefix + authenticationToken);
+		headers.setContentType(MediaType.APPLICATION_JSON);
+
+		Map<String, String> bodyMap = new HashMap<>();
+		bodyMap.put("channel", channelId);
+		bodyMap.put("text", message);
+
+		apiUtil.apiCall(sendMessageUrl, String.class, headers, bodyMap, HttpMethod.POST);
+	}
+
+	@Getter
+	static class ConversationResponse {
+		private Boolean ok;
+		private SlackbotService.ConversationResponse.Channel channel;
+
+		@Getter
+		static class Channel {
+			private String id;
+		}
+	}
+
+	@Getter
+	static class SlackUserInfoResponse {
+		private Boolean ok;
+		private SlackbotService.SlackUserInfoResponse.SlackUser user;
+
+		@Getter
+		static class SlackUser {
+			private String id;
+		}
+	}
+}

--- a/gg-pingpong-api/src/main/java/gg/pingpong/api/user/noti/service/sns/SlackPartybotService.java
+++ b/gg-pingpong-api/src/main/java/gg/pingpong/api/user/noti/service/sns/SlackPartybotService.java
@@ -68,7 +68,9 @@ public class SlackPartybotService {
 			.collect(Collectors.toList());
 
 		String slackChannelId = createGroupChannelId(slackUserIds);
-		sendGroupMessage(slackChannelId, "서로 상호간의 예의를 지키며 진행해주세요. 노쇼신고는 42gg에서 하면 됩니다.");
+		sendGroupMessage(slackChannelId, "파티요정🧚으로부터 편지가 도착했습니다."
+			+ "\n장소 및 시간을 상호 협의해서 진행해주세요."
+			+ "\n파티원이 연락두절이라면 $$마지 못해 신고$$ ----> https://42gg.kr");
 	}
 
 	private void sendGroupMessage(String channelId, String message) {

--- a/gg-pingpong-api/src/main/java/gg/pingpong/api/user/noti/service/sns/SlackPartybotService.java
+++ b/gg-pingpong-api/src/main/java/gg/pingpong/api/user/noti/service/sns/SlackPartybotService.java
@@ -61,7 +61,7 @@ public class SlackPartybotService {
 	}
 
 	@Async("asyncExecutor")
-	public void send(List<User> users) {
+	public void partySend(List<User> users) {
 		List<String> slackUserIds = users.stream()
 			.map(User::getIntraId)
 			.map(this::getSlackUserId)

--- a/gg-pingpong-api/src/main/java/gg/pingpong/api/user/noti/service/sns/SlackbotService.java
+++ b/gg-pingpong-api/src/main/java/gg/pingpong/api/user/noti/service/sns/SlackbotService.java
@@ -108,7 +108,6 @@ public class SlackbotService {
 		static class Channel {
 			private String id;
 		}
-
 	}
 
 	@Getter


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 슬랙 초대하는 API 작성했습니다.
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - 파티원이 전부 모이거나 host가 시작했을시에 슬랙 그룹 DM으로 초대해주는 기능 작성했습니다.
  - 42gg봇이 나가도 다른사람이 DM메세지를 보낼경우 다시 기록이 남기때문에, 다음에 같은 인원이 시작할 경우 내역이 남아있는 방으로 초대되는것은 막을 수 없다고 판단했습니다. (유일한 해결방법은 게임시작한지 하루정도 지난 후 전부 강퇴하고 슬랙 봇이 나가는 기능을 구현하면 가능할 수 있을 것 같으나, 채팅방이 유지되길 바라는(하루가 지나도) 사람이 있을 수 있을 것 같아 폐지)
  - 메세지는 비슷한 맥락을 유지하되 슬로건 및 URI은 차후 수정 예정입니다.
  - SlackBotService에 같이 작성할 수 있었으나, 따로 작성한 이유는 차후 모듈화에서 분리할 수 있을까봐 따로 작성했습니다.
  - Email까지 보내는건 슬랙 단체DM을 만들어주는 과정에서 너무 많은 알림을 막기 위함이었으며, 마찬가지로 알림의 불편함 때문에 댓글도 알림을 보내지 않기로 결정했습니다. (사용자가 파티에 참여한 후, 자기 할일 하다가 슬랙알림이 오면 play하는걸 의도) 차후 댓글기능이 채팅방의 기능을 할 경우 슬랙 댓글 알림을 추가할 예정입니다.
  - 프론트의 요청으로 DTO 몇가지 수정했습니다.
 ## 💡Issue 번호 <!-- issue number을 link 시켜주세요 (ex. "- close #4242") -->
 - closed #720 