### PR TITLE
🔨 [Refactoring] 개인일정, 전체일정 업데이트 시, 현재 시간과 비교해서 활성상태값 변경 로직 수정

### DIFF
--- a/gg-calendar-api/src/main/java/gg/calendar/api/admin/schedule/publicschedule/service/PublicScheduleAdminService.java
+++ b/gg-calendar-api/src/main/java/gg/calendar/api/admin/schedule/publicschedule/service/PublicScheduleAdminService.java
@@ -18,6 +18,7 @@ import gg.data.calendar.PublicSchedule;
 import gg.data.calendar.type.DetailClassification;
 import gg.data.calendar.type.EventTag;
 import gg.data.calendar.type.JobTag;
+import gg.data.calendar.type.ScheduleStatus;
 import gg.data.calendar.type.TechTag;
 import gg.utils.exception.ErrorCode;
 import gg.utils.exception.custom.InvalidParameterException;
@@ -69,7 +70,8 @@ public class PublicScheduleAdminService {
 			publicScheduleAdminUpdateReqDto.getEventTag(), publicScheduleAdminUpdateReqDto.getJobTag(),
 			publicScheduleAdminUpdateReqDto.getTechTag(), publicScheduleAdminUpdateReqDto.getTitle(),
 			publicScheduleAdminUpdateReqDto.getContent(), publicScheduleAdminUpdateReqDto.getLink(),
-			publicScheduleAdminUpdateReqDto.getStartTime(), publicScheduleAdminUpdateReqDto.getEndTime());
+			publicScheduleAdminUpdateReqDto.getStartTime(), publicScheduleAdminUpdateReqDto.getEndTime(),
+			checkStatus(publicScheduleAdminUpdateReqDto.getEndTime()));
 
 		return PublicScheduleAdminUpdateResDto.toDto(publicSchedule);
 	}
@@ -104,6 +106,10 @@ public class PublicScheduleAdminService {
 		if (!classification.isValid(eventTag, jobTag, techTag)) {
 			throw new InvalidParameterException(ErrorCode.CLASSIFICATION_NOT_MATCH);
 		}
+	}
+
+	private ScheduleStatus checkStatus(LocalDateTime endTime) {
+		return endTime.isBefore(LocalDateTime.now()) ? ScheduleStatus.DEACTIVATE : ScheduleStatus.ACTIVATE;
 	}
 
 }

--- a/gg-calendar-api/src/main/java/gg/calendar/api/user/schedule/privateschedule/service/PrivateScheduleService.java
+++ b/gg-calendar-api/src/main/java/gg/calendar/api/user/schedule/privateschedule/service/PrivateScheduleService.java
@@ -51,7 +51,8 @@ public class PrivateScheduleService {
 			.orElseThrow(() -> new NotExistException(ErrorCode.SCHEDULE_GROUP_NOT_FOUND));
 		User user = userRepository.getById(userDto.getId());
 		PrivateSchedule privateSchedule = new PrivateSchedule(user, publicSchedule,
-			privateScheduleCreateReqDto.isAlarm(), scheduleGroup.getId());
+			privateScheduleCreateReqDto.isAlarm(), scheduleGroup.getId(),
+			publicSchedule.getStatus());
 
 		privateScheduleRepository.save(privateSchedule);
 	}

--- a/gg-calendar-api/src/main/java/gg/calendar/api/user/schedule/privateschedule/service/PrivateScheduleService.java
+++ b/gg-calendar-api/src/main/java/gg/calendar/api/user/schedule/privateschedule/service/PrivateScheduleService.java
@@ -68,7 +68,8 @@ public class PrivateScheduleService {
 
 		privateSchedule.updateCascade(privateScheduleUpdateReqDto.getTitle(), privateScheduleUpdateReqDto.getContent(),
 			privateScheduleUpdateReqDto.getLink(), privateScheduleUpdateReqDto.getStartTime(),
-			privateScheduleUpdateReqDto.getEndTime(), privateScheduleUpdateReqDto.isAlarm(), scheduleGroup.getId());
+			privateScheduleUpdateReqDto.getEndTime(), privateScheduleUpdateReqDto.isAlarm(), scheduleGroup.getId(),
+			checkStatus(privateScheduleUpdateReqDto.getEndTime()));
 		return PrivateScheduleUpdateResDto.toDto(privateSchedule);
 	}
 
@@ -127,5 +128,9 @@ public class PrivateScheduleService {
 		if (!intraId.equals(author)) {
 			throw new ForbiddenException(ErrorCode.CALENDAR_AUTHOR_NOT_MATCH);
 		}
+	}
+
+	private ScheduleStatus checkStatus(LocalDateTime endTime) {
+		return endTime.isBefore(LocalDateTime.now()) ? ScheduleStatus.DEACTIVATE : ScheduleStatus.ACTIVATE;
 	}
 }

--- a/gg-calendar-api/src/main/java/gg/calendar/api/user/schedule/publicschedule/controller/request/PublicScheduleCreateEventReqDto.java
+++ b/gg-calendar-api/src/main/java/gg/calendar/api/user/schedule/publicschedule/controller/request/PublicScheduleCreateEventReqDto.java
@@ -51,7 +51,7 @@ public class PublicScheduleCreateEventReqDto {
 		this.endTime = endTime;
 	}
 
