### PR TITLE
[Fix] publicSchedule에서 privateSchedule불러오지 못하게, api수정 #1163

### DIFF
--- a/gg-calendar-api/src/main/java/gg/calendar/api/user/schedule/publicschedule/controller/PublicScheduleController.java
+++ b/gg-calendar-api/src/main/java/gg/calendar/api/user/schedule/publicschedule/controller/PublicScheduleController.java
@@ -30,7 +30,6 @@ import gg.calendar.api.user.schedule.publicschedule.controller.response.PublicSc
 import gg.calendar.api.user.schedule.publicschedule.controller.response.PublicScheduleUpdateResDto;
 import gg.calendar.api.user.schedule.publicschedule.service.PublicScheduleService;
 import gg.data.calendar.PublicSchedule;
-import gg.data.calendar.type.DetailClassification;
 import gg.utils.dto.ListResponseDto;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
@@ -76,15 +75,14 @@ public class PublicScheduleController {
 		return ResponseEntity.ok(PublicScheduleDetailRetrieveResDto.toDto(publicSchedule));
 	}
 
-	@GetMapping("/period/{detailClassification}")
+	@GetMapping
 	public ResponseEntity<ListResponseDto<PublicSchedulePeriodRetrieveResDto>> publicSchedulePeriodRetrieveGet(
-		@PathVariable DetailClassification detailClassification,
 		@RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate start,
 		@RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate end) {
 		LocalDateTime startTime = start.atStartOfDay();
 		LocalDateTime endTime = end.atTime(LocalTime.MAX);
-		List<PublicSchedulePeriodRetrieveResDto> res = publicScheduleService.retrievePublicSchedulePeriod(
-			startTime, endTime, detailClassification);
+		List<PublicSchedulePeriodRetrieveResDto> res = publicScheduleService.retrieveNonPrivateSchedulePeriod(
+			startTime, endTime);
 		return ResponseEntity.ok(ListResponseDto.toDto(res));
 	}
 

--- a/gg-calendar-api/src/main/java/gg/calendar/api/user/schedule/publicschedule/service/PublicScheduleService.java
+++ b/gg-calendar-api/src/main/java/gg/calendar/api/user/schedule/publicschedule/service/PublicScheduleService.java
@@ -94,13 +94,13 @@ public class PublicScheduleService {
 		return publicRetrieveSchedule;
 	}
 
