### PR TITLE
🐛 [Fix] 공고 전체 조회 API의 잘못된 응답 수정

### DIFF
--- a/gg-admin-repo/src/main/java/gg/admin/repo/recruit/RecruitmentAdminRepository.java
+++ b/gg-admin-repo/src/main/java/gg/admin/repo/recruit/RecruitmentAdminRepository.java
@@ -12,6 +12,8 @@ import gg.data.recruit.recruitment.Recruitment;
 public interface RecruitmentAdminRepository extends JpaRepository<Recruitment, Long> {
 	Page<Recruitment> findAllByOrderByEndTimeDesc(Pageable pageable);
 
+	Page<Recruitment> findAllByIsDeletedOrderByEndTimeDesc(boolean isDeleted, Pageable pageable);
+
 	@Query("SELECT r FROM Recruitment r WHERE r.id = :recruitId AND r.isDeleted = false")
 	Optional<Recruitment> findNotDeletedRecruit(Long recruitId);
 }

--- a/gg-data/src/main/java/gg/data/recruit/recruitment/Recruitment.java
+++ b/gg-data/src/main/java/gg/data/recruit/recruitment/Recruitment.java
@@ -80,6 +80,10 @@ public class Recruitment extends BaseTimeEntity {
 		this.isFinish = finish;
 	}
 
+	public boolean getIsFinsh() {
+		return this.isFinish;
+	}
+
 	/**
 	 * Question에서 호출하는 연관관계 편의 메서드, 기타 호출 금지
 	 * @param question

--- a/gg-recruit-api/src/main/java/gg/recruit/api/admin/controller/RecruitmentAdminController.java
+++ b/gg-recruit-api/src/main/java/gg/recruit/api/admin/controller/RecruitmentAdminController.java
@@ -82,7 +82,7 @@ public class RecruitmentAdminController {
 	}
 
 	@GetMapping
-	public ResponseEntity<RecruitmentsResponse> getRecruitments(PageRequestDto pageRequestDto) {
+	public ResponseEntity<RecruitmentsResponse> getRecruitments(@Valid PageRequestDto pageRequestDto) {
 		Pageable pageable = PageRequest.of(pageRequestDto.getPage() - 1, pageRequestDto.getSize());
 		AllRecruitmentsResult allRecruitments = recruitmentAdminService.getAllRecruitments(pageable);
 		return ResponseEntity.ok(

--- a/gg-recruit-api/src/main/java/gg/recruit/api/admin/controller/response/RecruitmentDto.java
+++ b/gg-recruit-api/src/main/java/gg/recruit/api/admin/controller/response/RecruitmentDto.java
@@ -3,26 +3,27 @@ package gg.recruit.api.admin.controller.response;
 import java.time.LocalDateTime;
 
 import gg.data.recruit.recruitment.Recruitment;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class RecruitmentDto {
 	private Long id;
 	private String title;
-	private String status;
+	private Boolean isFinish;
 	private String generation;
 	private LocalDateTime startDate;
 	private LocalDateTime endDate;
 
 	@Builder
-	public RecruitmentDto(Long id, String title, String status, String generation, LocalDateTime startDate,
+	public RecruitmentDto(Long id, String title, Boolean isFinish, String generation, LocalDateTime startDate,
 		LocalDateTime endDate) {
 		this.id = id;
 		this.title = title;
-		this.status = status;
+		this.isFinish = isFinish;
 		this.generation = generation;
 		this.startDate = startDate;
 		this.endDate = endDate;
@@ -32,6 +33,7 @@ public class RecruitmentDto {
 		return RecruitmentDto.builder()
 			.id(recruitment.getId())
 			.title(recruitment.getTitle())
+			.isFinish(recruitment.getIsFinsh())
 			.generation(recruitment.getGeneration())
 			.startDate(recruitment.getStartTime())
 			.endDate(recruitment.getEndTime())

--- a/gg-recruit-api/src/main/java/gg/recruit/api/admin/controller/response/RecruitmentsResponse.java
+++ b/gg-recruit-api/src/main/java/gg/recruit/api/admin/controller/response/RecruitmentsResponse.java
@@ -14,8 +14,8 @@ public class RecruitmentsResponse {
 	private List<RecruitmentDto> recruitments = new ArrayList<>();
 	private int totalPage;
 
-	public RecruitmentsResponse(List<Recruitment> recruitments, int totalPage) {
-		for (Recruitment recruitment : recruitments) {
+	public RecruitmentsResponse(List<Recruitment> recruitmentList, int totalPage) {
+		for (Recruitment recruitment : recruitmentList) {
 			this.recruitments.add(RecruitmentDto.toRecruitmentDto(recruitment));
 		}
 		this.totalPage = totalPage;

--- a/gg-recruit-api/src/main/java/gg/recruit/api/admin/service/RecruitmentAdminService.java
+++ b/gg-recruit-api/src/main/java/gg/recruit/api/admin/service/RecruitmentAdminService.java
@@ -78,7 +78,8 @@ public class RecruitmentAdminService {
 	 */
 	@Transactional(readOnly = true)
 	public AllRecruitmentsResult getAllRecruitments(Pageable pageable) {
-		Page<Recruitment> allByOrderByEndDateDesc = recruitmentAdminRepository.findAllByOrderByEndTimeDesc(pageable);
+		Page<Recruitment> allByOrderByEndDateDesc = recruitmentAdminRepository.findAllByIsDeletedOrderByEndTimeDesc(
+			false, pageable);
 		return new AllRecruitmentsResult(allByOrderByEndDateDesc.getTotalPages(), allByOrderByEndDateDesc.getContent());
 	}
 