-	public static PublicSchedule toEntity(String intraId, PublicScheduleCreateEventReqDto dto) {
+	public static PublicSchedule toEntity(String intraId, PublicScheduleCreateEventReqDto dto, ScheduleStatus status) {
 		return PublicSchedule.builder()
 			.classification(DetailClassification.EVENT)
 			.eventTag(dto.eventTag)
@@ -61,7 +61,7 @@ public class PublicScheduleCreateEventReqDto {
 			.link(dto.link)
 			.startTime(dto.startTime)
 			.endTime(dto.endTime)
-			.status(ScheduleStatus.ACTIVATE)
+			.status(status)
 			.build();
 	}
 }

--- a/gg-calendar-api/src/main/java/gg/calendar/api/user/schedule/publicschedule/controller/request/PublicScheduleCreateJobReqDto.java
+++ b/gg-calendar-api/src/main/java/gg/calendar/api/user/schedule/publicschedule/controller/request/PublicScheduleCreateJobReqDto.java
@@ -56,7 +56,7 @@ public class PublicScheduleCreateJobReqDto {
 		this.endTime = endTime;
 	}
 
-	public static PublicSchedule toEntity(String intraId, PublicScheduleCreateJobReqDto dto) {
+	public static PublicSchedule toEntity(String intraId, PublicScheduleCreateJobReqDto dto, ScheduleStatus status) {
 		return PublicSchedule.builder()
 			.classification(DetailClassification.JOB_NOTICE)
 			.jobTag(dto.jobTag)
@@ -67,7 +67,7 @@ public class PublicScheduleCreateJobReqDto {
 			.link(dto.link)
 			.startTime(dto.startTime)
 			.endTime(dto.endTime)
-			.status(ScheduleStatus.ACTIVATE)
+			.status(status)
 			.build();
 	}
 

--- a/gg-calendar-api/src/main/java/gg/calendar/api/user/schedule/publicschedule/service/PublicScheduleService.java
+++ b/gg-calendar-api/src/main/java/gg/calendar/api/user/schedule/publicschedule/service/PublicScheduleService.java
@@ -73,7 +73,8 @@ public class PublicScheduleService {
 		checkAuthor(req.getAuthor(), user);
 		validateTimeRange(req.getStartTime(), req.getEndTime());
 		existingSchedule.update(req.getClassification(), req.getEventTag(), req.getJobTag(), req.getTechTag(),
-			req.getTitle(), req.getContent(), req.getLink(), req.getStartTime(), req.getEndTime());
+			req.getTitle(), req.getContent(), req.getLink(), req.getStartTime(), req.getEndTime(),
+			checkStatus(req.getEndTime()));
 		return existingSchedule;
 	}
 
@@ -139,5 +140,9 @@ public class PublicScheduleService {
 		if (!classification.isValid(eventTag, jobTag, techTag)) {
 			throw new InvalidParameterException(ErrorCode.CLASSIFICATION_NOT_MATCH);
 		}
+	}
+
+	private ScheduleStatus checkStatus(LocalDateTime endTime) {
+		return endTime.isBefore(LocalDateTime.now()) ? ScheduleStatus.DEACTIVATE : ScheduleStatus.ACTIVATE;
 	}
 }

--- a/gg-calendar-api/src/main/java/gg/calendar/api/user/schedule/publicschedule/service/PublicScheduleService.java
+++ b/gg-calendar-api/src/main/java/gg/calendar/api/user/schedule/publicschedule/service/PublicScheduleService.java
@@ -50,7 +50,8 @@ public class PublicScheduleService {
 		User user = userRepository.getById(userId);
 		checkAuthor(req.getAuthor(), user);
 		validateTimeRange(req.getStartTime(), req.getEndTime());
-		PublicSchedule eventPublicSchedule = PublicScheduleCreateEventReqDto.toEntity(user.getIntraId(), req);
+		PublicSchedule eventPublicSchedule = PublicScheduleCreateEventReqDto.toEntity(user.getIntraId(), req,
+			checkStatus(req.getEndTime()));
 		publicScheduleRepository.save(eventPublicSchedule);
 	}
 
@@ -59,7 +60,8 @@ public class PublicScheduleService {
 		User user = userRepository.getById(userId);
 		checkAuthor(req.getAuthor(), user);
 		validateTimeRange(req.getStartTime(), req.getEndTime());
-		PublicSchedule jobPublicSchedule = PublicScheduleCreateJobReqDto.toEntity(user.getIntraId(), req);
+		PublicSchedule jobPublicSchedule = PublicScheduleCreateJobReqDto.toEntity(user.getIntraId(), req,
+			checkStatus(req.getEndTime()));
 		publicScheduleRepository.save(jobPublicSchedule);
 	}
 
@@ -68,13 +70,21 @@ public class PublicScheduleService {
 		tagErrorCheck(req.getClassification(), req.getEventTag(), req.getJobTag(), req.getTechTag());
 		User user = userRepository.getById(userId);
 		PublicSchedule existingSchedule = publicScheduleRepository.findByIdAndStatusNot(scheduleId,
-			ScheduleStatus.DELETE).orElseThrow(() -> new NotExistException(ErrorCode.PUBLIC_SCHEDULE_NOT_FOUND));
+				ScheduleStatus.DELETE)
+			.orElseThrow(() -> new NotExistException(ErrorCode.PUBLIC_SCHEDULE_NOT_FOUND));
 		checkAuthor(existingSchedule.getAuthor(), user);
 		checkAuthor(req.getAuthor(), user);
 		validateTimeRange(req.getStartTime(), req.getEndTime());
+
+		// PublicSchedule 업데이트
 		existingSchedule.update(req.getClassification(), req.getEventTag(), req.getJobTag(), req.getTechTag(),
 			req.getTitle(), req.getContent(), req.getLink(), req.getStartTime(), req.getEndTime(),
 			checkStatus(req.getEndTime()));
+
+		// 벌크 업데이트 적용 (SELECT 없이 바로 UPDATE 실행)
+		ScheduleStatus status = checkStatus(req.getEndTime());
+		privateScheduleRepository.bulkUpdateScheduleStatus(existingSchedule, status);
+
 		return existingSchedule;
 	}
 
