### PR TITLE
🔨 [Refactoring] ScheduleCustom 삭제 시, 연관된 PrivateSchedule 전체 삭제되도록 수정

### DIFF
--- a/gg-calendar-api/src/main/java/gg/calendar/api/user/custom/service/CalendarCustomService.java
+++ b/gg-calendar-api/src/main/java/gg/calendar/api/user/custom/service/CalendarCustomService.java
@@ -65,7 +65,7 @@ public class CalendarCustomService {
 			} else {
 				privateSchedule.delete();
 			}
-			scheduleGroupRepository.delete(scheduleGroup);
 		}
+		scheduleGroupRepository.delete(scheduleGroup);
 	}
 }

--- a/gg-calendar-api/src/main/java/gg/calendar/api/user/custom/service/CalendarCustomService.java
+++ b/gg-calendar-api/src/main/java/gg/calendar/api/user/custom/service/CalendarCustomService.java
@@ -11,8 +11,11 @@ import gg.calendar.api.user.custom.controller.request.CalendarCustomCreateReqDto
 import gg.calendar.api.user.custom.controller.request.CalendarCustomUpdateReqDto;
 import gg.calendar.api.user.custom.controller.response.CalendarCustomUpdateResDto;
 import gg.calendar.api.user.custom.controller.response.CalendarCustomViewResDto;
+import gg.data.calendar.PrivateSchedule;
 import gg.data.calendar.ScheduleGroup;
+import gg.data.calendar.type.DetailClassification;
 import gg.data.user.User;
+import gg.repo.calendar.PrivateScheduleRepository;
 import gg.repo.calendar.ScheduleGroupRepository;
 import gg.repo.user.UserRepository;
 import gg.utils.exception.ErrorCode;
