### PR TITLE
🔨 [Refactoring] Admin 공유일정 삭제 API 수정 및 테스트 코드 작성 #1114

### DIFF
--- a/gg-admin-repo/src/main/java/gg/admin/repo/calendar/PrivateScheduleAdminRepository.java
+++ b/gg-admin-repo/src/main/java/gg/admin/repo/calendar/PrivateScheduleAdminRepository.java
@@ -1,5 +1,7 @@
 package gg.admin.repo.calendar;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -7,4 +9,7 @@ import gg.data.calendar.PrivateSchedule;
 
 @Repository
 public interface PrivateScheduleAdminRepository extends JpaRepository<PrivateSchedule, Long> {
+
+	List<PrivateSchedule> findByPublicScheduleId(Long publicScheduleId);
+
 }


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - Admin 공유일정 삭제 API 수정 
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - Admin 공유일정 삭제 API 수정 
  - Admin 공유일정 삭제 API 수정 테스트 코드 작성 완료
 ## ✅ 변경로직 <!-- 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
  - PublicSchedule의 delete로직과 동일하게 admin에서도 연관된 privateSchedule을 찾아서 삭제하는 로직 추가했습니다.
  - ScheduleGroup의 데이터에는 변함이 없음을 확인했습니다.
  - PrivateSchedule의 status가 delete로 변경되는것 확인했습니다.
 ## 💡Issue 번호 <!-- issue number을 link 시켜주세요 (ex. "- close #4242") -->
 - close #1114 