@@ -118,7 +128,8 @@ public class PublicScheduleService {
 			.orElseThrow(() -> new NotExistException(ErrorCode.PUBLIC_SCHEDULE_NOT_FOUND));
 		scheduleGroupRepository.findByIdAndUserId(groupId, userId)
 			.orElseThrow(() -> new NotExistException(ErrorCode.SCHEDULE_GROUP_NOT_FOUND));
-		PrivateSchedule privateSchedule = new PrivateSchedule(user, publicSchedule, false, groupId);
+		PrivateSchedule privateSchedule = new PrivateSchedule(user, publicSchedule, false, groupId,
+			publicSchedule.getStatus());
 		privateScheduleRepository.save(privateSchedule);
 		entityManager.flush();
 		publicScheduleRepository.incrementSharedCount(publicSchedule.getId());

--- a/gg-calendar-api/src/test/java/gg/calendar/api/admin/schedule/privateschedule/PrivateScheduleAdminMockData.java
+++ b/gg-calendar-api/src/test/java/gg/calendar/api/admin/schedule/privateschedule/PrivateScheduleAdminMockData.java
@@ -68,13 +68,13 @@ public class PrivateScheduleAdminMockData {
 
 	public PrivateSchedule createPrivateSchedule(PublicSchedule publicSchedule, ScheduleGroup scheduleGroup) {
 		PrivateSchedule privateSchedule = new PrivateSchedule(scheduleGroup.getUser(), publicSchedule, false,
-			scheduleGroup.getId());
+			scheduleGroup.getId(), ScheduleStatus.ACTIVATE);
 		return privateScheduleRepository.save(privateSchedule);
 	}
 
 	public PrivateSchedule createPrivateScheduleNoGroup(PublicSchedule publicSchedule, User user) {
 		PrivateSchedule privateSchedule = new PrivateSchedule(user, publicSchedule, false,
-			500L);
+			500L, ScheduleStatus.ACTIVATE);
 		return privateScheduleRepository.save(privateSchedule);
 	}
 
@@ -100,7 +100,7 @@ public class PrivateScheduleAdminMockData {
 			scheduleGroupRepository.save(scheduleGroup);
 
 			PrivateSchedule privateSchedule = new PrivateSchedule(user, publicSchedule, false,
-				scheduleGroup.getId());
+				scheduleGroup.getId(), ScheduleStatus.ACTIVATE);
 		}
 	}
 }

