### PR TITLE
🧪 [Test] Admin 카테고리 추가 및 제거 테스트 코드 작성

### DIFF
--- a/gg-admin-repo/src/main/java/gg/admin/repo/category/CategoryAdminRepository.java
+++ b/gg-admin-repo/src/main/java/gg/admin/repo/category/CategoryAdminRepository.java
@@ -6,4 +6,6 @@ import gg.data.party.Category;
 
 public interface CategoryAdminRepository extends JpaRepository<Category, Long> {
 	Boolean existsByName(String categoryName);
+
+	Category findByName(String categoryName);
 }

--- a/gg-pingpong-api/src/main/java/gg/party/api/admin/category/controller/CategoryAdminController.java
+++ b/gg-pingpong-api/src/main/java/gg/party/api/admin/category/controller/CategoryAdminController.java
@@ -1,5 +1,7 @@
 package gg.party.api.admin.category.controller;
 
+import javax.validation.Valid;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -25,7 +27,7 @@ public class CategoryAdminController {
 	 * @return 추가 성공 여부
 	 */
 	@PostMapping
-	public ResponseEntity<Void> categoryAdd(@RequestBody CategoryAddAdminReqDto reqDto) {
+	public ResponseEntity<Void> categoryAdd(@RequestBody @Valid CategoryAddAdminReqDto reqDto) {
 		categoryAdminService.addCategory(reqDto);
 		return ResponseEntity.status(HttpStatus.CREATED).build();
 	}

--- a/gg-pingpong-api/src/main/java/gg/party/api/admin/category/controller/request/CategoryAddAdminReqDto.java
+++ b/gg-pingpong-api/src/main/java/gg/party/api/admin/category/controller/request/CategoryAddAdminReqDto.java
@@ -7,4 +7,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class CategoryAddAdminReqDto {
 	private String categoryName;
+
+	public CategoryAddAdminReqDto(String category) {
+		this.categoryName = category;
+	}
 }

--- a/gg-pingpong-api/src/main/java/gg/party/api/admin/category/controller/request/CategoryAddAdminReqDto.java
+++ b/gg-pingpong-api/src/main/java/gg/party/api/admin/category/controller/request/CategoryAddAdminReqDto.java
@@ -1,11 +1,16 @@
 package gg.party.api.admin.category.controller.request;
 
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 public class CategoryAddAdminReqDto {
+	@NotBlank(message = "카테고리 이름은 비어 있을 수 없습니다.")
+	@Size(min = 1, max = 10, message = "카테고리 이름은 1자 이상 10자 이하이어야 합니다.")
 	private String categoryName;
 
 	public CategoryAddAdminReqDto(String category) {

--- a/gg-pingpong-api/src/main/java/gg/party/api/admin/category/service/CategoryAdminService.java
+++ b/gg-pingpong-api/src/main/java/gg/party/api/admin/category/service/CategoryAdminService.java
@@ -35,7 +35,7 @@ public class CategoryAdminService {
 
 	/**
 	 * 카테고리 삭제
-	 * 삭제 시 기존에 room에 연결되어 있던 카테고리는 default(1) 로 변경
+	 * 삭제 시 기존에 room에 연결되어 있던 카테고리는 etc 로 변경
 	 * @param categoryId 삭제할 카테고리 id
 	 * @exception CategoryNotFoundException 유효하지 않은 카테고리 - 404
 	 * @exception DefaultCategoryNeedException default 카테고리 존재 x 또는 default 카테고리 삭제 요청 - 400
@@ -45,10 +45,10 @@ public class CategoryAdminService {
 		Category category = categoryAdminRepository.findById(categoryId)
 			.orElseThrow(CategoryNotFoundException::new);
 
-		Category defaultCategory = categoryAdminRepository.findById(DefaultCategoryNeedException.DEFAULT_CATEGORY_ID)
-			.orElseThrow(DefaultCategoryNeedException::new);
+		Category defaultCategory = categoryAdminRepository.findByName(
+			DefaultCategoryNeedException.DEFAULT_CATEGORY_NAME);
 
-		if (category.equals(defaultCategory)) {
+		if (defaultCategory == null || category.equals(defaultCategory)) {
 			throw new DefaultCategoryNeedException();
 		}
 

--- a/gg-pingpong-api/src/main/java/gg/party/api/admin/category/service/CategoryAdminService.java
+++ b/gg-pingpong-api/src/main/java/gg/party/api/admin/category/service/CategoryAdminService.java
@@ -21,7 +21,7 @@ public class CategoryAdminService {
 	/**
 	 * 카테고리 추가
 	 * @param reqDto 추가할 카테고리 이름
-	 * @exception CategoryDuplicateException 중복된 카테고리
+	 * @exception CategoryDuplicateException 중복된 카테고리 - 409
 	 */
 	@Transactional
 	public void addCategory(CategoryAddAdminReqDto reqDto) {
@@ -37,8 +37,8 @@ public class CategoryAdminService {
 	 * 카테고리 삭제
 	 * 삭제 시 기존에 room에 연결되어 있던 카테고리는 default(1) 로 변경
 	 * @param categoryId 삭제할 카테고리 id
-	 * @exception CategoryNotFoundException 유효하지 않은 카테고리
-	 * @exception DefaultCategoryNeedException default 카테고리 존재 x 또는 default 카테고리 삭제 요청
+	 * @exception CategoryNotFoundException 유효하지 않은 카테고리 - 404
+	 * @exception DefaultCategoryNeedException default 카테고리 존재 x 또는 default 카테고리 삭제 요청 - 400
 	 */
 	@Transactional
 	public void removeCategory(Long categoryId) {

--- a/gg-pingpong-api/src/test/java/gg/party/api/admin/category/CategoryAdminControllerTest.java
+++ b/gg-pingpong-api/src/test/java/gg/party/api/admin/category/CategoryAdminControllerTest.java
@@ -24,7 +24,6 @@ import gg.data.user.type.RacketType;
 import gg.data.user.type.RoleType;
 import gg.data.user.type.SnsType;
 import gg.party.api.admin.category.controller.request.CategoryAddAdminReqDto;
-import gg.party.api.admin.report.service.ReportAdminService;
 import gg.repo.party.CategoryRepository;
 import gg.utils.TestDataUtils;
 import gg.utils.annotation.IntegrationTest;
@@ -47,8 +46,6 @@ public class CategoryAdminControllerTest {
 	AuthTokenProvider tokenProvider;
 	@Autowired
 	CategoryRepository categoryRepository;
-	@Autowired
-	ReportAdminService reportAdminService;
 	User userTester;
 	String userAccessToken;
 	Category defaultCategory;
@@ -61,7 +58,7 @@ public class CategoryAdminControllerTest {
 			userTester = testDataUtils.createNewUser("adminTester", "adminTester",
 				RacketType.DUAL, SnsType.SLACK, RoleType.ADMIN);
 			userAccessToken = tokenProvider.createToken(userTester.getId());
-			defaultCategory = testDataUtils.createNewCategory("default");
+			defaultCategory = testDataUtils.createNewCategory("etc");
 		}
 
 		@Test
@@ -107,7 +104,7 @@ public class CategoryAdminControllerTest {
 			userTester = testDataUtils.createNewUser("adminTester", "adminTester",
 				RacketType.DUAL, SnsType.SLACK, RoleType.ADMIN);
 			userAccessToken = tokenProvider.createToken(userTester.getId());
-			defaultCategory = testDataUtils.createNewCategory("default");
+			defaultCategory = testDataUtils.createNewCategory("etc");
 		}
 
 		@Test

--- a/gg-pingpong-api/src/test/java/gg/party/api/admin/category/CategoryAdminControllerTest.java
+++ b/gg-pingpong-api/src/test/java/gg/party/api/admin/category/CategoryAdminControllerTest.java
@@ -70,7 +70,7 @@ public class CategoryAdminControllerTest {
 
 		@Test
 		@DisplayName("카테고리 추가 성공 201")
-		public void Success() throws Exception {
+		public void success() throws Exception {
 			//given
 			String url = "/party/admin/categories";
 			CategoryAddAdminReqDto categoryAddAdminReqDto = new CategoryAddAdminReqDto("category");
@@ -119,7 +119,7 @@ public class CategoryAdminControllerTest {
 
 		@Test
 		@DisplayName("카테고리 삭제 성공 204")
-		public void Success() throws Exception {
+		public void success() throws Exception {
 			//given
 			String categoryID = testCategory.getId().toString();
 			String url = "/party/admin/categories/" + categoryID;

--- a/gg-pingpong-api/src/test/java/gg/party/api/admin/category/CategoryAdminControllerTest.java
+++ b/gg-pingpong-api/src/test/java/gg/party/api/admin/category/CategoryAdminControllerTest.java
@@ -83,7 +83,7 @@ public class CategoryAdminControllerTest {
 		}
 
 		@Test
-		@DisplayName("이미 존재하는 카테고리로 인한 에러 400")
+		@DisplayName("이미 존재하는 카테고리로 인한 에러 409")
 		public void fail() throws Exception {
 			//given
 			String url = "/party/admin/categories";
@@ -95,7 +95,7 @@ public class CategoryAdminControllerTest {
 					.contentType(MediaType.APPLICATION_JSON)
 					.content(jsonRequest)
 					.header(HttpHeaders.AUTHORIZATION, "Bearer " + userAccessToken))
-				.andExpect(status().isBadRequest()).toString();
+				.andExpect(status().isConflict()).toString();
 		}
 	}
 
@@ -118,7 +118,7 @@ public class CategoryAdminControllerTest {
 			String categoryID = testCategory.getId().toString();
 			String url = "/party/admin/categories" + categoryID;
 			//when
-			String contentAsString = mockMvc.perform(post(url)
+			String contentAsString = mockMvc.perform(delete(url)
 					.contentType(MediaType.APPLICATION_JSON)
 					.header(HttpHeaders.AUTHORIZATION, "Bearer " + userAccessToken))
 				.andExpect(status().isNoContent())
@@ -134,20 +134,20 @@ public class CategoryAdminControllerTest {
 			String categoryID = "10";
 			String url = "/party/admin/categories" + categoryID;
 			//when & then
-			String contentAsString = mockMvc.perform(post(url)
+			String contentAsString = mockMvc.perform(delete(url)
 					.contentType(MediaType.APPLICATION_JSON)
 					.header(HttpHeaders.AUTHORIZATION, "Bearer " + userAccessToken))
 				.andExpect(status().isNotFound()).toString();
 		}
 
 		@Test
-		@DisplayName("default 카테고리 삭제 요청에 대한 오류 400")
+		@DisplayName("default 카테고리 삭제 요청에 대한 에러 400")
 		public void fail() throws Exception {
 			//given
 			String categoryID = defaultCategory.getId().toString();
 			String url = "/party/admin/categories" + categoryID;
 			//when & then
-			String contentAsString = mockMvc.perform(post(url)
+			String contentAsString = mockMvc.perform(delete(url)
 					.contentType(MediaType.APPLICATION_JSON)
 					.header(HttpHeaders.AUTHORIZATION, "Bearer " + userAccessToken))
 				.andExpect(status().isBadRequest()).toString();

--- a/gg-pingpong-api/src/test/java/gg/party/api/admin/category/CategoryAdminControllerTest.java
+++ b/gg-pingpong-api/src/test/java/gg/party/api/admin/category/CategoryAdminControllerTest.java
@@ -1,0 +1,101 @@
+package gg.party.api.admin.category;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.apache.http.HttpHeaders;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import gg.auth.utils.AuthTokenProvider;
+import gg.data.party.Category;
+import gg.data.user.User;
+import gg.data.user.type.RacketType;
+import gg.data.user.type.RoleType;
+import gg.data.user.type.SnsType;
+import gg.party.api.admin.category.controller.request.CategoryAddAdminReqDto;
+import gg.party.api.admin.report.service.ReportAdminService;
+import gg.repo.party.CategoryRepository;
+import gg.utils.TestDataUtils;
+import gg.utils.annotation.IntegrationTest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@IntegrationTest
+@AutoConfigureMockMvc
+@Transactional
+@RequiredArgsConstructor
+@Slf4j
+public class CategoryAdminControllerTest {
+	@Autowired
+	MockMvc mockMvc;
+	@Autowired
+	TestDataUtils testDataUtils;
+	@Autowired
+	ObjectMapper objectMapper;
+	@Autowired
+	AuthTokenProvider tokenProvider;
+	@Autowired
+	CategoryRepository categoryRepository;
+	@Autowired
+	ReportAdminService reportAdminService;
+	User userTester;
+	String userAccessToken;
+	Category testCategory;
+
+	@Nested
+	@DisplayName("카테고리 추가 테스트")
+	class CategoryAdd {
+		@BeforeEach
+		void beforeEach() {
+			userTester = testDataUtils.createNewUser("adminTester", "adminTester",
+				RacketType.DUAL, SnsType.SLACK, RoleType.ADMIN);
+			userAccessToken = tokenProvider.createToken(userTester.getId());
+			testCategory = testDataUtils.createNewCategory("test");
+		}
+
+		@Test
+		@DisplayName("카테고리 추가 성공 201")
+		public void Success() throws Exception {
+			//given
+			String url = "/party/admin/categories";
+			CategoryAddAdminReqDto categoryAddAdminReqDto = new CategoryAddAdminReqDto("category");
+			String jsonRequest = objectMapper.writeValueAsString(categoryAddAdminReqDto);
+			//when
+			String contentAsString = mockMvc.perform(post(url)
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(jsonRequest)
+					.header(HttpHeaders.AUTHORIZATION, "Bearer " + userAccessToken))
+				.andExpect(status().isCreated())
+				.andReturn().getResponse().getContentAsString();
+			//then
+			assertThat(categoryRepository.findAll()).isNotNull();
+		}
+
+		@Test
+		@DisplayName("이미 존재하는 카테고리로 인한 에러 400")
+		public void fail() throws Exception {
+			//given
+			String url = "/party/admin/categories";
+			testDataUtils.createNewCategory("category");
+			CategoryAddAdminReqDto categoryAddAdminReqDto = new CategoryAddAdminReqDto("category");
+			String jsonRequest = objectMapper.writeValueAsString(categoryAddAdminReqDto);
+			//when & then
+			String contentAsString = mockMvc.perform(post(url)
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(jsonRequest)
+					.header(HttpHeaders.AUTHORIZATION, "Bearer " + userAccessToken))
+				.andExpect(status().isBadRequest()).toString();
+		}
+	}
+}

--- a/gg-utils/src/main/java/gg/utils/exception/ErrorCode.java
+++ b/gg-utils/src/main/java/gg/utils/exception/ErrorCode.java
@@ -179,11 +179,11 @@ public enum ErrorCode {
 	ROOM_SAME_STATUS(400, "PT204", "이미 처리된 방 입니다."),
 	ROOM_NOT_OPEN(400, "PT205", "모집중인 방이 아닙니다."),
 	ROOM_NOT_PARTICIPANT(400, "PT206", "참여하지 않은 방 입니다."),
-	CATEGORY_DUPLICATE(400, "PT207", "중복된 카테고리 입니다."),
-	ROOM_MIN_MAX_PEOPLE(400, "PT208", "최소인원이 최대인원보다 큽니다."),
+	ROOM_MIN_MAX_PEOPLE(400, "PT207", "최소인원이 최대인원보다 큽니다."),
 	USER_ALREADY_IN_ROOM(409, "PT301", "이미 참여한 방 입니다."),
 	ALREADY_REPORTED(409, "PT302", "이미 신고한 요청입니다."),
 	SELF_REPORT(409, "PT303", "자신을 신고할 수 없습니다."),
+	CATEGORY_DUPLICATE(409, "PT304", "중복된 카테고리 입니다."),
 	ON_PENALTY(403, "PT501", "패널티 상태입니다.");
 
 	private final int status;

--- a/gg-utils/src/main/java/gg/utils/exception/party/DefaultCategoryNeedException.java
+++ b/gg-utils/src/main/java/gg/utils/exception/party/DefaultCategoryNeedException.java
@@ -4,7 +4,7 @@ import gg.utils.exception.ErrorCode;
 import gg.utils.exception.custom.BusinessException;
 
 public class DefaultCategoryNeedException extends BusinessException {
-	public static final Long DEFAULT_CATEGORY_ID = 1L;
+	public static final String DEFAULT_CATEGORY_NAME = "etc";
 
 	public DefaultCategoryNeedException() {
 		super(ErrorCode.DEFAULT_CATEGORY_NEED.getMessage(), ErrorCode.DEFAULT_CATEGORY_NEED);

--- a/gg-utils/src/main/java/gg/utils/exception/party/DefaultCategoryNeedException.java
+++ b/gg-utils/src/main/java/gg/utils/exception/party/DefaultCategoryNeedException.java
@@ -1,9 +1,9 @@
 package gg.utils.exception.party;
 
 import gg.utils.exception.ErrorCode;
-import gg.utils.exception.custom.NotExistException;
+import gg.utils.exception.custom.BusinessException;
 
-public class DefaultCategoryNeedException extends NotExistException {
+public class DefaultCategoryNeedException extends BusinessException {
 	public static final Long DEFAULT_CATEGORY_ID = 1L;
 
 	public DefaultCategoryNeedException() {

--- a/gg-utils/src/testFixtures/java/gg/utils/TestDataUtils.java
+++ b/gg-utils/src/testFixtures/java/gg/utils/TestDataUtils.java
@@ -14,8 +14,13 @@ import gg.data.manage.Announcement;
 import gg.data.noti.Noti;
 import gg.data.noti.type.NotiType;
 import gg.data.party.Category;
+import gg.data.party.Comment;
+import gg.data.party.CommentReport;
+import gg.data.party.GameTemplate;
 import gg.data.party.PartyPenalty;
 import gg.data.party.Room;
+import gg.data.party.RoomReport;
+import gg.data.party.UserReport;
 import gg.data.party.UserRoom;
 import gg.data.party.type.RoomType;
 import gg.data.pingpong.game.Game;
@@ -53,8 +58,13 @@ import gg.repo.manage.AnnouncementRepository;
 import gg.repo.manage.SlotManagementRepository;
 import gg.repo.noti.NotiRepository;
 import gg.repo.party.CategoryRepository;
+import gg.repo.party.CommentReportRepository;
+import gg.repo.party.CommentRepository;
 import gg.repo.party.PartyPenaltyRepository;
+import gg.repo.party.RoomReportRepository;
 import gg.repo.party.RoomRepository;
+import gg.repo.party.TemplateRepository;
+import gg.repo.party.UserReportRepository;
 import gg.repo.party.UserRoomRepository;
 import gg.repo.rank.RankRepository;
 import gg.repo.rank.TierRepository;
@@ -95,6 +105,11 @@ public class TestDataUtils {
 	private final UserRoomRepository userRoomRepository;
 	private final CategoryRepository categoryRepository;
 	private final PartyPenaltyRepository partyPenaltyRepository;
+	private final TemplateRepository templateRepository;
+	private final CommentRepository commentRepository;
+	private final CommentReportRepository commentReportRepository;
+	private final RoomReportRepository roomReportRepository;
+	private final UserReportRepository userReportRepository;
 
 	public String getLoginAccessToken() {
 		User user = User.builder()
@@ -827,5 +842,45 @@ public class TestDataUtils {
 			.build();
 		userRepository.save(user);
 		return user;
+	}
+
+	public GameTemplate createTemplate(Category category, String gameName, Integer maxGamePeople, Integer minGamePeople,
+		Integer maxGameTime, Integer minGameTime, String genre, String difficulty, String summary) {
+		GameTemplate gameTemplate = GameTemplate.builder()
+			.category(category)
+			.gameName(gameName)
+			.maxGamePeople(maxGamePeople)
+			.minGamePeople(minGamePeople)
+			.maxGameTime(maxGameTime)
+			.minGameTime(minGameTime)
+			.genre(genre)
+			.difficulty(difficulty)
+			.summary(summary)
+			.build();
+		return templateRepository.save(gameTemplate);
+	}
+
+	public Comment createComment(User user, UserRoom userRoom, Room room, String content) {
+		Comment comment = new Comment(user, userRoom, room, content);
+		commentRepository.save(comment);
+		return comment;
+	}
+
+	public CommentReport createCommentReport(User user, Room room, Comment comment) {
+		CommentReport commentReport = new CommentReport(user, comment, room, "test");
+		commentReportRepository.save(commentReport);
+		return commentReport;
+	}
+
+	public RoomReport createRoomReport(User user, User targetUser, Room room) {
+		RoomReport roomReport = new RoomReport(user, targetUser, room, "test");
+		roomReportRepository.save(roomReport);
+		return roomReport;
+	}
+
+	public UserReport createUserReport(User user, User targetUser, Room room) {
+		UserReport userReport = new UserReport(user, targetUser, room, "test");
+		userReportRepository.save(userReport);
+		return userReport;
 	}
 }


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - admin 유저가 카테고리를 추가하거나 제거하는 로직을 작성했습니다.
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - 기존 서비스 로직에서 고정값으로 받던 defaultCategory를 name으로 검색("etc")으로 수정했습니다.(사유 : 처음 카테고리 생성시 defalut를 만들지 않으면 db에 접근해야함)
  - 카테고리를 제거할때, defaultCategory로 바뀌는지 확인하는 로직도 추가했습니다.
  - 400으로 오지 않는 exception을 수정했습니다.
  - 400으로 오던 duplicate exception을 수정했습니다.
  - 머지를 대비해 컨플릭트를 줄이기 위해 testUtills만 따로 수정
 ## 💡Issue 번호 <!-- issue number을 link 시켜주세요 (ex. "- close #4242") -->
 - closed #759 