--- a/gg-recruit-api/src/main/java/gg/recruit/api/user/controller/RecruitmentController.java
+++ b/gg-recruit-api/src/main/java/gg/recruit/api/user/controller/RecruitmentController.java
@@ -1,5 +1,7 @@
 package gg.recruit.api.user.controller;
 
+import javax.validation.Valid;
+
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -25,7 +27,7 @@ public class RecruitmentController {
 	private final ApplicationService applicationService;
 
 	@GetMapping
-	public ActiveRecruitmentListResDto findActiveRecruitmentList(PageRequestDto requestDto) {
+	public ActiveRecruitmentListResDto findActiveRecruitmentList(@Valid PageRequestDto requestDto) {
 		Pageable pageable = PageRequest.of(requestDto.getPage() - 1, requestDto.getSize());
 		return new ActiveRecruitmentListResDto(recruitmentService.findActiveRecruitmentList(pageable));
 	}

--- a/gg-recruit-api/src/test/java/gg/recruit/api/admin/service/RecruitmentAdminServiceUnitTest.java
+++ b/gg-recruit-api/src/test/java/gg/recruit/api/admin/service/RecruitmentAdminServiceUnitTest.java
@@ -51,13 +51,13 @@ class RecruitmentAdminServiceUnitTest {
 		// given
 		Page<Recruitment> mock = mock(Page.class);
 		Pageable mockPageable = mock(Pageable.class);
-		given(recruitmentAdminRepository.findAllByOrderByEndTimeDesc(mockPageable)).willReturn(mock);
+		given(recruitmentAdminRepository.findAllByIsDeletedOrderByEndTimeDesc(false, mockPageable)).willReturn(mock);
 
 		// when
 		recruitmentAdminService.getAllRecruitments(mockPageable);
 
 		// then
-		verify(recruitmentAdminRepository, times(1)).findAllByOrderByEndTimeDesc(mockPageable);
+		verify(recruitmentAdminRepository, times(1)).findAllByIsDeletedOrderByEndTimeDesc(false, mockPageable);
 	}
 
 	@Nested


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 공고 전체 조회 API의 잘못된 응답에 대한 수정

 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - `status` -> `isFinish` 필드명 수정
  - 공고 전체 조회시 삭제된 공고는 필터링하여 보내지 않도록 수정했습니다. (`isDeleted`가 true인 공고 필터링)
  - `PageRequestDto`에 대해 valid 검사가 이루어지지 않아 500 에러 발생 가능했습니다. `@Valid` 추가했습니다.
