### PR TITLE
✨ [Feature] Admin 공유일정 조회 API #1063

### DIFF
--- a/gg-admin-repo/src/main/java/gg/admin/repo/calendar/PublicScheduleAdminRepository.java
+++ b/gg-admin-repo/src/main/java/gg/admin/repo/calendar/PublicScheduleAdminRepository.java
@@ -2,13 +2,18 @@ package gg.admin.repo.calendar;
 
 import java.util.List;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import gg.data.calendar.PublicSchedule;
+import gg.data.calendar.type.DetailClassification;
 
 @Repository
 public interface PublicScheduleAdminRepository extends JpaRepository<PublicSchedule, Long> {
 
 	List<PublicSchedule> findByAuthor(String author);
+
+	Page<PublicSchedule> findAllByClassification(DetailClassification detailClassification, Pageable pageable);
 }

--- a/gg-calendar-api/src/main/java/gg/calendar/api/admin/schedule/publicschedule/controller/PublicScheduleAdminController.java
+++ b/gg-calendar-api/src/main/java/gg/calendar/api/admin/schedule/publicschedule/controller/PublicScheduleAdminController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import gg.calendar.api.admin.schedule.publicschedule.controller.request.PublicScheduleAdminCreateReqDto;
-import gg.calendar.api.admin.schedule.publicschedule.controller.response.PublicScheduleAdminSimpleResDto;
+import gg.calendar.api.admin.schedule.publicschedule.controller.response.PublicScheduleAdminResDto;
 import gg.calendar.api.admin.schedule.publicschedule.service.PublicScheduleAdminService;
 import gg.data.calendar.type.DetailClassification;
 import gg.utils.dto.PageRequestDto;
@@ -35,12 +35,12 @@ public class PublicScheduleAdminController {
 	}
 
 	@GetMapping("/list/{detailClassification}")