--- a/gg-calendar-api/src/test/java/gg/calendar/api/admin/schedule/publicschedule/controller/PublicScheduleAdminControllerTest.java
+++ b/gg-calendar-api/src/test/java/gg/calendar/api/admin/schedule/publicschedule/controller/PublicScheduleAdminControllerTest.java
@@ -754,8 +754,10 @@ public class PublicScheduleAdminControllerTest {
 				.build();
 			scheduleGroupAdminRepository.save(scheduleGroup);
 			scheduleGroupAdminRepository.save(scheduleGroup2);
-			PrivateSchedule privateSchedule1 = new PrivateSchedule(other, publicSchedule, false, scheduleGroup.getId());
-			PrivateSchedule privateSchedule2 = new PrivateSchedule(user, publicSchedule, false, scheduleGroup2.getId());
+			PrivateSchedule privateSchedule1 = new PrivateSchedule(other, publicSchedule, false, scheduleGroup.getId(),
+				ScheduleStatus.ACTIVATE);
+			PrivateSchedule privateSchedule2 = new PrivateSchedule(user, publicSchedule, false, scheduleGroup2.getId(),
+				ScheduleStatus.ACTIVATE);
 			privateScheduleAdminRepository.save(privateSchedule1);
 			privateScheduleAdminRepository.save(privateSchedule2);
 			mockMvc.perform(patch("/admin/calendar/public/{id}", publicSchedule.getId()).header("Authorization",

--- a/gg-calendar-api/src/test/java/gg/calendar/api/user/schedule/privateschedule/PrivateScheduleMockData.java
+++ b/gg-calendar-api/src/test/java/gg/calendar/api/user/schedule/privateschedule/PrivateScheduleMockData.java
@@ -39,6 +39,23 @@ public class PrivateScheduleMockData {
 		return publicScheduleRepository.save(publicSchedule);
 	}
 
+	public PublicSchedule createPublicScheduleDeactivate(String author, DetailClassification classification) {
+		PublicSchedule publicSchedule = PublicSchedule.builder()
+			.classification(classification)
+			.eventTag(null)
+			.jobTag(null)
+			.techTag(null)
+			.title("Test Schedule")
+			.author(author)
+			.content("Test Content")
+			.link("http://test.com")
+			.status(ScheduleStatus.DEACTIVATE)
+			.startTime(LocalDateTime.now().minusDays(3))
+			.endTime(LocalDateTime.now().minusDays(1))
+			.build();
+		return publicScheduleRepository.save(publicSchedule);
+	}
+
 	public ScheduleGroup createScheduleGroup(User user) {
 		ScheduleGroup scheduleGroup = ScheduleGroup.builder()
 			.user(user)
@@ -49,7 +66,15 @@ public class PrivateScheduleMockData {
 	}
 
 	public PrivateSchedule createPrivateSchedule(User user, PublicSchedule publicSchedule, Long scheduleGroupId) {
-		PrivateSchedule privateSchedule = new PrivateSchedule(user, publicSchedule, false, scheduleGroupId);
+		PrivateSchedule privateSchedule = new PrivateSchedule(user, publicSchedule, false, scheduleGroupId,
+			ScheduleStatus.ACTIVATE);
+		return privateScheduleRepository.save(privateSchedule);
+	}
+
+	public PrivateSchedule createPrivateScheduleDeactivate(User user, PublicSchedule publicSchedule,
+		Long scheduleGroupId) {
+		PrivateSchedule privateSchedule = new PrivateSchedule(user, publicSchedule, false, scheduleGroupId,
+			ScheduleStatus.DEACTIVATE);
 		return privateScheduleRepository.save(privateSchedule);
 	}
 }

--- a/gg-calendar-api/src/test/java/gg/calendar/api/user/schedule/privateschedule/controller/PrivateScheduleControllerTest.java
+++ b/gg-calendar-api/src/test/java/gg/calendar/api/user/schedule/privateschedule/controller/PrivateScheduleControllerTest.java
@@ -182,6 +182,75 @@ public class PrivateScheduleControllerTest {
 		}
 
 		@Test
+		@DisplayName("성공 200 : DEACTIVATE -> ACTIVATE")
+		void successActivate() throws Exception {
+			//given
+			ScheduleGroup scheduleGroup = privateScheduleMockData.createScheduleGroup(user);
+			PublicSchedule publicSchedule = privateScheduleMockData.createPublicScheduleDeactivate(user.getIntraId(),
+				DetailClassification.PRIVATE_SCHEDULE);
+			PrivateSchedule privateSchedule = privateScheduleMockData.createPrivateScheduleDeactivate(user,
+				publicSchedule,
+				scheduleGroup.getId());
+			PrivateScheduleUpdateReqDto reqDto = PrivateScheduleUpdateReqDto.builder()
+				.alarm(false)
+				.title("123")
+				.content("")
+				.link(null)
+				.startTime(LocalDateTime.now())
+				.endTime(LocalDateTime.now().plusDays(1))
+				.groupId(scheduleGroup.getId())
+				.build();
+			//when
+			mockMvc.perform(put("/calendar/private/" + privateSchedule.getId())
+					.header("Authorization", "Bearer " + accessToken)
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(reqDto)))
+				.andExpect(status().isOk());
+			//then
+			PrivateSchedule updated = privateScheduleRepository.findById(privateSchedule.getId()).orElseThrow();
+			Assertions.assertThat(privateSchedule.getGroupId()).isEqualTo(updated.getGroupId());
+			Assertions.assertThat(privateSchedule.getAlarm()).isEqualTo(updated.getAlarm());
+			Assertions.assertThat(privateSchedule.getGroupId()).isEqualTo(updated.getGroupId());
+			Assertions.assertThat(privateSchedule.getPublicSchedule()).isEqualTo(updated.getPublicSchedule());
+			Assertions.assertThat(privateSchedule.getPublicSchedule().getStatus()).isEqualTo(ScheduleStatus.ACTIVATE);
+			Assertions.assertThat(privateSchedule.getStatus()).isEqualTo(ScheduleStatus.ACTIVATE);
+		}
+
+		@Test
+		@DisplayName("성공 200 : ACTIVATE -> DEACTIVATE")
+		void successDeactivate() throws Exception {
+			//given
+			ScheduleGroup scheduleGroup = privateScheduleMockData.createScheduleGroup(user);
+			PublicSchedule publicSchedule = privateScheduleMockData.createPublicSchedule(user.getIntraId(),
+				DetailClassification.PRIVATE_SCHEDULE);
+			PrivateSchedule privateSchedule = privateScheduleMockData.createPrivateSchedule(user, publicSchedule,
+				scheduleGroup.getId());
+			PrivateScheduleUpdateReqDto reqDto = PrivateScheduleUpdateReqDto.builder()
+				.alarm(false)
+				.title("123")
+				.content("")
+				.link(null)
+				.startTime(LocalDateTime.now().minusDays(3))
+				.endTime(LocalDateTime.now().minusDays(1))
+				.groupId(scheduleGroup.getId())
+				.build();
+			//when
+			mockMvc.perform(put("/calendar/private/" + privateSchedule.getId())
+					.header("Authorization", "Bearer " + accessToken)
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(reqDto)))
+				.andExpect(status().isOk());
+			//then
+			PrivateSchedule updated = privateScheduleRepository.findById(privateSchedule.getId()).orElseThrow();
+			Assertions.assertThat(privateSchedule.getGroupId()).isEqualTo(updated.getGroupId());
+			Assertions.assertThat(privateSchedule.getAlarm()).isEqualTo(updated.getAlarm());
+			Assertions.assertThat(privateSchedule.getGroupId()).isEqualTo(updated.getGroupId());
+			Assertions.assertThat(privateSchedule.getPublicSchedule()).isEqualTo(updated.getPublicSchedule());
+			Assertions.assertThat(privateSchedule.getPublicSchedule().getStatus()).isEqualTo(ScheduleStatus.DEACTIVATE);
+			Assertions.assertThat(privateSchedule.getStatus()).isEqualTo(ScheduleStatus.DEACTIVATE);
+		}
+
+		@Test
 		@DisplayName("종료 날짜가 시작 날짜보다 빠른 경우 400")
 		void endTimeBeforeStartTime() throws Exception {
 			//given

--- a/gg-calendar-api/src/test/java/gg/calendar/api/user/schedule/publicschedule/controller/PublicScheduleControllerTest.java
+++ b/gg-calendar-api/src/test/java/gg/calendar/api/user/schedule/publicschedule/controller/PublicScheduleControllerTest.java
@@ -249,7 +249,7 @@ public class PublicScheduleControllerTest {
 					.link("https://test.com")
 					.startTime(LocalDateTime.now())
 					.endTime(LocalDateTime.now().plusDays(1))
-					.build());
+					.build(), ScheduleStatus.ACTIVATE);
 			publicScheduleRepository.save(eventPublicSchedule);
 
 			PublicScheduleUpdateReqDto updateDto = PublicScheduleUpdateReqDto.builder()
@@ -277,6 +277,90 @@ public class PublicScheduleControllerTest {
 		}
 
 		@Test
+		@DisplayName("[200]공개일정업데이트성공시-42event : DEACTIVATE -> ACTIVATE")
+		void updateEventPublicScheduleSuccessActivate() throws Exception {
+			// given
+			PublicSchedule eventPublicSchedule = PublicSchedule.builder()
+				.classification(DetailClassification.EVENT)
+				.eventTag(EventTag.INSTRUCTION)
+				.author(user.getIntraId())
+				.title("42EventTag")
+				.content("42EventTagTest")
+				.link("https://test.com")
+				.status(ScheduleStatus.DEACTIVATE)
+				.startTime(LocalDateTime.now().minusDays(3))
+				.endTime(LocalDateTime.now().minusDays(1))
+				.build();
+			publicScheduleRepository.save(eventPublicSchedule);
+
+			PublicScheduleUpdateReqDto updateDto = PublicScheduleUpdateReqDto.builder()
+				.classification(DetailClassification.EVENT)
+				.eventTag(EventTag.INSTRUCTION)
+				.author(user.getIntraId())
+				.title("Updated Title")
+				.content("Updated Content")
+				.link("https://updated.com")
+				.startTime(LocalDateTime.now())
+				.endTime(LocalDateTime.now().plusDays(2))
+				.build();
+
+			// when
+			mockMvc.perform(
+				put("/calendar/public/" + eventPublicSchedule.getId()).header("Authorization", "Bearer " + accessToken)
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(updateDto))).andExpect(status().isOk());
+
+			// then
+			List<PublicSchedule> schedules = publicScheduleRepository.findByAuthor(user.getIntraId());
+			assertThat(schedules).hasSize(1);
+			assertThat(schedules.get(0).getTitle()).isEqualTo("Updated Title");
+			assertThat(schedules.get(0).getContent()).isEqualTo("Updated Content");
+			assertThat(schedules.get(0).getStatus()).isEqualTo(ScheduleStatus.ACTIVATE);
+		}
+
+		@Test
+		@DisplayName("[200]공개일정업데이트성공시-42event : ACTIVATE -> DEACTIVATE")
+		void updateEventPublicScheduleSuccessDeactivate() throws Exception {
+			// given
+			PublicSchedule eventPublicSchedule = PublicSchedule.builder()
+				.classification(DetailClassification.EVENT)
+				.eventTag(EventTag.INSTRUCTION)
+				.author(user.getIntraId())
+				.title("42EventTag")
+				.content("42EventTagTest")
+				.link("https://test.com")
+				.status(ScheduleStatus.ACTIVATE)
+				.startTime(LocalDateTime.now())
+				.endTime(LocalDateTime.now().plusDays(2))
+				.build();
+			publicScheduleRepository.save(eventPublicSchedule);
+
+			PublicScheduleUpdateReqDto updateDto = PublicScheduleUpdateReqDto.builder()
+				.classification(DetailClassification.EVENT)
+				.eventTag(EventTag.INSTRUCTION)
+				.author(user.getIntraId())
+				.title("Updated Title")
+				.content("Updated Content")
+				.link("https://updated.com")
+				.startTime(LocalDateTime.now().minusDays(3))
+				.endTime(LocalDateTime.now().minusDays(1))
+				.build();
+
+			// when
+			mockMvc.perform(
+				put("/calendar/public/" + eventPublicSchedule.getId()).header("Authorization", "Bearer " + accessToken)
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(updateDto))).andExpect(status().isOk());
+
+			// then
+			List<PublicSchedule> schedules = publicScheduleRepository.findByAuthor(user.getIntraId());
+			assertThat(schedules).hasSize(1);
+			assertThat(schedules.get(0).getTitle()).isEqualTo("Updated Title");
+			assertThat(schedules.get(0).getContent()).isEqualTo("Updated Content");
+			assertThat(schedules.get(0).getStatus()).isEqualTo(ScheduleStatus.DEACTIVATE);
+		}
+
+		@Test
 		@DisplayName("[200]공개일정업데이트성공시-Job")
 		void updateJobPublicScheduleSuccess() throws Exception {
 			// given
@@ -290,7 +374,7 @@ public class PublicScheduleControllerTest {
 					.link("https://test.com")
 					.startTime(LocalDateTime.now())
 					.endTime(LocalDateTime.now().plusDays(1))
-					.build());
+					.build(), ScheduleStatus.ACTIVATE);
 			publicScheduleRepository.save(jobPublicSchedule);
 
 			PublicScheduleUpdateReqDto updateDto = PublicScheduleUpdateReqDto.builder()