-	public List<PublicSchedulePeriodRetrieveResDto> retrievePublicSchedulePeriod(LocalDateTime start, LocalDateTime end,
-		DetailClassification classification) {
+	public List<PublicSchedulePeriodRetrieveResDto> retrieveNonPrivateSchedulePeriod(LocalDateTime start,
+		LocalDateTime end) {
 		validateTimeRange(start, end);
-		List<PublicSchedule> classSchedules = publicScheduleRepository
-			.findByEndTimeGreaterThanEqualAndStartTimeLessThanEqualAndClassification(
-				start, end, classification);
-		return classSchedules.stream().map(PublicSchedulePeriodRetrieveResDto::toDto).collect(Collectors.toList());
+		List<PublicSchedule> nonPrivateSchedules = publicScheduleRepository
+			.findByEndTimeGreaterThanEqualAndStartTimeLessThanEqualAndClassificationNot(
+				start, end, DetailClassification.PRIVATE_SCHEDULE);
+		return nonPrivateSchedules.stream().map(PublicSchedulePeriodRetrieveResDto::toDto).collect(Collectors.toList());
 	}
 
 	@Transactional

--- a/gg-calendar-api/src/test/java/gg/calendar/api/user/schedule/publicschedule/controller/PublicScheduleControllerTest.java
+++ b/gg-calendar-api/src/test/java/gg/calendar/api/user/schedule/publicschedule/controller/PublicScheduleControllerTest.java
@@ -885,7 +885,7 @@ public class PublicScheduleControllerTest {
 	@DisplayName("공유일정기간조회")
 	class RetrievePublicScheduleByPeriod {
 		@Test
-		@DisplayName("[200]공개일정 event 기간조회성공")
+		@DisplayName("[200]공개일정 기간조회성공 (비공개일정 제외)")
 		void retrievePublicScheduleByEventPeriodSuccess() throws Exception {
 			//given
 			mockData.createPublicScheduleEvent(7);
@@ -894,7 +894,7 @@ public class PublicScheduleControllerTest {
 			LocalDateTime end = LocalDateTime.now().plusDays(7);
 			//when
 			mockMvc.perform(
-					get("/calendar/public/period/{detail_classification}", detailClassification).header("Authorization",
+					get("/calendar/public", detailClassification).header("Authorization",
 							"Bearer " + accessToken)
 						.param("start", start.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")))
 						.param("end", end.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"))))
@@ -902,8 +902,11 @@ public class PublicScheduleControllerTest {
 				.andDo(print());
 
 			//then
-			assertThat(publicScheduleRepository.findAll()).hasSize(7);
-			assertThat(publicScheduleRepository.findAll()).extracting("classification")
+			List<PublicSchedule> allSchedules = publicScheduleRepository.findAll();
+			assertThat(allSchedules).hasSize(7); // Total of 5 EVENT + 2 OTHER_TYPE
+
+			// Verify classifications of returned schedules
+			assertThat(allSchedules).extracting("classification")
 				.containsOnly(DetailClassification.EVENT);
 		}
 
@@ -917,7 +920,7 @@ public class PublicScheduleControllerTest {
 			LocalDateTime end = LocalDateTime.now().plusDays(7);
 			//when
 			mockMvc.perform(
-					get("/calendar/public/period/{detail_classification}",
+					get("/calendar/public",
 						detailClassification).header("Authorization",
 							"Bearer " + accessToken).param("start",
 							start.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")))
@@ -940,33 +943,12 @@ public class PublicScheduleControllerTest {
 			LocalDateTime end = LocalDateTime.now().minusDays(7);
 			//when & then
 			mockMvc.perform(
-					get("/calendar/public/period/{detail_classification}",
+					get("/calendar/public",
 						detailClassification).header("Authorization",
 							"Bearer " + accessToken).param("start",
 							start.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")))
 						.param("end", end.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"))))
 				.andExpect(status().isBadRequest())
-				.andDo(print());
-		}
-
-		@Test
-		@DisplayName("[400]공개일정 조회실패 - 잘못된 detail_classification 이 들어왔을 때")
-		void retrievePublicScheduleFaultDetailClassification() throws Exception {
-			// given
-			mockData.createPublicScheduleEvent(7);
-			LocalDateTime start = LocalDateTime.now().plusDays(0);
-			LocalDateTime end = LocalDateTime.now().plusDays(7);
-			//when & then
-			mockMvc.perform(get("/calendar/public/period/{detail_classification}", "wrong")
-					.header("Authorization",
-						"Bearer " + accessToken).param("start", start.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")))
-					.param("end", end.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"))))
-				.andExpect(status().isBadRequest())
-				.andExpect(result -> {
-					// 에러 응답의 세부 내용 출력
-					System.out.println("Response Body: " + result.getResponse().getContentAsString());
-					System.out.println("Status Code: " + result.getResponse().getStatus());
-				})
 				.andDo(print());
 		}
 
@@ -980,7 +962,7 @@ public class PublicScheduleControllerTest {
 			LocalDateTime end = LocalDateTime.now().plusDays(7);
 			//when & then
 			mockMvc.perform(
-					get("/calendar/public/period/{detail_classification}",
+					get("/calendar/public/",
 						detailClassification).header("Authorization",
 							"Bearer " + accessToken).param("start",
 							start.format(DateTimeFormatter.ofPattern("yyyy/MM/dd")))

--- a/gg-pingpong-api/src/test/resources/application.yml
+++ b/gg-pingpong-api/src/test/resources/application.yml
@@ -75,7 +75,7 @@ info:
   web:
     coalitionUrl: 'https://api.intra.42.fr/v2/users/{id}/coalitions'
     pointHistoryUrl: 'https://api.intra.42.fr/v2/users/{id}/correction_point_historics?sort=-id'
-    
+
 constant:
   allowedMinimalStartDays: 2
   tournamentSchedule: "0 0 0 * * *"

--- a/gg-repo/src/main/java/gg/repo/calendar/PublicScheduleRepository.java
+++ b/gg-repo/src/main/java/gg/repo/calendar/PublicScheduleRepository.java
@@ -25,6 +25,9 @@ public interface PublicScheduleRepository extends JpaRepository<PublicSchedule, 
 	List<PublicSchedule> findByEndTimeGreaterThanEqualAndStartTimeLessThanEqualAndClassification(
 		LocalDateTime startTime, LocalDateTime endTime, DetailClassification classification);
 
+	List<PublicSchedule> findByEndTimeGreaterThanEqualAndStartTimeLessThanEqualAndClassificationNot(
+		LocalDateTime start, LocalDateTime end, DetailClassification classification);
+
 	boolean existsByTitleAndStartTime(String title, LocalDateTime beginAt);
 
 	@Modifying(clearAutomatically = true)


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - PublicSchedule에서 PrivateSchedule을 불러오지 못하게 api수정
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - 기존 PublicSchedule에서 모든 schedule불러오는 부분->private만 제외하고 올려지게 수정
 ## ✅ 변경로직 <!-- 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
  - 기존 PublicSchedule에서 모든 schedule불러오는 부분->private만 제외하고 올려지게 수정
 ## 💡Issue 번호 <!-- issue number을 link 시켜주세요 (ex. "- close #4242") -->
 - #1163 