-	public ResponseEntity<PageResponseDto<PublicScheduleAdminSimpleResDto>> publicScheduleAdminClassificationList(
+	public ResponseEntity<PageResponseDto<PublicScheduleAdminResDto>> publicScheduleAdminClassificationList(
 		@PathVariable DetailClassification detailClassification, @ModelAttribute PageRequestDto pageRequestDto) {
 		int page = pageRequestDto.getPage();
 		int size = pageRequestDto.getSize();
 
-		PageResponseDto<PublicScheduleAdminSimpleResDto> pageResponseDto = publicScheduleAdminService.findPublicScheduleByDetailClassification(
+		PageResponseDto<PublicScheduleAdminResDto> pageResponseDto = publicScheduleAdminService.findPublicScheduleByDetailClassification(
 			detailClassification, page, size);
 
 		return ResponseEntity.ok(pageResponseDto);

--- a/gg-calendar-api/src/main/java/gg/calendar/api/admin/schedule/publicschedule/controller/PublicScheduleAdminController.java
+++ b/gg-calendar-api/src/main/java/gg/calendar/api/admin/schedule/publicschedule/controller/PublicScheduleAdminController.java
@@ -40,7 +40,7 @@ public class PublicScheduleAdminController {
 		int page = pageRequestDto.getPage();
 		int size = pageRequestDto.getSize();
 
-		PageResponseDto<PublicScheduleAdminResDto> pageResponseDto = publicScheduleAdminService.findPublicScheduleByDetailClassification(
+		PageResponseDto<PublicScheduleAdminResDto> pageResponseDto = publicScheduleAdminService.findAllByClassification(
 			detailClassification, page, size);
 
 		return ResponseEntity.ok(pageResponseDto);

--- a/gg-calendar-api/src/main/java/gg/calendar/api/admin/schedule/publicschedule/controller/PublicScheduleAdminController.java
+++ b/gg-calendar-api/src/main/java/gg/calendar/api/admin/schedule/publicschedule/controller/PublicScheduleAdminController.java
@@ -4,7 +4,9 @@ import javax.validation.Valid;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -13,10 +15,13 @@ import org.springframework.web.bind.annotation.RestController;
 import gg.auth.UserDto;
 import gg.auth.argumentresolver.Login;
 import gg.calendar.api.admin.schedule.publicschedule.controller.request.PublicScheduleAdminCreateReqDto;
+import gg.calendar.api.admin.schedule.publicschedule.controller.response.PublicScheduleAdminSimpleResDto;
 import gg.calendar.api.admin.schedule.publicschedule.service.PublicScheduleAdminService;
+import gg.data.calendar.type.DetailClassification;
+import gg.utils.dto.PageRequestDto;
+import gg.utils.dto.PageResponseDto;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.java.Log;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -36,4 +41,15 @@ public class PublicScheduleAdminController {
 		return ResponseEntity.status(HttpStatus.CREATED).build();
 	}
 
+	@GetMapping("/list/{detailClassification}")
+	public ResponseEntity<PageResponseDto<PublicScheduleAdminSimpleResDto>> publicScheduleAdminClassificationList(
+		@PathVariable DetailClassification detailClassification, @ModelAttribute PageRequestDto pageRequestDto) {
+		int page = pageRequestDto.getPage();
+		int size = pageRequestDto.getSize();
+
+		PageResponseDto<PublicScheduleAdminSimpleResDto> pageResponseDto = publicScheduleAdminService.findPublicScheduleByDetailClassification(
+			detailClassification, page, size);
+
+		return ResponseEntity.ok(pageResponseDto);
+	}
 }

--- a/gg-calendar-api/src/main/java/gg/calendar/api/admin/schedule/publicschedule/controller/response/PublicScheduleAdminResDto.java
+++ b/gg-calendar-api/src/main/java/gg/calendar/api/admin/schedule/publicschedule/controller/response/PublicScheduleAdminResDto.java
@@ -1,4 +1,0 @@
-package gg.calendar.api.admin.schedule.publicschedule.controller.response;
-
-public class PublicScheduleAdminResDto {
-}

--- a/gg-calendar-api/src/main/java/gg/calendar/api/admin/schedule/publicschedule/controller/response/PublicScheduleAdminResDto.java
+++ b/gg-calendar-api/src/main/java/gg/calendar/api/admin/schedule/publicschedule/controller/response/PublicScheduleAdminResDto.java
@@ -8,10 +8,14 @@ import gg.data.calendar.type.EventTag;
 import gg.data.calendar.type.JobTag;
 import gg.data.calendar.type.ScheduleStatus;
 import gg.data.calendar.type.TechTag;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
-public class PublicScheduleAdminSimpleResDto {
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PublicScheduleAdminResDto {
 	private Long id;
 
 	private DetailClassification classification;
@@ -36,7 +40,8 @@ public class PublicScheduleAdminSimpleResDto {
 
 	private ScheduleStatus status;
 
-	public PublicScheduleAdminSimpleResDto(PublicSchedule publicSchedule) {
+	@Builder
+	public PublicScheduleAdminResDto(PublicSchedule publicSchedule) {
 		this.id = publicSchedule.getId();
 		this.classification = publicSchedule.getClassification();
 		this.eventTag = publicSchedule.getEventTag();
@@ -49,6 +54,13 @@ public class PublicScheduleAdminSimpleResDto {
 		this.link = publicSchedule.getLink();
 		this.sharedCount = publicSchedule.getSharedCount();
 		this.status = publicSchedule.getStatus();
+	}
 
+	@Override
+	public String toString() {
+		return "PublicScheduleAdminResDto{" + "id=" + id + ", classification=" + classification + ", eventTag="
+			+ eventTag + ", jobTag=" + jobTag + ", techTag=" + techTag + ", author='" + author + '\'' + ", title='"
+			+ title + '\'' + ", startTime=" + startTime + ", endTime=" + endTime + ", link='" + link + '\''
+			+ ", sharedCount=" + sharedCount + ", status=" + status + '}';
 	}
 }

--- a/gg-calendar-api/src/main/java/gg/calendar/api/admin/schedule/publicschedule/controller/response/PublicScheduleAdminSimpleResDto.java
+++ b/gg-calendar-api/src/main/java/gg/calendar/api/admin/schedule/publicschedule/controller/response/PublicScheduleAdminSimpleResDto.java
@@ -1,0 +1,54 @@
+package gg.calendar.api.admin.schedule.publicschedule.controller.response;
+
+import java.time.LocalDateTime;
+
+import gg.data.calendar.PublicSchedule;
+import gg.data.calendar.type.DetailClassification;
+import gg.data.calendar.type.EventTag;
+import gg.data.calendar.type.JobTag;
+import gg.data.calendar.type.ScheduleStatus;
+import gg.data.calendar.type.TechTag;
+import lombok.Getter;
+
+@Getter
+public class PublicScheduleAdminSimpleResDto {
+	private Long id;
+
+	private DetailClassification classification;
+
+	private EventTag eventTag;
+
+	private JobTag jobTag;
+
+	private TechTag techTag;
+
+	private String author;
+
+	private String title;
+
+	private LocalDateTime startTime;
+
+	private LocalDateTime endTime;
+
+	private String link;
+
+	private Integer sharedCount;
+
+	private ScheduleStatus status;
+
+	public PublicScheduleAdminSimpleResDto(PublicSchedule publicSchedule) {
+		this.id = publicSchedule.getId();
+		this.classification = publicSchedule.getClassification();
+		this.eventTag = publicSchedule.getEventTag();
+		this.jobTag = publicSchedule.getJobTag();
+		this.techTag = publicSchedule.getTechTag();
+		this.author = publicSchedule.getAuthor();
+		this.title = publicSchedule.getTitle();
+		this.startTime = publicSchedule.getStartTime();
+		this.endTime = publicSchedule.getEndTime();
+		this.link = publicSchedule.getLink();
+		this.sharedCount = publicSchedule.getSharedCount();
+		this.status = publicSchedule.getStatus();
+
+	}
+}

--- a/gg-calendar-api/src/main/java/gg/calendar/api/admin/schedule/publicschedule/service/PublicScheduleAdminService.java
+++ b/gg-calendar-api/src/main/java/gg/calendar/api/admin/schedule/publicschedule/service/PublicScheduleAdminService.java
@@ -1,16 +1,21 @@
 package gg.calendar.api.admin.schedule.publicschedule.service;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import gg.admin.repo.calendar.PublicScheduleAdminRepository;
 import gg.calendar.api.admin.schedule.publicschedule.controller.request.PublicScheduleAdminCreateReqDto;
+import gg.calendar.api.admin.schedule.publicschedule.controller.response.PublicScheduleAdminSimpleResDto;
 import gg.data.calendar.PublicSchedule;
-import gg.data.calendar.type.EventTag;
-import gg.data.calendar.type.JobTag;
-import gg.data.calendar.type.TechTag;
+import gg.data.calendar.type.DetailClassification;
+import gg.utils.dto.PageResponseDto;
 import gg.utils.exception.ErrorCode;
 import gg.utils.exception.custom.CustomRuntimeException;
 import lombok.RequiredArgsConstructor;
@@ -30,6 +35,24 @@ public class PublicScheduleAdminService {
 
 		PublicSchedule publicSchedule = PublicScheduleAdminCreateReqDto.toEntity(publicScheduleAdminCreateReqDto);
 		publicScheduleAdminRepository.save(publicSchedule);
+	}
+
+	public PageResponseDto<PublicScheduleAdminSimpleResDto> findPublicScheduleByDetailClassification(
+		DetailClassification detailClassification, int page, int size) {
+
+		Pageable pageable = PageRequest.of(page - 1, size,
+			Sort.by(Sort.Order.asc("status"), Sort.Order.asc("startTime")));
+
+		Page<PublicSchedule> publicSchedules = publicScheduleAdminRepository.findAllByClassification(
+			detailClassification, pageable);
+
+		// PublicSchedule의 생성자가 필요한데 지금 private으로 막혀있어서 어떻게 할 것인가에 대한 논의
+		// 여기서 sharedcount는 있는 그대로를 들고와야함
+
+		List<PublicScheduleAdminSimpleResDto> publicScheduleList = publicSchedules.stream()
+			.map(PublicScheduleAdminSimpleResDto::new)
+			.toList();
+		return PageResponseDto.of(publicSchedules.getTotalElements(), publicScheduleList);
 	}
 
 	private void dateTimeErrorCheck(LocalDateTime startTime, LocalDateTime endTime) {

--- a/gg-calendar-api/src/main/java/gg/calendar/api/admin/schedule/publicschedule/service/PublicScheduleAdminService.java
+++ b/gg-calendar-api/src/main/java/gg/calendar/api/admin/schedule/publicschedule/service/PublicScheduleAdminService.java
@@ -12,7 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import gg.admin.repo.calendar.PublicScheduleAdminRepository;
 import gg.calendar.api.admin.schedule.publicschedule.controller.request.PublicScheduleAdminCreateReqDto;
-import gg.calendar.api.admin.schedule.publicschedule.controller.response.PublicScheduleAdminSimpleResDto;
+import gg.calendar.api.admin.schedule.publicschedule.controller.response.PublicScheduleAdminResDto;
 import gg.data.calendar.PublicSchedule;
 import gg.data.calendar.type.DetailClassification;
 import gg.utils.dto.PageResponseDto;
@@ -37,7 +37,7 @@ public class PublicScheduleAdminService {
 		publicScheduleAdminRepository.save(publicSchedule);
 	}
 
-	public PageResponseDto<PublicScheduleAdminSimpleResDto> findPublicScheduleByDetailClassification(
+	public PageResponseDto<PublicScheduleAdminResDto> findPublicScheduleByDetailClassification(
 		DetailClassification detailClassification, int page, int size) {
 
 		Pageable pageable = PageRequest.of(page - 1, size,
@@ -46,11 +46,8 @@ public class PublicScheduleAdminService {
 		Page<PublicSchedule> publicSchedules = publicScheduleAdminRepository.findAllByClassification(
 			detailClassification, pageable);
 
-		// PublicSchedule의 생성자가 필요한데 지금 private으로 막혀있어서 어떻게 할 것인가에 대한 논의
-		// 여기서 sharedcount는 있는 그대로를 들고와야함
-
-		List<PublicScheduleAdminSimpleResDto> publicScheduleList = publicSchedules.stream()
-			.map(PublicScheduleAdminSimpleResDto::new)
+		List<PublicScheduleAdminResDto> publicScheduleList = publicSchedules.stream()
+			.map(PublicScheduleAdminResDto::new)
 			.toList();
 		return PageResponseDto.of(publicSchedules.getTotalElements(), publicScheduleList);
 	}

--- a/gg-calendar-api/src/main/java/gg/calendar/api/admin/schedule/publicschedule/service/PublicScheduleAdminService.java
+++ b/gg-calendar-api/src/main/java/gg/calendar/api/admin/schedule/publicschedule/service/PublicScheduleAdminService.java
@@ -2,6 +2,7 @@ package gg.calendar.api.admin.schedule.publicschedule.service;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -37,7 +38,7 @@ public class PublicScheduleAdminService {
 		publicScheduleAdminRepository.save(publicSchedule);
 	}
 
-	public PageResponseDto<PublicScheduleAdminResDto> findPublicScheduleByDetailClassification(
+	public PageResponseDto<PublicScheduleAdminResDto> findAllByClassification(
 		DetailClassification detailClassification, int page, int size) {
 
 		Pageable pageable = PageRequest.of(page - 1, size,
@@ -48,7 +49,7 @@ public class PublicScheduleAdminService {
 
 		List<PublicScheduleAdminResDto> publicScheduleList = publicSchedules.stream()
 			.map(PublicScheduleAdminResDto::new)
-			.toList();
+			.collect(Collectors.toList());
 		return PageResponseDto.of(publicSchedules.getTotalElements(), publicScheduleList);
 	}
 

--- a/gg-calendar-api/src/test/java/gg/calendar/api/admin/PublicScheduleAdminMockData.java
+++ b/gg-calendar-api/src/test/java/gg/calendar/api/admin/PublicScheduleAdminMockData.java
@@ -7,10 +7,11 @@ import javax.persistence.EntityManager;
 import org.springframework.stereotype.Component;
 
 import gg.admin.repo.calendar.PublicScheduleAdminRepository;
-import gg.calendar.api.admin.schedule.publicschedule.controller.request.PublicScheduleAdminCreateReqDto;
 import gg.data.calendar.PublicSchedule;
 import gg.data.calendar.type.DetailClassification;
 import gg.data.calendar.type.EventTag;
+import gg.data.calendar.type.JobTag;
+import gg.data.calendar.type.ScheduleStatus;
 import lombok.RequiredArgsConstructor;
 
 @Component
@@ -35,4 +36,53 @@ public class PublicScheduleAdminMockData {
 		return publicScheduleAdminRepository.save(publicSchedule);
 	}
 
+	public void createPublicScheduleEvent(int size) {
+		for (int i = 0; i < size; i++) {
+			PublicSchedule publicSchedule = PublicSchedule.builder()
+				.classification(DetailClassification.EVENT)
+				.eventTag(EventTag.JOB_FORUM)
+				.author("42GG")
+				.title("Job " + i)
+				.content("TEST JOB")
+				.link("https://gg.42seoul.kr")
+				.status(ScheduleStatus.ACTIVATE)
+				.startTime(LocalDateTime.now().plusDays(i))
+				.endTime(LocalDateTime.now().plusDays(i + 10))
+				.build();
+			publicScheduleAdminRepository.save(publicSchedule);
+		}
+	}
+
+	public void createPublicScheduleJob(int size) {
+		for (int i = 0; i < size; i++) {
+			PublicSchedule publicSchedule = PublicSchedule.builder()
+				.classification(DetailClassification.JOB_NOTICE)
+				.jobTag(JobTag.EXPERIENCED)
+				.author("42GG")
+				.title("Job " + i)
+				.content("TEST JOB")
+				.link("https://gg.42seoul.kr")
+				.status(ScheduleStatus.ACTIVATE)
+				.startTime(LocalDateTime.now().plusDays(i))
+				.endTime(LocalDateTime.now().plusDays(i + 10))
+				.build();
+			publicScheduleAdminRepository.save(publicSchedule);
+		}
+	}
+
+	public void createPublicSchedulePrivate(int size) {
+		for (int i = 0; i < size; i++) {
+			PublicSchedule publicSchedule = PublicSchedule.builder()
+				.classification(DetailClassification.PRIVATE_SCHEDULE)
+				.author("42GG")
+				.title("Private " + i)
+				.content("TEST Private")
+				.link("https://gg.42seoul.kr")
+				.status(ScheduleStatus.ACTIVATE)
+				.startTime(LocalDateTime.now().plusDays(i))
+				.endTime(LocalDateTime.now().plusDays(i + 10))
+				.build();
+			publicScheduleAdminRepository.save(publicSchedule);
+		}
+	}
 }

--- a/gg-calendar-api/src/test/java/gg/calendar/api/admin/schedule/publicschedule/controller/PublicScheduleAdminControllerTest.java
+++ b/gg-calendar-api/src/test/java/gg/calendar/api/admin/schedule/publicschedule/controller/PublicScheduleAdminControllerTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -180,11 +181,12 @@ public class PublicScheduleAdminControllerTest {
 		}
 	}
 
+	@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 	@Nested
 	@DisplayName("Admin PublicSchedule 태그 조회 테스트")
 	class GetPublicScheduleAdminClassificationListTest {
 
-		private static Stream<Arguments> inputParams() {
+		private Stream<Arguments> inputParams() {
 			return Stream.of(Arguments.of("EVENT", 2, 10), Arguments.of("JOB_NOTICE", 1, 10),
 				Arguments.of("PRIVATE_SCHEDULE", 1, 2));
 		}

--- a/gg-calendar-api/src/test/java/gg/calendar/api/admin/schedule/publicschedule/controller/PublicScheduleAdminControllerTest.java
+++ b/gg-calendar-api/src/test/java/gg/calendar/api/admin/schedule/publicschedule/controller/PublicScheduleAdminControllerTest.java
@@ -184,6 +184,11 @@ public class PublicScheduleAdminControllerTest {
 	@DisplayName("Admin PublicSchedule 태그 조회 테스트")
 	class GetPublicScheduleAdminClassificationListTest {
 
+		private static Stream<Arguments> inputParams() {
+			return Stream.of(Arguments.of("EVENT", 2, 10), Arguments.of("JOB_NOTICE", 1, 10),
+				Arguments.of("PRIVATE_SCHEDULE", 1, 2));
+		}
+
 		@ParameterizedTest
 		@MethodSource("inputParams")
 		@DisplayName("Admin PublicSchedule 태그 조회 테스트 - 성공")
@@ -222,11 +227,6 @@ public class PublicScheduleAdminControllerTest {
 			for (PublicScheduleAdminResDto dto : result) {
 				System.out.println(dto.toString());
 			}
-		}
-
-		private static Stream<Arguments> inputParams() {
-			return Stream.of(Arguments.of("EVENT", 2, 10), Arguments.of("JOB_NOTICE", 1, 10),
-				Arguments.of("PRIVATE_SCHEDULE", 1, 2));
 		}
 	}
 }

--- a/gg-calendar-api/src/test/java/gg/calendar/api/admin/schedule/publicschedule/controller/PublicScheduleAdminControllerTest.java
+++ b/gg-calendar-api/src/test/java/gg/calendar/api/admin/schedule/publicschedule/controller/PublicScheduleAdminControllerTest.java
@@ -7,6 +7,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Stream;
 
 import javax.persistence.EntityManager;
 import javax.transaction.Transactional;
@@ -15,16 +16,23 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import gg.admin.repo.calendar.PublicScheduleAdminRepository;
 import gg.calendar.api.admin.PublicScheduleAdminMockData;
 import gg.calendar.api.admin.schedule.publicschedule.controller.request.PublicScheduleAdminCreateReqDto;
+import gg.calendar.api.admin.schedule.publicschedule.controller.response.PublicScheduleAdminResDto;
 import gg.calendar.api.admin.schedule.publicschedule.service.PublicScheduleAdminService;
 import gg.data.calendar.PublicSchedule;
 import gg.data.calendar.type.DetailClassification;
@@ -34,6 +42,7 @@ import gg.data.calendar.type.ScheduleStatus;
 import gg.data.user.User;
 import gg.utils.TestDataUtils;
 import gg.utils.annotation.IntegrationTest;
+import gg.utils.dto.PageResponseDto;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -168,6 +177,56 @@ public class PublicScheduleAdminControllerTest {
 					.content(objectMapper.writeValueAsString(requestDto)))
 				.andDo(print())
 				.andExpect(status().isBadRequest());
+		}
+	}
+
+	@Nested
+	@DisplayName("Admin PublicSchedule 태그 조회 테스트")
+	class GetPublicScheduleAdminClassificationListTest {
+
+		@ParameterizedTest
+		@MethodSource("inputParams")
+		@DisplayName("Admin PublicSchedule 태그 조회 테스트 - 성공")
+		void getPublicScheduleAdminClassificationListTestSuccess(String tags, int page, int size) throws
+			Exception {
+			// given
+			publicScheduleAdminMockData.createPublicScheduleEvent(20);
+			publicScheduleAdminMockData.createPublicScheduleJob(10);
+			publicScheduleAdminMockData.createPublicSchedulePrivate(5);
+
+			MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+			params.add("page", String.valueOf(page));
+			params.add("size", String.valueOf(size));
+
+			// when
+			// multivalue map 을 통해서 값이 넘어옴
+			String response = mockMvc.perform(
+					get("/admin/calendar/public/list/{detailClassification}", tags).header("Authorization",
+							"Bearer " + accessToken)
+						.params(params))
+				.andDo(print())
+				.andExpect(status().isOk()).andReturn().getResponse().getContentAsString();
+
+			// then
+			PageResponseDto<PublicScheduleAdminResDto> pageResponseDto = objectMapper.readValue(
+				response, new TypeReference<>() {
+				});
+			List<PublicScheduleAdminResDto> result = pageResponseDto.getContent();
+
+			if (DetailClassification.valueOf(tags) == DetailClassification.PRIVATE_SCHEDULE) {
+				assertThat(result.size()).isEqualTo(2);
+			} else {
+				assertThat(result.size()).isEqualTo(10);
+			}
+
+			for (PublicScheduleAdminResDto dto : result) {
+				System.out.println(dto.toString());
+			}
+		}
+
+		private static Stream<Arguments> inputParams() {
+			return Stream.of(Arguments.of("EVENT", 2, 10), Arguments.of("JOB_NOTICE", 1, 10),
+				Arguments.of("PRIVATE_SCHEDULE", 1, 2));
 		}
 	}
 }


### PR DESCRIPTION
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - Admin 공유일정 조회 API 엔드포인트 작성했습니다.
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - Admin 공유일정 조회 API 엔드포인트 작성
  - Admin 공유일정 조회 API 엔드포인트 테스트 코드 작성 및 테스트 확인 완료
 ## ✅ 변경로직 <!-- 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
  - 역직렬화를 위해서는 resDto에 @NoArgsConstructor가 있어야지 기본 생성자를 통해서 자동으로 setter를 통해서 값을 넣어서 PageResDto로 리턴을 해준다고 해서 PublicScheduleAdminResDto에 해당 어노테이션을 추가했습니다.
  - 기존의 엔드포인트에서 PathVariable로 받던것에서 pageReqDto가 추가되어서, DetailClassification은 PathVariable로 받고, PageReqDto(page, size)를 reqeustParam으로 받는 방식으로 작성했습니다
 ## 💡Issue 번호 <!-- issue number을 link 시켜주세요 (ex. "- close #4242") -->
 - #1063 