@@ -332,7 +416,7 @@ public class PublicScheduleControllerTest {
 					.link("https://test.com")
 					.startTime(LocalDateTime.now())
 					.endTime(LocalDateTime.now().plusDays(1))
-					.build());
+					.build(), ScheduleStatus.ACTIVATE);
 			publicScheduleRepository.save(jobPublicSchedule);
 
 			PublicScheduleUpdateReqDto updateDto = PublicScheduleUpdateReqDto.builder()
@@ -375,7 +459,7 @@ public class PublicScheduleControllerTest {
 					.link("https://test.com")
 					.startTime(LocalDateTime.now())
 					.endTime(LocalDateTime.now().plusDays(1))
-					.build());
+					.build(), ScheduleStatus.ACTIVATE);
 			publicScheduleRepository.save(jobPublicSchedule);
 
 			PublicScheduleUpdateReqDto updateDto = PublicScheduleUpdateReqDto.builder()
@@ -417,7 +501,7 @@ public class PublicScheduleControllerTest {
 					.link("https://test.com")
 					.startTime(LocalDateTime.now())
 					.endTime(LocalDateTime.now().plusDays(1))
-					.build());
+					.build(), ScheduleStatus.ACTIVATE);
 			publicScheduleRepository.save(jobPublicSchedule);
 
 			PublicScheduleUpdateReqDto updateDto = PublicScheduleUpdateReqDto.builder()
