### PR TITLE
🐛 [Fix] pchange 히스토리 조회 시 game 시간 기준이 아닌 게임 점수 입력 시간 조회 수정

### DIFF
--- a/gg-pingpong-api/src/main/java/gg/pingpong/api/user/user/dto/UserHistoryData.java
+++ b/gg-pingpong-api/src/main/java/gg/pingpong/api/user/user/dto/UserHistoryData.java
@@ -14,6 +14,6 @@ public class UserHistoryData {
 
 	public UserHistoryData(PChange pChange) {
 		this.ppp = pChange.getPppResult();
-		this.date = pChange.getCreatedAt();
+		this.date = pChange.getGame().getStartTime();
 	}
 }

--- a/gg-pingpong-api/src/test/java/gg/pingpong/api/user/user/service/UserServiceTest.java
+++ b/gg-pingpong-api/src/test/java/gg/pingpong/api/user/user/service/UserServiceTest.java
@@ -1,0 +1,92 @@
+package gg.pingpong.api.user.user.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import gg.data.game.Game;
+import gg.data.game.PChange;
+import gg.data.game.type.Mode;
+import gg.data.game.type.StatusType;
+import gg.data.season.Season;
+import gg.data.user.User;
+import gg.data.user.type.RacketType;
+import gg.data.user.type.RoleType;
+import gg.data.user.type.SnsType;
+import gg.pingpong.api.user.season.service.SeasonFindService;
+import gg.pingpong.api.user.user.controller.response.UserHistoryResponseDto;
+import gg.pingpong.api.utils.ReflectionUtilsForUnitTest;
+import gg.repo.game.PChangeRepository;
+import gg.utils.annotation.UnitTest;
+
+@UnitTest
+class UserServiceTest {
+
+	@Mock
+	SeasonFindService seasonFindService;
+
+	@Mock
+	PChangeRepository pChangeRepository;
+
+	@InjectMocks
+	UserService userService;
+
+	@Nested
+	@DisplayName("getUserHistory 테스트 - User 의 PChange 변화 내역을 조회 한다.")
+	class GetUserHistoryTest {
+
+		Season season;
+		List<PChange> pChanges;
+		@BeforeEach
+		void setUp() {
+			season = new Season();
+			ReflectionUtilsForUnitTest.setFieldWithReflection(season, "id", 1L);
+			pChanges = new ArrayList<>();
+			for (int i = 0; i < 5; i++) {
+				Game game = new Game(season, StatusType.END, Mode.RANK,
+					LocalDateTime.now().minusDays(i), LocalDateTime.now().minusDays(i).plusMinutes(15));
+				User user = new User("testId" + i, "testEmail" + i, "imageUri",
+					RacketType.DUAL, RoleType.ADMIN, 0, SnsType.SLACK, 111L);
+				PChange pChange = new PChange(game, user, 1111, true);
+				ReflectionUtilsForUnitTest.setFieldWithReflection(pChange, "id", (long) i);
+				pChanges.add(pChange);
+			}
+			when(pChangeRepository.findPChangesHistory(anyString(), anyLong())).thenReturn(pChanges);
+		}
+
+		@Test
+		@DisplayName("success - seasonId가 0일 때")
+		void seasonId_zero() {
+			when(seasonFindService.findCurrentSeason(any())).thenReturn(season);
+			UserHistoryResponseDto userHistory = userService.getUserHistory("testId", 0L);
+			assertEquals(5, userHistory.getHistorics().size());
+			Collections.reverse(pChanges);
+			for (int i = 0; i < 5; i++) {
+				assertEquals(pChanges.get(i).getGame().getStartTime(), userHistory.getHistorics().get(i).getDate());
+			}
+		}
+
+		@Test
+		@DisplayName("success - seasonId가 0이 아닐 때")
+		void seasonId_not_zero() {
+			when(seasonFindService.findSeasonById(anyLong())).thenReturn(season);
+			UserHistoryResponseDto userHistory = userService.getUserHistory("testId", 1L);
+			assertEquals(5, userHistory.getHistorics().size());
+			Collections.reverse(pChanges);
+			for (int i = 0; i < 5; i++) {
+				assertEquals(pChanges.get(i).getGame().getStartTime(), userHistory.getHistorics().get(i).getDate());
+			}
+		}
+	}
+}


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  -  pchange 히스토리 조회 시 game 시간 기준이 아닌 pchange 생성 시간 기준으로 date가 들어가고 있었음
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - UserHistoryDate 의 date 기준을 게임 시작 시간으로 변경
  - getUserHIstory Unit Test 코드 추가
 ## 💡Issue 번호 <!-- issue number을 link 시켜주세요 (ex. "- close #4242") -->
 - close #474 