### PR TITLE
1035 feature 전체일정 생성 api 작성

### DIFF
--- a/gg-calendar-api/src/main/java/gg/calendar/api/schedule/publicschedule/controller/PublicScheduleController.java
+++ b/gg-calendar-api/src/main/java/gg/calendar/api/schedule/publicschedule/controller/PublicScheduleController.java
@@ -1,4 +1,35 @@
 package gg.calendar.api.schedule.publicschedule.controller;
 
+import javax.validation.Valid;
+
+import org.apache.coyote.Response;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import gg.auth.UserDto;
+import gg.auth.argumentresolver.Login;
+import gg.calendar.api.schedule.publicschedule.controller.request.PublicScheduleCreateReqDto;
+import gg.calendar.api.schedule.publicschedule.service.PublicScheduleService;
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/public")
 public class PublicScheduleController {
+	private final PublicScheduleService publicScheduleService;
+
+	@PostMapping("/create")
+	public ResponseEntity<Void> createPublicSchedule(
+		@Valid @ModelAttribute PublicScheduleCreateReqDto publicScheduleCreateReqDto,
+		@Login @Parameter(hidden = true) UserDto userDto) {
+		publicScheduleService.createPublicSchedule(userDto, publicScheduleCreateReqDto);
+		return ResponseEntity.status(HttpStatus.CREATED).build();
+	}
 }

--- a/gg-calendar-api/src/main/java/gg/calendar/api/schedule/publicschedule/controller/PublicScheduleController.java
+++ b/gg-calendar-api/src/main/java/gg/calendar/api/schedule/publicschedule/controller/PublicScheduleController.java
@@ -6,6 +6,8 @@ import org.apache.coyote.Response;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -13,6 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 import gg.auth.UserDto;
 import gg.auth.argumentresolver.Login;
 import gg.calendar.api.schedule.publicschedule.controller.request.PublicScheduleCreateReqDto;
+import gg.calendar.api.schedule.publicschedule.controller.request.PublicScheduleUpdateReqDto;
 import gg.calendar.api.schedule.publicschedule.service.PublicScheduleService;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
@@ -31,5 +34,22 @@ public class PublicScheduleController {
 		@Login @Parameter(hidden = true) UserDto userDto) {
 		publicScheduleService.createPublicSchedule(userDto, publicScheduleCreateReqDto);
 		return ResponseEntity.status(HttpStatus.CREATED).build();
+	}
+
+	@PatchMapping("/{scheduleId}/update")
+	public ResponseEntity<Void> updatePublicSchedule(@PathVariable @Valid Long scheduleId,
+		@Valid @ModelAttribute PublicScheduleUpdateReqDto publicScheduleUpdateReqDto,
+		@Login @Parameter(hidden = true) UserDto userDto) {
+		Long userId = userDto.getId();
+		publicScheduleService.updatePublicSchedule(scheduleId, userId, publicScheduleUpdateReqDto);
+		return ResponseEntity.status(HttpStatus.OK).build();
+	}
+
+	@PatchMapping("/{scheduleId}/delete")
+	public ResponseEntity<Void> deletePublicSchedule(@PathVariable @Valid Long scheduleId,
+		@Login @Parameter(hidden = true) UserDto uSerDto) {
+		Long userId = uSerDto.getId();
+		publicScheduleService.deletePublicSchedule(scheduleId, userId);
+		return ResponseEntity.status(HttpStatus.OK).build();
 	}
 }

--- a/gg-calendar-api/src/main/java/gg/calendar/api/schedule/publicschedule/controller/PublicScheduleController.java
+++ b/gg-calendar-api/src/main/java/gg/calendar/api/schedule/publicschedule/controller/PublicScheduleController.java
@@ -16,6 +16,7 @@ import gg.auth.UserDto;
 import gg.auth.argumentresolver.Login;
 import gg.calendar.api.schedule.publicschedule.controller.request.PublicScheduleCreateReqDto;
 import gg.calendar.api.schedule.publicschedule.controller.request.PublicScheduleUpdateReqDto;