@@ -484,7 +568,7 @@ public class PublicScheduleControllerTest {
 					.link("https://original.com")
 					.startTime(LocalDateTime.now())
 					.endTime(LocalDateTime.now().plusDays(1))
-					.build());
+					.build(), ScheduleStatus.ACTIVATE);
 			publicScheduleRepository.save(publicSchedule);
 
 			String longTitle = "publicScheduleTest".repeat(20);
@@ -525,7 +609,7 @@ public class PublicScheduleControllerTest {
 					.link("https://original.com")
 					.startTime(LocalDateTime.now())
 					.endTime(LocalDateTime.now().plusDays(1))
-					.build());
+					.build(), ScheduleStatus.ACTIVATE);
 			publicScheduleRepository.save(publicSchedule);
 
 			String longContent = "publicScheduleTest".repeat(200);
@@ -566,7 +650,7 @@ public class PublicScheduleControllerTest {
 					.link("https://original.com")
 					.startTime(LocalDateTime.now())
 					.endTime(LocalDateTime.now().plusDays(1))
-					.build());
+					.build(), ScheduleStatus.ACTIVATE);
 			publicScheduleRepository.save(publicSchedule);
 
 			PublicScheduleUpdateReqDto updateDto = PublicScheduleUpdateReqDto.builder()
@@ -603,7 +687,7 @@ public class PublicScheduleControllerTest {
 					.link("https://original.com")
 					.startTime(LocalDateTime.now())
 					.endTime(LocalDateTime.now().plusDays(1))
-					.build());
+					.build(), ScheduleStatus.ACTIVATE);
 			publicScheduleRepository.save(publicSchedule);
 
 			PublicScheduleUpdateReqDto updatePublicSchedule = PublicScheduleUpdateReqDto.builder()
@@ -645,7 +729,7 @@ public class PublicScheduleControllerTest {
 					.link("https://original.com")
 					.startTime(LocalDateTime.now())
 					.endTime(LocalDateTime.now().plusDays(1))
-					.build());
+					.build(), ScheduleStatus.ACTIVATE);
 			publicScheduleRepository.save(publicSchedule);
 
 			PublicScheduleUpdateReqDto updatePublicSchedule = PublicScheduleUpdateReqDto.builder()
@@ -688,7 +772,7 @@ public class PublicScheduleControllerTest {
 						.link("https://original.com")
 						.startTime(LocalDateTime.now())
 						.endTime(LocalDateTime.now().plusDays(1))
-						.build());
+						.build(), ScheduleStatus.ACTIVATE);
 				publicScheduleRepository.save(publicSchedule);
 				// when
 				mockMvc.perform(patch("/calendar/public/" + publicSchedule.getId()).header("Authorization",
@@ -712,7 +796,7 @@ public class PublicScheduleControllerTest {
 						.link("https://original.com")
 						.startTime(LocalDateTime.now())
 						.endTime(LocalDateTime.now().plusDays(1))
-						.build());
+						.build(), ScheduleStatus.ACTIVATE);
 				publicScheduleRepository.save(publicSchedule);
 
 				//when
@@ -737,7 +821,7 @@ public class PublicScheduleControllerTest {
 						.link("https://original.com")
 						.startTime(LocalDateTime.now())
 						.endTime(LocalDateTime.now().plusDays(1))
-						.build());
+						.build(), ScheduleStatus.ACTIVATE);
 				publicScheduleRepository.save(publicSchedule);
 				// when
 				mockMvc.perform(patch("/calendar/public/9999").header("Authorization", "Bearer " + accessToken))
@@ -763,7 +847,7 @@ public class PublicScheduleControllerTest {
 						.link("https://original.com")
 						.startTime(LocalDateTime.now())
 						.endTime(LocalDateTime.now().plusDays(1))
-						.build());
+						.build(), ScheduleStatus.ACTIVATE);
 				publicScheduleRepository.save(publicSchedule);
 
 				// when
@@ -790,12 +874,14 @@ public class PublicScheduleControllerTest {
 						.link("https://original.com")
 						.startTime(LocalDateTime.now())
 						.endTime(LocalDateTime.now().plusDays(1))
-						.build());
+						.build(), ScheduleStatus.ACTIVATE);
 
 				publicScheduleRepository.save(publicSchedule);
 