@@ -25,6 +28,7 @@ import lombok.RequiredArgsConstructor;
 public class CalendarCustomService {
 	private final ScheduleGroupRepository scheduleGroupRepository;
 	private final UserRepository userRepository;
+	private final PrivateScheduleRepository privateScheduleRepository;
 
 	@Transactional
 	public void createScheduleGroup(UserDto userDto, CalendarCustomCreateReqDto calendarCustomCreateReqDto) {
@@ -53,6 +57,15 @@ public class CalendarCustomService {
 	public void deleteScheduleGroup(UserDto userDto, Long scheduleGroupId) {
 		ScheduleGroup scheduleGroup = scheduleGroupRepository.findByIdAndUserId(scheduleGroupId, userDto.getId())
 			.orElseThrow(() -> new NotExistException(ErrorCode.SCHEDULE_GROUP_NOT_FOUND));
-		scheduleGroupRepository.delete(scheduleGroup);
+
+		List<PrivateSchedule> privateSchedules = privateScheduleRepository.findByGroupId(scheduleGroupId);
+		for (PrivateSchedule privateSchedule : privateSchedules) {
+			if (privateSchedule.getPublicSchedule().getClassification().equals(DetailClassification.PRIVATE_SCHEDULE)) {
+				privateSchedule.deleteCascade();
+			} else {
+				privateSchedule.delete();
+			}
+			scheduleGroupRepository.delete(scheduleGroup);
+		}
 	}
 }

--- a/gg-calendar-api/src/main/java/gg/calendar/api/user/schedule/publicschedule/service/PublicScheduleService.java
+++ b/gg-calendar-api/src/main/java/gg/calendar/api/user/schedule/publicschedule/service/PublicScheduleService.java
@@ -117,7 +117,7 @@ public class PublicScheduleService {
 			.orElseThrow(() -> new NotExistException(ErrorCode.SCHEDULE_GROUP_NOT_FOUND));
 		PrivateSchedule privateSchedule = new PrivateSchedule(user, publicSchedule, false, groupId);
 		privateScheduleRepository.save(privateSchedule);
-		publicSchedule.incrementSharedCount();
+		publicScheduleRepository.incrementSharedCount(publicSchedule.getId());
 	}
 
 	private void checkAuthor(String author, User user) {

--- a/gg-calendar-api/src/main/java/gg/calendar/api/user/schedule/publicschedule/service/PublicScheduleService.java
+++ b/gg-calendar-api/src/main/java/gg/calendar/api/user/schedule/publicschedule/service/PublicScheduleService.java
@@ -103,8 +103,9 @@ public class PublicScheduleService {
 	public List<PublicSchedulePeriodRetrieveResDto> retrieveNonPrivateSchedulePeriod(LocalDateTime start,
 		LocalDateTime end) {
 		validateTimeRange(start, end);
-		List<PublicSchedule> nonPrivateSchedules = publicScheduleRepository.findByEndTimeGreaterThanEqualAndStartTimeLessThanEqualAndClassificationNotAndStatusNot(
-			start, end, DetailClassification.PRIVATE_SCHEDULE, ScheduleStatus.DELETE);
+		List<PublicSchedule> nonPrivateSchedules = publicScheduleRepository
+			.findByEndTimeGreaterThanEqualAndStartTimeLessThanEqualAndClassificationNotAndStatusNot(
+				start, end, DetailClassification.PRIVATE_SCHEDULE, ScheduleStatus.DELETE);
 		return nonPrivateSchedules.stream().map(PublicSchedulePeriodRetrieveResDto::toDto).collect(Collectors.toList());
 	}
 

--- a/gg-calendar-api/src/main/java/gg/calendar/api/user/schedule/publicschedule/service/PublicScheduleService.java
+++ b/gg-calendar-api/src/main/java/gg/calendar/api/user/schedule/publicschedule/service/PublicScheduleService.java
@@ -4,6 +4,9 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -39,6 +42,9 @@ public class PublicScheduleService {
 	private final PrivateScheduleRepository privateScheduleRepository;
 	private final ScheduleGroupRepository scheduleGroupRepository;
 
+	@PersistenceContext
+	private EntityManager entityManager;
+
 	@Transactional
 	public void createEventPublicSchedule(PublicScheduleCreateEventReqDto req, Long userId) {
 		User user = userRepository.getById(userId);
@@ -62,8 +68,7 @@ public class PublicScheduleService {
 		tagErrorCheck(req.getClassification(), req.getEventTag(), req.getJobTag(), req.getTechTag());
 		User user = userRepository.getById(userId);
 		PublicSchedule existingSchedule = publicScheduleRepository.findByIdAndStatusNot(scheduleId,
-				ScheduleStatus.DELETE)
-			.orElseThrow(() -> new NotExistException(ErrorCode.PUBLIC_SCHEDULE_NOT_FOUND));
+			ScheduleStatus.DELETE).orElseThrow(() -> new NotExistException(ErrorCode.PUBLIC_SCHEDULE_NOT_FOUND));
 		checkAuthor(existingSchedule.getAuthor(), user);
 		checkAuthor(req.getAuthor(), user);
 		validateTimeRange(req.getStartTime(), req.getEndTime());
@@ -76,8 +81,7 @@ public class PublicScheduleService {
 	public void deletePublicSchedule(Long scheduleId, Long userId) {
 		User user = userRepository.getById(userId);
 		PublicSchedule existingSchedule = publicScheduleRepository.findByIdAndStatusNot(scheduleId,
-				ScheduleStatus.DELETE)
-			.orElseThrow(() -> new NotExistException(ErrorCode.PUBLIC_SCHEDULE_NOT_FOUND));
+			ScheduleStatus.DELETE).orElseThrow(() -> new NotExistException(ErrorCode.PUBLIC_SCHEDULE_NOT_FOUND));
 		checkAuthor(existingSchedule.getAuthor(), user);
 
 		List<PrivateSchedule> privateSchedules = privateScheduleRepository.findByPublicSchedule(existingSchedule);
@@ -92,17 +96,15 @@ public class PublicScheduleService {
 	public PublicSchedule getPublicScheduleDetailRetrieve(Long scheduleId, Long userId) {
 		User user = userRepository.getById(userId);
 		PublicSchedule publicRetrieveSchedule = publicScheduleRepository.findByIdAndStatusNot(scheduleId,
-				ScheduleStatus.DELETE)
-			.orElseThrow(() -> new NotExistException(ErrorCode.PUBLIC_SCHEDULE_NOT_FOUND));
+			ScheduleStatus.DELETE).orElseThrow(() -> new NotExistException(ErrorCode.PUBLIC_SCHEDULE_NOT_FOUND));
 		return publicRetrieveSchedule;
 	}
 
 	public List<PublicSchedulePeriodRetrieveResDto> retrieveNonPrivateSchedulePeriod(LocalDateTime start,
 		LocalDateTime end) {
 		validateTimeRange(start, end);
-		List<PublicSchedule> nonPrivateSchedules = publicScheduleRepository
-			.findByEndTimeGreaterThanEqualAndStartTimeLessThanEqualAndClassificationNotAndStatusNot(
-				start, end, DetailClassification.PRIVATE_SCHEDULE, ScheduleStatus.DELETE);
+		List<PublicSchedule> nonPrivateSchedules = publicScheduleRepository.findByEndTimeGreaterThanEqualAndStartTimeLessThanEqualAndClassificationNotAndStatusNot(
+			start, end, DetailClassification.PRIVATE_SCHEDULE, ScheduleStatus.DELETE);
 		return nonPrivateSchedules.stream().map(PublicSchedulePeriodRetrieveResDto::toDto).collect(Collectors.toList());
 	}
 
@@ -110,13 +112,14 @@ public class PublicScheduleService {
 	public void addPublicScheduleToPrivateSchedule(Long scheduleId, Long groupId, UserDto userDto) {
 		User user = userRepository.getById(userDto.getId());
 		Long userId = userDto.getId();
-		PublicSchedule publicSchedule = publicScheduleRepository.findByIdAndStatusNot(scheduleId,
-				ScheduleStatus.DELETE)
+		PublicSchedule publicSchedule = publicScheduleRepository.findByIdAndStatusNot(scheduleId, ScheduleStatus.DELETE)
 			.orElseThrow(() -> new NotExistException(ErrorCode.PUBLIC_SCHEDULE_NOT_FOUND));
 		scheduleGroupRepository.findByIdAndUserId(groupId, userId)
 			.orElseThrow(() -> new NotExistException(ErrorCode.SCHEDULE_GROUP_NOT_FOUND));
 		PrivateSchedule privateSchedule = new PrivateSchedule(user, publicSchedule, false, groupId);
 		privateScheduleRepository.save(privateSchedule);
+		entityManager.flush();
+		entityManager.clear();
 		publicScheduleRepository.incrementSharedCount(publicSchedule.getId());
 	}
 

--- a/gg-calendar-api/src/main/java/gg/calendar/api/user/schedule/publicschedule/service/PublicScheduleService.java
+++ b/gg-calendar-api/src/main/java/gg/calendar/api/user/schedule/publicschedule/service/PublicScheduleService.java
@@ -120,7 +120,6 @@ public class PublicScheduleService {
 		PrivateSchedule privateSchedule = new PrivateSchedule(user, publicSchedule, false, groupId);
 		privateScheduleRepository.save(privateSchedule);
 		entityManager.flush();
-		entityManager.clear();
 		publicScheduleRepository.incrementSharedCount(publicSchedule.getId());
 	}
 

--- a/gg-calendar-api/src/test/java/gg/calendar/api/user/custom/controller/CalendarCustomControllerTest.java
+++ b/gg-calendar-api/src/test/java/gg/calendar/api/user/custom/controller/CalendarCustomControllerTest.java
@@ -23,8 +23,14 @@ import gg.calendar.api.user.custom.CalendarCustomMockData;
 import gg.calendar.api.user.custom.controller.request.CalendarCustomCreateReqDto;
 import gg.calendar.api.user.custom.controller.request.CalendarCustomUpdateReqDto;
 import gg.calendar.api.user.custom.controller.response.CalendarCustomViewResDto;
+import gg.calendar.api.user.schedule.privateschedule.PrivateScheduleMockData;
+import gg.data.calendar.PrivateSchedule;
+import gg.data.calendar.PublicSchedule;
 import gg.data.calendar.ScheduleGroup;
+import gg.data.calendar.type.DetailClassification;
+import gg.data.calendar.type.ScheduleStatus;
 import gg.data.user.User;
+import gg.repo.calendar.PrivateScheduleRepository;
 import gg.repo.calendar.ScheduleGroupRepository;
 import gg.utils.TestDataUtils;
 import gg.utils.annotation.IntegrationTest;
@@ -46,7 +52,13 @@ public class CalendarCustomControllerTest {
 	private ScheduleGroupRepository scheduleGroupRepository;
 
 	@Autowired
+	private PrivateScheduleRepository privateScheduleRepository;
+
+	@Autowired
 	private CalendarCustomMockData calendarCustomMockData;
+
+	@Autowired
+	private PrivateScheduleMockData privateScheduleMockData;
 
 	@Autowired
 	private TestDataUtils testDataUtils;
@@ -236,6 +248,52 @@ public class CalendarCustomControllerTest {
 					.header("Authorization", "Bearer " + accessToken)
 					.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().isNotFound());
+		}
+
+		@Test
+		@DisplayName("스케줄 그룹을 삭제했을 때, 연관된 PrivateSchedule이 삭제되는 경우 204")
+		void deleteCascade() throws Exception {
+			//given
+			ScheduleGroup scheduleGroup = calendarCustomMockData.createScheduleGroup(user);
+			PublicSchedule publicSchedule = privateScheduleMockData.createPublicSchedule(user.getIntraId(),
+				DetailClassification.PRIVATE_SCHEDULE);
+			PrivateSchedule privateSchedule = privateScheduleMockData.createPrivateSchedule(user, publicSchedule,
+				scheduleGroup.getId());
+			//when
+			mockMvc.perform(delete("/calendar/custom/" + scheduleGroup.getId())
+					.header("Authorization", "Bearer " + accessToken)
+					.contentType(MediaType.APPLICATION_JSON))
+				.andExpect(status().isNoContent());
+			List<ScheduleGroup> empty = scheduleGroupRepository.findAll();
+			//then
+			Assertions.assertThat(empty.size()).isEqualTo(0);
+			privateScheduleRepository.findById(privateSchedule.getId()).ifPresent(ps -> {
+				Assertions.assertThat(ps.getStatus()).isEqualTo(ScheduleStatus.DELETE);
+				Assertions.assertThat(ps.getPublicSchedule().getStatus()).isEqualTo(ScheduleStatus.DELETE);
+			});
+		}
+
+		@Test
+		@DisplayName("스케줄 그룹을 삭제했을 때, 연관된 PublicSchedule은 삭제되지 않는 경우 204")
+		void deleteNotCascade() throws Exception {
+			//given
+			ScheduleGroup scheduleGroup = calendarCustomMockData.createScheduleGroup(user);
+			PublicSchedule publicSchedule = privateScheduleMockData.createPublicSchedule(user.getIntraId(),
+				DetailClassification.JOB_NOTICE);
+			PrivateSchedule privateSchedule = privateScheduleMockData.createPrivateSchedule(user, publicSchedule,
+				scheduleGroup.getId());
+			//when
+			mockMvc.perform(delete("/calendar/custom/" + scheduleGroup.getId())
+					.header("Authorization", "Bearer " + accessToken)
+					.contentType(MediaType.APPLICATION_JSON))
+				.andExpect(status().isNoContent());
+			List<ScheduleGroup> empty = scheduleGroupRepository.findAll();
+			//then
+			Assertions.assertThat(empty.size()).isEqualTo(0);
+			privateScheduleRepository.findById(privateSchedule.getId()).ifPresent(ps -> {
+				Assertions.assertThat(ps.getStatus()).isEqualTo(ScheduleStatus.DELETE);
+				Assertions.assertThat(ps.getPublicSchedule().getStatus()).isEqualTo(ScheduleStatus.ACTIVATE);
+			});
 		}
 	}
 }

--- a/gg-data/src/main/java/gg/data/calendar/PublicSchedule.java
+++ b/gg-data/src/main/java/gg/data/calendar/PublicSchedule.java
@@ -103,8 +103,8 @@ public class PublicSchedule extends BaseTimeEntity {
 		this.status = ScheduleStatus.DELETE;
 	}
 
-	public void incrementSharedCount() {
-		this.sharedCount++;
-	}
+	// public void incrementSharedCount() {
+	// 	this.sharedCount++;
+	// }
 }
 

--- a/gg-repo/src/main/java/gg/repo/calendar/PrivateScheduleRepository.java
+++ b/gg-repo/src/main/java/gg/repo/calendar/PrivateScheduleRepository.java
@@ -23,7 +23,7 @@ public interface PrivateScheduleRepository extends JpaRepository<PrivateSchedule
 
 	List<PrivateSchedule> findByPublicSchedule(PublicSchedule publicSchedule);
 
-	List<PrivateSchedule> findByGroupId(Long GroupId);
+	List<PrivateSchedule> findByGroupId(Long groupId);
 
 	@Query("SELECT pr FROM PrivateSchedule pr "
 		+ "JOIN pr.publicSchedule pu "

--- a/gg-repo/src/main/java/gg/repo/calendar/PrivateScheduleRepository.java
+++ b/gg-repo/src/main/java/gg/repo/calendar/PrivateScheduleRepository.java
@@ -23,6 +23,8 @@ public interface PrivateScheduleRepository extends JpaRepository<PrivateSchedule
 
 	List<PrivateSchedule> findByPublicSchedule(PublicSchedule publicSchedule);
 
+	List<PrivateSchedule> findByGroupId(Long GroupId);
+
 	@Query("SELECT pr FROM PrivateSchedule pr "
 		+ "JOIN pr.publicSchedule pu "
 		+ "WHERE NOT (pu.startTime > :endTime OR pu.endTime < :startTime) "

--- a/gg-repo/src/main/java/gg/repo/calendar/PublicScheduleRepository.java
+++ b/gg-repo/src/main/java/gg/repo/calendar/PublicScheduleRepository.java
@@ -30,11 +30,15 @@ public interface PublicScheduleRepository extends JpaRepository<PublicSchedule, 
 	List<PublicSchedule> findByEndTimeGreaterThanEqualAndStartTimeLessThanEqualAndClassificationNotAndStatusNot(
 		LocalDateTime start, LocalDateTime end, DetailClassification classification, ScheduleStatus status);
 
-
 	@Modifying(clearAutomatically = true)
 	@Transactional
 	@Query("UPDATE PublicSchedule ps SET ps.status = :status WHERE ps.status = :currentStatus AND ps.endTime < :time")
 	void updateExpiredPublicSchedules(@Param("status") ScheduleStatus status,
 		@Param("currentStatus") ScheduleStatus currentStatus,
 		@Param("time") LocalDateTime time);
+
+	@Modifying
+	@Query("UPDATE PublicSchedule p SET p.sharedCount = p.sharedCount + 1 WHERE p.id = :scheduleId")
+	void incrementSharedCount(@Param("scheduleId") Long scheduleId);
+
 }


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - [Refactoring] ScheduleCustom 삭제 시, 연관된 PrivateSchedule 전체 삭제되도록 수정
 ## ✅ 변경로직 <!-- 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
  - addPublicScheduleToPrivateSchedule 내부에서 데드락이 발생하는걸 해결 테스트 해봐야함
  - ScheduleGroup 삭제 시 연관된 스케줄 삭제
 ## 💡Issue 번호 <!-- issue number을 link 시켜주세요 (ex. "- close #4242") -->
 - #1185 