### PR TITLE
🛠️ [Fix] 전체일정-개인일정 가져오기에서 누락된 sharedCount 추가부분 수정

### DIFF
--- a/gg-calendar-api/src/main/java/gg/calendar/api/user/schedule/publicschedule/service/PublicScheduleService.java
+++ b/gg-calendar-api/src/main/java/gg/calendar/api/user/schedule/publicschedule/service/PublicScheduleService.java
@@ -113,6 +113,7 @@ public class PublicScheduleService {
 			.orElseThrow(() -> new NotExistException(ErrorCode.SCHEDULE_GROUP_NOT_FOUND));
 		PrivateSchedule privateSchedule = new PrivateSchedule(user, publicSchedule, false, groupId);
 		privateScheduleRepository.save(privateSchedule);
+		publicSchedule.incrementSharedCount();
 	}
 
 	private void checkAuthor(String author, User user) {

--- a/gg-data/src/main/java/gg/data/calendar/PublicSchedule.java
+++ b/gg-data/src/main/java/gg/data/calendar/PublicSchedule.java
@@ -86,8 +86,8 @@ public class PublicSchedule extends BaseTimeEntity {
 		this.endTime = endTime;
 	}
 
-	public void update(DetailClassification classification, EventTag eventTag, JobTag jobTag,
-		TechTag techTag, String title, String content, String link, LocalDateTime startTime, LocalDateTime endTime) {
+	public void update(DetailClassification classification, EventTag eventTag, JobTag jobTag, TechTag techTag,
+		String title, String content, String link, LocalDateTime startTime, LocalDateTime endTime) {
 		this.classification = classification;
 		this.eventTag = eventTag;
 		this.jobTag = jobTag;
@@ -101,6 +101,10 @@ public class PublicSchedule extends BaseTimeEntity {
 
 	public void delete() {
 		this.status = ScheduleStatus.DELETE;
+	}
+
+	public void incrementSharedCount() {
+		this.sharedCount++;
 	}
 }
 


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 전체일정-개인일정 가져오기에서 누락된 sharedCount 추가부분 수정
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - 개인일정에 가져갈 시, 전체일정의 sharedCount부분이 올라가는 로직이 누락되어있어, 추가하였습니다.
 ## 💡Issue 번호 <!-- issue number을 link 시켜주세요 (ex. "- close #4242") -->
 - close #1153 