-				PrivateSchedule privateSchedule1 = new PrivateSchedule(user, publicSchedule, false, 1L);
-				PrivateSchedule privateSchedule2 = new PrivateSchedule(otherUser, publicSchedule, true, 2L);
+				PrivateSchedule privateSchedule1 = new PrivateSchedule(user, publicSchedule, false, 1L,
+					ScheduleStatus.ACTIVATE);
+				PrivateSchedule privateSchedule2 = new PrivateSchedule(otherUser, publicSchedule, true, 2L,
+					ScheduleStatus.ACTIVATE);
 				privateScheduleRepository.saveAll(Arrays.asList(privateSchedule1, privateSchedule2));
 
 				// when
@@ -823,7 +909,7 @@ public class PublicScheduleControllerTest {
 						.link("https://original.com")
 						.startTime(LocalDateTime.now())
 						.endTime(LocalDateTime.now().plusDays(1))
-						.build());
+						.build(), ScheduleStatus.ACTIVATE);
 				publicScheduleRepository.save(publicSchedule);
 				// when
 				mockMvc.perform(
@@ -848,7 +934,7 @@ public class PublicScheduleControllerTest {
 						.link("https://original.com")
 						.startTime(LocalDateTime.now())
 						.endTime(LocalDateTime.now().plusDays(1))
-						.build());
+						.build(), ScheduleStatus.ACTIVATE);
 				publicScheduleRepository.save(publicSchedule);
 
 				// when & then
@@ -870,7 +956,7 @@ public class PublicScheduleControllerTest {
 						.link("https://original.com")
 						.startTime(LocalDateTime.now())
 						.endTime(LocalDateTime.now().plusDays(1))
-						.build());
+						.build(), ScheduleStatus.ACTIVATE);
 				publicScheduleRepository.save(publicSchedule);
 
 				//when & then