+import gg.calendar.api.schedule.publicschedule.controller.response.PublicScheduleUpdateResDto;
 import gg.calendar.api.schedule.publicschedule.service.PublicScheduleService;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
@@ -37,11 +38,11 @@ public class PublicScheduleController {
 	}
 
 	@PatchMapping("/{scheduleId}/update")
-	public ResponseEntity<Void> updatePublicSchedule(@PathVariable @Valid Long scheduleId,
+	public ResponseEntity<PublicScheduleUpdateResDto> updatePublicSchedule(@PathVariable @Valid Long scheduleId,
 		@Valid @ModelAttribute PublicScheduleUpdateReqDto publicScheduleUpdateReqDto,
 		@Login @Parameter(hidden = true) UserDto userDto) {
 		Long userId = userDto.getId();
-		publicScheduleService.updatePublicSchedule(scheduleId, userId, publicScheduleUpdateReqDto);
+		PublicScheduleUpdateResDto scheduleUpdate =   publicScheduleService.updatePublicSchedule(scheduleId, userId, publicScheduleUpdateReqDto);
 		return ResponseEntity.status(HttpStatus.OK).build();
 	}
 

--- a/gg-calendar-api/src/main/java/gg/calendar/api/schedule/publicschedule/controller/request/PublicScheduleCreateReqDto.java
+++ b/gg-calendar-api/src/main/java/gg/calendar/api/schedule/publicschedule/controller/request/PublicScheduleCreateReqDto.java
@@ -1,0 +1,63 @@
+package gg.calendar.api.schedule.publicschedule.controller.request;
+import java.time.LocalDateTime;
+import java.util.Set;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+import org.springframework.format.annotation.DateTimeFormat;
+
+import gg.data.calendar.PrivateSchedule;
+import gg.data.calendar.PublicSchedule;
+import gg.data.calendar.type.DetailClassification;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import gg.data.calendar.Tag;
+
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PublicScheduleCreateReqDto {
+	@NotNull
+	private DetailClassification classification;
+
+	@NotNull
+	private Set<Tag> tags;
+
+	@NotBlank
+	@Size(max = 50, message = "제목은 50자이하로 입력해주세요.")
+	private String title;
+
+	@Size(max = 2000, message = "내용은 2000자이하로 입력해주세요.")
+	private String content;
+
+	private String link;
+
+	@NotNull
+	private boolean alarm;
+
+	private String color;
+
+	@NotNull
+	@DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+	private LocalDateTime startTime;
+
+	@NotNull
+	@DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+	private LocalDateTime endTime;
+
+	public static PublicSchedule of(String author, PublicScheduleCreateReqDto publicScheduleCreateReqDto){
+		return PublicSchedule.builder()
+			.author(author)
+			.classification(publicScheduleCreateReqDto.classification)
+			.tags(publicScheduleCreateReqDto.tags)
+			.title(publicScheduleCreateReqDto.title)
+			.content(publicScheduleCreateReqDto.content)
+			.link(publicScheduleCreateReqDto.link)
+			.startTime(publicScheduleCreateReqDto.startTime)
+			.endTime(publicScheduleCreateReqDto.endTime)
+			.build();
+	}
+}

--- a/gg-calendar-api/src/main/java/gg/calendar/api/schedule/publicschedule/controller/request/PublicScheduleReqDto.java
+++ b/gg-calendar-api/src/main/java/gg/calendar/api/schedule/publicschedule/controller/request/PublicScheduleReqDto.java
@@ -1,4 +1,23 @@
 package gg.calendar.api.schedule.publicschedule.controller.request;
 
+import java.time.LocalDateTime;
+import java.util.Set;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+import org.springframework.format.annotation.DateTimeFormat;
+
+import gg.data.calendar.PublicSchedule;
+import gg.data.calendar.Tag;
+import gg.data.calendar.type.DetailClassification;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PublicScheduleReqDto {
+
 }

--- a/gg-calendar-api/src/main/java/gg/calendar/api/schedule/publicschedule/controller/request/PublicScheduleUpdateReqDto.java
+++ b/gg-calendar-api/src/main/java/gg/calendar/api/schedule/publicschedule/controller/request/PublicScheduleUpdateReqDto.java
@@ -1,0 +1,51 @@
+package gg.calendar.api.schedule.publicschedule.controller.request;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+import org.springframework.format.annotation.DateTimeFormat;
+
+import gg.data.calendar.PublicSchedule;
+import gg.data.calendar.Tag;
+import gg.data.calendar.type.DetailClassification;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PublicScheduleUpdateReqDto {
+	@NotNull
+	private DetailClassification classification;
+
+	@NotNull
+	private Set<Tag> tags;
+
+	@NotBlank
+	@Size(max = 50, message = "제목은 50자이하로 입력해주세요.")
+	private String title;
+
+	@Size(max = 2000, message = "내용은 2000자이하로 입력해주세요.")
+	private String content;
+
+	private String link;
+
+	@NotNull
+	private boolean alarm;
+
+	private String color;
+
+	@NotNull
+	@DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+	private LocalDateTime startTime;
+
+	@NotNull
+	@DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+	private LocalDateTime endTime;
+
+
+}

--- a/gg-calendar-api/src/main/java/gg/calendar/api/schedule/publicschedule/controller/response/PublicScheduleUpdateResDto.java
+++ b/gg-calendar-api/src/main/java/gg/calendar/api/schedule/publicschedule/controller/response/PublicScheduleUpdateResDto.java
@@ -1,0 +1,59 @@
+package gg.calendar.api.schedule.publicschedule.controller.response;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+
+import gg.calendar.api.schedule.publicschedule.controller.request.PublicScheduleUpdateReqDto;
+import gg.data.calendar.PublicSchedule;
+import gg.data.calendar.Tag;
+import gg.data.calendar.type.DetailClassification;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PublicScheduleUpdateResDto {
+	private Long id;
+	private DetailClassification detailClassification;
+	private Set<Tag> tags;
+	private String title;
+	private String content;
+	private String link;
+	private LocalDateTime startTime;
+	private LocalDateTime endTime;
+	private boolean alarm;
+	private String color;
+
+	@Builder
+	public PublicScheduleUpdateResDto(Long id, DetailClassification detailClassification,  Set<Tag> tags, String title,
+		String content, String link, LocalDateTime startTime, LocalDateTime endTime, boolean alarm, String color)
+	{
+		this.id = id;
+		this.detailClassification = detailClassification;
+		this.tags = tags;
+		this.title = title;
+		this.content = content;
+		this.link = link;
+		this.startTime = startTime;
+		this.endTime = endTime;
+		this.alarm = alarm;
+		this.color = color;
+	}
+
+	public static PublicScheduleUpdateResDto from(PublicSchedule publicSchedule)
+	{
+		return PublicScheduleUpdateResDto.builder().id(publicSchedule.getId())
+			.detailClassification(publicSchedule.getClassification())
+			.tags(publicSchedule.getTags())
+			.title(publicSchedule.getTitle())
+			.content(publicSchedule.getContent())
+			.link(publicSchedule.getLink())
+			.startTime(publicSchedule.getStartTime())
+			.endTime(publicSchedule.getEndTime())
+			.alarm(publicSchedule.isAlarm())
+			.color(publicSchedule.getColor())
+			.build();
+	}
+}

--- a/gg-calendar-api/src/main/java/gg/calendar/api/schedule/publicschedule/service/PublicScheduleService.java
+++ b/gg-calendar-api/src/main/java/gg/calendar/api/schedule/publicschedule/service/PublicScheduleService.java
@@ -1,4 +1,32 @@
 package gg.calendar.api.schedule.publicschedule.service;
 
+
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import gg.auth.UserDto;
+import gg.calendar.api.schedule.publicschedule.controller.request.PublicScheduleCreateReqDto;
+import gg.data.calendar.PublicSchedule;
+import gg.data.user.User;
+import gg.repo.calendar.PublicScheduleRepository;
+import gg.repo.user.UserRepository;
+import gg.utils.exception.user.UserNotFoundException;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class PublicScheduleService {
+	private final PublicScheduleRepository publicSchduleRepository;
+	private final UserRepository userRepository;
+
+	@Transactional
+	public void createPublicSchedule(UserDto userDto, PublicScheduleCreateReqDto publicScheduleCreateReqDto)
+	{
+		PublicSchedule publicSchedule = PublicScheduleCreateReqDto.of(userDto.getIntraId(),
+			publicScheduleCreateReqDto);
+		publicSchduleRepository.save(publicSchedule);
+	}
+
 }

--- a/gg-calendar-api/src/main/java/gg/calendar/api/schedule/publicschedule/service/PublicScheduleService.java
+++ b/gg-calendar-api/src/main/java/gg/calendar/api/schedule/publicschedule/service/PublicScheduleService.java
@@ -5,11 +5,14 @@ package gg.calendar.api.schedule.publicschedule.service;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.nimbusds.oauth2.sdk.util.StringUtils;
+
 import gg.auth.UserDto;
 import gg.calendar.api.schedule.publicschedule.controller.request.PublicScheduleCreateReqDto;
 import gg.calendar.api.schedule.publicschedule.controller.request.PublicScheduleUpdateReqDto;
 import gg.calendar.api.schedule.publicschedule.controller.response.PublicScheduleUpdateResDto;
 import gg.data.calendar.PublicSchedule;
+import gg.data.calendar.type.DetailClassification;
 import gg.data.calendar.type.ScheduleStatus;
 import gg.data.user.User;
 import gg.repo.calendar.PublicScheduleRepository;
@@ -36,12 +39,33 @@ public class PublicScheduleService {
 	@Transactional
 	public PublicScheduleUpdateResDto updatePublicSchedule(Long scheduleId, Long userId, PublicScheduleUpdateReqDto publicScheduleUpdateReqDto){
 		PublicSchedule publicSchedule = publicSchduleRepository.findByUserIdAndSchduleId(userId, scheduleId).orElseThrow(()-> new IllegalArgumentException("해당 일정이 없습니다."));
+
+		validateScheduleUpdate(publicScheduleUpdateReqDto);
 		publicSchedule.update(publicScheduleUpdateReqDto.getClassification(), publicScheduleUpdateReqDto.getTags(),
 			publicScheduleUpdateReqDto.getTitle(), publicScheduleUpdateReqDto.getContent(),
 			publicScheduleUpdateReqDto.getLink(), publicScheduleUpdateReqDto.getStartTime(),
 			publicScheduleUpdateReqDto.getEndTime(), publicScheduleUpdateReqDto.isAlarm(),
 			publicScheduleUpdateReqDto.getColor());
 		return PublicScheduleUpdateResDto.from(publicSchedule);
+	}
+
+	private void validateScheduleUpdate(PublicScheduleUpdateReqDto publicScheduleUpdateReqDto)
+	{
+		if (publicScheduleUpdateReqDto.getStartTime().isAfter(publicScheduleUpdateReqDto.getEndTime()))
+		{
+			throw new IllegalArgumentException("시작 시간이 종료 시간보다 늦을 수 없습니다.");
+		}
+		if (publicScheduleUpdateReqDto.getEndTime().isBefore(publicScheduleUpdateReqDto.getStartTime()))
+		{
+			throw new IllegalArgumentException("종료시간이 시작시간보다 빠를 수 없습니다.");
+		}
+		if (publicScheduleUpdateReqDto.getEndTime().isEqual(publicScheduleUpdateReqDto.getStartTime()))
+		{
+			throw new IllegalArgumentException("시작 시간과 종료시간이 같을 수 없습니다.");
+		}
+		if (StringUtils.isBlank(publicScheduleUpdateReqDto.getTitle())) {
+			throw new IllegalArgumentException("일정 제목은 필수입니다.");
+		}
 	}
 
 	// TODO: 에러처리하기

--- a/gg-calendar-api/src/main/java/gg/calendar/api/schedule/publicschedule/service/PublicScheduleService.java
+++ b/gg-calendar-api/src/main/java/gg/calendar/api/schedule/publicschedule/service/PublicScheduleService.java
@@ -7,7 +7,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import gg.auth.UserDto;
 import gg.calendar.api.schedule.publicschedule.controller.request.PublicScheduleCreateReqDto;
+import gg.calendar.api.schedule.publicschedule.controller.request.PublicScheduleUpdateReqDto;
 import gg.data.calendar.PublicSchedule;
+import gg.data.calendar.type.ScheduleStatus;
 import gg.data.user.User;
 import gg.repo.calendar.PublicScheduleRepository;
 import gg.repo.user.UserRepository;
@@ -29,4 +31,25 @@ public class PublicScheduleService {
 		publicSchduleRepository.save(publicSchedule);
 	}
 
+	//TODO: 에러처리하기!
+	@Transactional
+	public void updatePublicSchedule(Long scheduleId, Long userId, PublicScheduleUpdateReqDto publicScheduleUpdateReqDto){
+		PublicSchedule publicSchedule = publicSchduleRepository.findByUserIdAndSchduleId(userId, scheduleId).orElseThrow(()-> new IllegalArgumentException("해당 일정이 없습니다."));
+		publicSchedule.update(publicScheduleUpdateReqDto.getClassification(), publicScheduleUpdateReqDto.getTags(),
+			publicScheduleUpdateReqDto.getTitle(), publicScheduleUpdateReqDto.getContent(),
+			publicScheduleUpdateReqDto.getLink(), publicScheduleUpdateReqDto.getStartTime(),
+			publicScheduleUpdateReqDto.getEndTime(), publicScheduleUpdateReqDto.isAlarm(),
+			publicScheduleUpdateReqDto.getColor());
+	}
+
+	// TODO: 에러처리하기
+	@Transactional
+	public void deletePublicSchedule(Long scheduleId, Long userId) {
+		PublicSchedule publicSchedule = publicSchduleRepository.findByUserIdAndSchduleId(userId, scheduleId).orElseThrow(()-> new IllegalArgumentException("해당 일정이 없습니다"));
+
+		if (publicSchedule.getStatus() == ScheduleStatus.DELETE) {
+			throw new IllegalArgumentException("이미 삭제된 일정입니다.");
+		}
+		publicSchedule.delete();
+	}
 }

--- a/gg-calendar-api/src/main/java/gg/calendar/api/schedule/publicschedule/service/PublicScheduleService.java
+++ b/gg-calendar-api/src/main/java/gg/calendar/api/schedule/publicschedule/service/PublicScheduleService.java
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 import gg.auth.UserDto;
 import gg.calendar.api.schedule.publicschedule.controller.request.PublicScheduleCreateReqDto;
 import gg.calendar.api.schedule.publicschedule.controller.request.PublicScheduleUpdateReqDto;
+import gg.calendar.api.schedule.publicschedule.controller.response.PublicScheduleUpdateResDto;
 import gg.data.calendar.PublicSchedule;
 import gg.data.calendar.type.ScheduleStatus;
 import gg.data.user.User;
@@ -33,13 +34,14 @@ public class PublicScheduleService {
 
 	//TODO: 에러처리하기!
 	@Transactional
-	public void updatePublicSchedule(Long scheduleId, Long userId, PublicScheduleUpdateReqDto publicScheduleUpdateReqDto){
+	public PublicScheduleUpdateResDto updatePublicSchedule(Long scheduleId, Long userId, PublicScheduleUpdateReqDto publicScheduleUpdateReqDto){
 		PublicSchedule publicSchedule = publicSchduleRepository.findByUserIdAndSchduleId(userId, scheduleId).orElseThrow(()-> new IllegalArgumentException("해당 일정이 없습니다."));
 		publicSchedule.update(publicScheduleUpdateReqDto.getClassification(), publicScheduleUpdateReqDto.getTags(),
 			publicScheduleUpdateReqDto.getTitle(), publicScheduleUpdateReqDto.getContent(),
 			publicScheduleUpdateReqDto.getLink(), publicScheduleUpdateReqDto.getStartTime(),
 			publicScheduleUpdateReqDto.getEndTime(), publicScheduleUpdateReqDto.isAlarm(),
 			publicScheduleUpdateReqDto.getColor());
+		return PublicScheduleUpdateResDto.from(publicSchedule);
 	}
 
 	// TODO: 에러처리하기

--- a/gg-data/src/main/java/gg/data/calendar/PublicSchedule.java
+++ b/gg-data/src/main/java/gg/data/calendar/PublicSchedule.java
@@ -56,6 +56,11 @@ public class PublicSchedule extends BaseTimeEntity {
 	@Column(nullable = false)
 	private ScheduleStatus status;
 
+	@Column(columnDefinition = "boolean default true")
+	private boolean alarm;
+
+	private String color;
+
 	@Builder
 	public PublicSchedule(DetailClassification classification, Set<Tag> tags, String author, String title,
 		String content, String link, LocalDateTime startTime, LocalDateTime endTime) {
@@ -70,14 +75,27 @@ public class PublicSchedule extends BaseTimeEntity {
 		this.status = ScheduleStatus.ACTIVATE;
 	}
 
-	public void update(DetailClassification classification, Set<Tag> tags, String author, String title, String content,
-		String link, LocalDateTime startTime, LocalDateTime endTime) {
+	// public void update(DetailClassification classification, Set<Tag> tags, String author, String title, String content,
+	// 	String link, LocalDateTime startTime, LocalDateTime endTime) {
+	//
+	// }
+	//
+	// public void update(DetailClassification classification, Set<Tag> tags, String title, String content, String link,
+	// 	LocalDateTime startTime, LocalDateTime endTime) {
+	//
+	// 	this.classification = classification;
+	// 	this.tags = tags;
+	// 	this.title = title;
+	// 	this.content = content;
+	// 	this.link = link;
+	// 	this.startTime = startTime;
+	// 	this.endTime = endTime;
+	// }
 
-	}
-
-	public void update(DetailClassification classification, Set<Tag> tags, String title, String content, String link,
-		LocalDateTime startTime, LocalDateTime endTime) {
-
+	public void update(DetailClassification classification, Set<Tag> tags,
+		String title, String content, String link,
+		LocalDateTime startTime, LocalDateTime endTime,
+		boolean alarm, String color) {
 		this.classification = classification;
 		this.tags = tags;
 		this.title = title;
@@ -85,5 +103,13 @@ public class PublicSchedule extends BaseTimeEntity {
 		this.link = link;
 		this.startTime = startTime;
 		this.endTime = endTime;
+		this.alarm = alarm;
+		this.color = color;
+	}
+
+	public void delete()
+	{
+		this.status = ScheduleStatus.DELETE;
+		this.alarm = false;
 	}
 }

--- a/gg-data/src/main/java/gg/data/user/type/SnsType.java
+++ b/gg-data/src/main/java/gg/data/user/type/SnsType.java
@@ -23,5 +23,4 @@ public enum SnsType {
 			.findAny()
 			.orElse(SLACK);
 	}
-
 }

--- a/gg-repo/src/main/java/gg/repo/calendar/PublicScheduleRepository.java
+++ b/gg-repo/src/main/java/gg/repo/calendar/PublicScheduleRepository.java
@@ -1,10 +1,15 @@
 package gg.repo.calendar;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import gg.data.calendar.PrivateSchedule;
 import gg.data.calendar.PublicSchedule;
 
 @Repository
 public interface PublicScheduleRepository extends JpaRepository<PublicSchedule, Long> {
+
+	Optional<PublicSchedule> findByUserIdAndSchduleId(Long userId, Long scheduleId);
 }


### PR DESCRIPTION
 ## 📌 개요 
  - 전체일정 생성 api 작성하였습니다. (그런데, 수정과 삭제를 곁들인..)
  - 수정과 삭제를 함께 작성하였습니다.
  - 추가적인 상세한 수정, 삭제 부분은 각자의 브랜치에서 작업하도록 하겠습니다.
 ## 💻 작업사항
  - 전체일정 생성 api controller, service작성과 함께, res, req dto 작성하였습니다.
  - gg-repo에 interface추가하였습니다.
  - gg-data에 publicschedule update, delete수정하였습니다.
 ## 💡Issue 번호
 - #1035 