@@ -996,7 +1082,7 @@ public class PublicScheduleControllerTest {
 					.link("https://original.com")
 					.startTime(LocalDateTime.now())
 					.endTime(LocalDateTime.now().plusDays(1))
-					.build());
+					.build(), ScheduleStatus.ACTIVATE);
 			publicSchedule = publicScheduleRepository.save(publicSchedule);
 			// when
 			mockMvc.perform(
@@ -1041,7 +1127,7 @@ public class PublicScheduleControllerTest {
 					.link("https://original.com")
 					.startTime(LocalDateTime.now())
 					.endTime(LocalDateTime.now().plusDays(1))
-					.build());
+					.build(), ScheduleStatus.ACTIVATE);
 			publicSchedule = publicScheduleRepository.save(publicSchedule);
 			// when
 			mockMvc.perform(

--- a/gg-calendar-api/src/test/java/gg/calendar/api/user/schedule/publicschedule/controller/request/PublicScheduleCreateEventReqDtoTest.java
+++ b/gg-calendar-api/src/test/java/gg/calendar/api/user/schedule/publicschedule/controller/request/PublicScheduleCreateEventReqDtoTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import gg.auth.UserDto;
 import gg.data.calendar.PublicSchedule;
 import gg.data.calendar.type.EventTag;
+import gg.data.calendar.type.ScheduleStatus;
 import gg.utils.annotation.UnitTest;
 
 @UnitTest
@@ -29,7 +30,8 @@ public class PublicScheduleCreateEventReqDtoTest {
 			.endTime(LocalDateTime.now().plusDays(2))
 			.build();
 
-		PublicSchedule schedule = PublicScheduleCreateEventReqDto.toEntity(user.getIntraId(), dto);
+		PublicSchedule schedule = PublicScheduleCreateEventReqDto.toEntity(user.getIntraId(), dto,
+			ScheduleStatus.ACTIVATE);
 		assertAll(() -> assertNotNull(schedule), () -> assertEquals(dto.getEventTag(), schedule.getEventTag()),
 			() -> assertEquals(user.getIntraId(), schedule.getAuthor()),
 			() -> assertEquals(dto.getTitle(), schedule.getTitle()),

--- a/gg-calendar-api/src/test/java/gg/calendar/api/user/schedule/publicschedule/controller/request/PublicScheduleCreateJobReqDtoTest.java
+++ b/gg-calendar-api/src/test/java/gg/calendar/api/user/schedule/publicschedule/controller/request/PublicScheduleCreateJobReqDtoTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import gg.auth.UserDto;
 import gg.data.calendar.PublicSchedule;
 import gg.data.calendar.type.JobTag;
+import gg.data.calendar.type.ScheduleStatus;
 import gg.data.calendar.type.TechTag;
 import gg.utils.annotation.UnitTest;
 
@@ -30,7 +31,8 @@ public class PublicScheduleCreateJobReqDtoTest {
 			.endTime(LocalDateTime.now().plusDays(2))
 			.build();
 
-		PublicSchedule schedule = PublicScheduleCreateJobReqDto.toEntity(user.getIntraId(), dto);
+		PublicSchedule schedule = PublicScheduleCreateJobReqDto.toEntity(user.getIntraId(), dto,
+			ScheduleStatus.ACTIVATE);
 		assertAll(() -> assertNotNull(schedule), () -> assertEquals(dto.getJobTag(), schedule.getJobTag()),
 			() -> assertEquals(user.getIntraId(), schedule.getAuthor()),
 			() -> assertEquals(dto.getTitle(), schedule.getTitle()),
@@ -56,7 +58,8 @@ public class PublicScheduleCreateJobReqDtoTest {
 			.endTime(LocalDateTime.now().plusDays(2))
 			.build();
 
-		PublicSchedule schedule = PublicScheduleCreateJobReqDto.toEntity(user.getIntraId(), dto);
+		PublicSchedule schedule = PublicScheduleCreateJobReqDto.toEntity(user.getIntraId(), dto,
+			ScheduleStatus.ACTIVATE);
 		assertAll(() -> assertNotNull(schedule), () -> assertEquals(dto.getJobTag(), schedule.getJobTag()),
 			() -> assertEquals(dto.getTechTag(), schedule.getTechTag()),
 			() -> assertEquals(user.getIntraId(), schedule.getAuthor()),

--- a/gg-data/src/main/java/gg/data/calendar/PrivateSchedule.java
+++ b/gg-data/src/main/java/gg/data/calendar/PrivateSchedule.java
@@ -47,17 +47,22 @@ public class PrivateSchedule extends BaseTimeEntity {
 	@Column(nullable = false, columnDefinition = "VARCHAR(50)")
 	private ScheduleStatus status;
 
-	public PrivateSchedule(User user, PublicSchedule publicSchedule, Boolean alarm, Long groupId) {
+	public PrivateSchedule(User user, PublicSchedule publicSchedule, Boolean alarm, Long groupId,
+		ScheduleStatus status) {
 		this.user = user;
 		this.publicSchedule = publicSchedule;
 		this.alarm = alarm;
 		this.groupId = groupId;
-		this.status = ScheduleStatus.ACTIVATE;
+		this.status = status;
 	}
 
 	public void update(Boolean alarm, Long groupId) {
 		this.alarm = alarm;
 		this.groupId = groupId;
+	}
+
+	public void updateSchedule(ScheduleStatus status) {
+		this.status = status;
 	}
 
 	public void updateCascade(String title, String content, String link, LocalDateTime startTime, LocalDateTime endTime,

--- a/gg-data/src/main/java/gg/data/calendar/PrivateSchedule.java
+++ b/gg-data/src/main/java/gg/data/calendar/PrivateSchedule.java
@@ -61,11 +61,12 @@ public class PrivateSchedule extends BaseTimeEntity {
 	}
 
 	public void updateCascade(String title, String content, String link, LocalDateTime startTime, LocalDateTime endTime,
-		boolean alarm, Long groupId) {
+		boolean alarm, Long groupId, ScheduleStatus status) {
 		this.alarm = alarm;
 		this.groupId = groupId;
+		this.status = status;
 		this.publicSchedule.update(DetailClassification.PRIVATE_SCHEDULE, null, null, null, title, content, link,
-			startTime, endTime);
+			startTime, endTime, status);
 	}
 
 	public void delete() {

--- a/gg-data/src/main/java/gg/data/calendar/PublicSchedule.java
+++ b/gg-data/src/main/java/gg/data/calendar/PublicSchedule.java
@@ -87,7 +87,8 @@ public class PublicSchedule extends BaseTimeEntity {
 	}
 
 	public void update(DetailClassification classification, EventTag eventTag, JobTag jobTag, TechTag techTag,
-		String title, String content, String link, LocalDateTime startTime, LocalDateTime endTime) {
+		String title, String content, String link, LocalDateTime startTime, LocalDateTime endTime,
+		ScheduleStatus status) {
 		this.classification = classification;
 		this.eventTag = eventTag;
 		this.jobTag = jobTag;
@@ -97,6 +98,7 @@ public class PublicSchedule extends BaseTimeEntity {
 		this.link = link;
 		this.startTime = startTime;
 		this.endTime = endTime;
+		this.status = status;
 	}
 
 	public void delete() {

--- a/gg-repo/src/main/java/gg/repo/calendar/PrivateScheduleRepository.java
+++ b/gg-repo/src/main/java/gg/repo/calendar/PrivateScheduleRepository.java
@@ -23,6 +23,9 @@ public interface PrivateScheduleRepository extends JpaRepository<PrivateSchedule
 
 	List<PrivateSchedule> findByPublicSchedule(PublicSchedule publicSchedule);
 
+	@Query("SELECT ps FROM PrivateSchedule ps JOIN FETCH ps.publicSchedule WHERE ps.publicSchedule = :publicSchedule")
+	List<PrivateSchedule> findWithFetchJoinByPublicSchedule(@Param("publicSchedule") PublicSchedule publicSchedule);
+
 	List<PrivateSchedule> findByGroupId(Long groupId);
 
 	@Query("SELECT pr FROM PrivateSchedule pr "
@@ -50,4 +53,11 @@ public interface PrivateScheduleRepository extends JpaRepository<PrivateSchedule
 		@Param("nextStartOfDay") LocalDateTime nextStartOfDay,
 		@Param("nextEndOfDay") LocalDateTime nextEndOfDay,
 		@Param("status") ScheduleStatus status);
+
+	@Transactional
+	@Modifying
+	@Query("UPDATE PrivateSchedule ps SET ps.status = :status WHERE ps.publicSchedule = :publicSchedule")
+	void bulkUpdateScheduleStatus(@Param("publicSchedule") PublicSchedule publicSchedule,
+		@Param("status") ScheduleStatus status);
+
 }


### PR DESCRIPTION
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 개인일정, 전체일정 업데이트 API 수정
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - 업데이트 시, 현재 시간과 비교해서 ScheduleStatus값 수정
 ## 💡Issue 번호 <!-- issue number을 link 시켜주세요 (ex. "- close #4242") -->
 - #1187