### PR TITLE
🔨 [Refactoring] 반환 순서 역순으로 오도록 JPA쿼리문 수정

### DIFF
--- a/gg-admin-repo/src/main/java/gg/admin/repo/calendar/PublicScheduleAdminRepository.java
+++ b/gg-admin-repo/src/main/java/gg/admin/repo/calendar/PublicScheduleAdminRepository.java
@@ -15,7 +15,7 @@ public interface PublicScheduleAdminRepository extends JpaRepository<PublicSched
 
 	List<PublicSchedule> findByAuthor(String author);
 
-	List<PublicSchedule> findAllByClassification(DetailClassification detailClassification);
+	List<PublicSchedule> findAllByClassificationOrderByIdDesc(DetailClassification detailClassification);
 
 	List<PublicSchedule> findAll();
 }

--- a/gg-calendar-api/src/main/java/gg/calendar/api/admin/schedule/privateschedule/controller/PrivateScheduleAdminController.java
+++ b/gg-calendar-api/src/main/java/gg/calendar/api/admin/schedule/privateschedule/controller/PrivateScheduleAdminController.java
@@ -15,7 +15,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/admin/calendar/private")
+@RequestMapping("/calendar/admin/private")
 public class PrivateScheduleAdminController {
 
 	private final PrivateScheduleAdminService privateScheduleAdminService;

--- a/gg-calendar-api/src/main/java/gg/calendar/api/admin/schedule/publicschedule/controller/PublicScheduleAdminController.java
+++ b/gg-calendar-api/src/main/java/gg/calendar/api/admin/schedule/publicschedule/controller/PublicScheduleAdminController.java
@@ -23,7 +23,7 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/admin/calendar/public")
+@RequestMapping("/calendar/admin/public")
 public class PublicScheduleAdminController {
 
 	private final PublicScheduleAdminService publicScheduleAdminService;

--- a/gg-calendar-api/src/main/java/gg/calendar/api/admin/schedule/publicschedule/controller/request/PublicScheduleAdminCreateEventReqDto.java
+++ b/gg-calendar-api/src/main/java/gg/calendar/api/admin/schedule/publicschedule/controller/request/PublicScheduleAdminCreateEventReqDto.java
@@ -31,6 +31,7 @@ public class PublicScheduleAdminCreateEventReqDto {
 	@Size(max = 2000, message = "내용은 2000자이하로 입력해주세요.")
 	private String content;
 
+	@Size(max = 255, message = "링크는 255자 이하로 입력해주세요.")
 	private String link;
 
 	@NotNull

--- a/gg-calendar-api/src/main/java/gg/calendar/api/admin/schedule/publicschedule/controller/request/PublicScheduleAdminCreateJobReqDto.java
+++ b/gg-calendar-api/src/main/java/gg/calendar/api/admin/schedule/publicschedule/controller/request/PublicScheduleAdminCreateJobReqDto.java
@@ -35,6 +35,7 @@ public class PublicScheduleAdminCreateJobReqDto {
 	@Size(max = 2000, message = "내용은 2000자이하로 입력해주세요.")
 	private String content;
 
+	@Size(max = 255, message = "링크는 255자 이하로 입력해주세요.")
 	private String link;
 
 	@NotNull

--- a/gg-calendar-api/src/main/java/gg/calendar/api/admin/schedule/publicschedule/controller/request/PublicScheduleAdminUpdateReqDto.java
+++ b/gg-calendar-api/src/main/java/gg/calendar/api/admin/schedule/publicschedule/controller/request/PublicScheduleAdminUpdateReqDto.java
@@ -37,6 +37,7 @@ public class PublicScheduleAdminUpdateReqDto {
 	@Size(max = 2000, message = "내용은 2000자이하로 입력해주세요.")
 	private String content;
 
+	@Size(max = 255, message = "링크는 255자 이하로 입력해주세요.")
 	private String link;
 
 	@NotNull

--- a/gg-calendar-api/src/main/java/gg/calendar/api/admin/schedule/totalschedule/controller/TotalScheduleAdminController.java
+++ b/gg-calendar-api/src/main/java/gg/calendar/api/admin/schedule/totalschedule/controller/TotalScheduleAdminController.java
@@ -20,7 +20,7 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/admin/calendar")
+@RequestMapping("/calendar/admin")
 public class TotalScheduleAdminController {
 
 	private final TotalScheduleAdminService totalScheduleAdminService;

--- a/gg-calendar-api/src/main/java/gg/calendar/api/admin/schedule/totalschedule/controller/TotalScheduleAdminController.java
+++ b/gg-calendar-api/src/main/java/gg/calendar/api/admin/schedule/totalschedule/controller/TotalScheduleAdminController.java
@@ -28,18 +28,16 @@ public class TotalScheduleAdminController {
 	@GetMapping("/list/{detailClassification}")
 	public ResponseEntity<TotalScheduleAdminSearchListResDto> totalScheduleAdminClassificationList(
 		@PathVariable DetailClassification detailClassification) {
-
 		TotalScheduleAdminSearchListResDto scheduleList = totalScheduleAdminService.findAllByClassification(
 			detailClassification);
-
 		return ResponseEntity.ok(scheduleList);
 	}
 
 	@GetMapping("/search")
 	public ResponseEntity<TotalScheduleAdminSearchListResDto> totalScheduleAdminSearchList(
 		@ModelAttribute @Valid TotalScheduleAdminSearchReqDto totalScheduleAdminSearchReqDto) {
-		TotalScheduleAdminSearchListResDto scheduleList = totalScheduleAdminService
-			.searchTotalScheduleAdminList(totalScheduleAdminSearchReqDto);
+		TotalScheduleAdminSearchListResDto scheduleList = totalScheduleAdminService.searchTotalScheduleAdminList(
+			totalScheduleAdminSearchReqDto);
 
 		return ResponseEntity.ok(scheduleList);
 	}

--- a/gg-calendar-api/src/main/java/gg/calendar/api/admin/schedule/totalschedule/service/TotalScheduleAdminService.java
+++ b/gg-calendar-api/src/main/java/gg/calendar/api/admin/schedule/totalschedule/service/TotalScheduleAdminService.java
@@ -35,7 +35,7 @@ public class TotalScheduleAdminService {
 
 	public TotalScheduleAdminSearchListResDto findAllByClassification(DetailClassification detailClassification) {
 
-		List<PublicSchedule> scheduleList = publicScheduleAdminRepository.findAllByClassification(
+		List<PublicSchedule> scheduleList = publicScheduleAdminRepository.findAllByClassificationOrderByIdDesc(
 			detailClassification);
 
 		return TotalScheduleAdminSearchListResDto.builder()

--- a/gg-calendar-api/src/main/java/gg/calendar/api/user/schedule/privateschedule/controller/request/PrivateScheduleCreateReqDto.java
+++ b/gg-calendar-api/src/main/java/gg/calendar/api/user/schedule/privateschedule/controller/request/PrivateScheduleCreateReqDto.java
@@ -25,6 +25,7 @@ public class PrivateScheduleCreateReqDto {
 	@Size(max = 2000)
 	private String content;
 
+	@Size(max = 255, message = "링크는 255자 이하로 입력해주세요.")
 	private String link;
 
 	@NotNull

--- a/gg-calendar-api/src/main/java/gg/calendar/api/user/schedule/privateschedule/controller/request/PrivateScheduleUpdateReqDto.java
+++ b/gg-calendar-api/src/main/java/gg/calendar/api/user/schedule/privateschedule/controller/request/PrivateScheduleUpdateReqDto.java
@@ -21,6 +21,7 @@ public class PrivateScheduleUpdateReqDto {
 	@Size(max = 2000)
 	private String content;
 
+	@Size(max = 255, message = "링크는 255자 이하로 입력해주세요.")
 	private String link;
 
 	@NotNull

--- a/gg-calendar-api/src/main/java/gg/calendar/api/user/schedule/publicschedule/controller/request/PublicScheduleCreateEventReqDto.java
+++ b/gg-calendar-api/src/main/java/gg/calendar/api/user/schedule/publicschedule/controller/request/PublicScheduleCreateEventReqDto.java
@@ -32,6 +32,7 @@ public class PublicScheduleCreateEventReqDto {
 	@Size(max = 2000, message = "내용은 2000자이하로 입력해주세요.")
 	private String content;
 
+	@Size(max = 255, message = "링크는 255자 이하로 입력해주세요.")
 	private String link;
 
 	@NotNull

--- a/gg-calendar-api/src/main/java/gg/calendar/api/user/schedule/publicschedule/controller/request/PublicScheduleCreateJobReqDto.java
+++ b/gg-calendar-api/src/main/java/gg/calendar/api/user/schedule/publicschedule/controller/request/PublicScheduleCreateJobReqDto.java
@@ -35,6 +35,7 @@ public class PublicScheduleCreateJobReqDto {
 	@Size(max = 2000, message = "내용은 2000자이하로 입력해주세요.")
 	private String content;
 
+	@Size(max = 255, message = "링크는 255자 이하로 입력해주세요.")
 	private String link;
 
 	@NotNull

--- a/gg-calendar-api/src/main/java/gg/calendar/api/user/schedule/publicschedule/controller/request/PublicScheduleUpdateReqDto.java
+++ b/gg-calendar-api/src/main/java/gg/calendar/api/user/schedule/publicschedule/controller/request/PublicScheduleUpdateReqDto.java
@@ -43,6 +43,7 @@ public class PublicScheduleUpdateReqDto {
 	@Size(max = 2000, message = "내용은 2000자이하로 입력해주세요.")
 	private String content;
 
+	@Size(max = 255, message = "링크는 255자 이하로 입력해주세요.")
 	private String link;
 
 	@NotNull

--- a/gg-calendar-api/src/main/java/gg/calendar/api/user/utils/service/FortyTwoEventService.java
+++ b/gg-calendar-api/src/main/java/gg/calendar/api/user/utils/service/FortyTwoEventService.java
@@ -40,9 +40,6 @@ public class FortyTwoEventService {
 
 	private void convertAndSaveEvent(FortyTwoEventResponse event) {
 		String description = event.getDescription();
-		// if (description != null && description.length() > 255) {
-		// 	description = description.substring(0, 255);
-		// }
 		PublicSchedule publicSchedule = PublicSchedule.builder()
 			.classification(DetailClassification.EVENT)
 			.eventTag(determineEventTag(event))

--- a/gg-calendar-api/src/main/java/gg/calendar/api/user/utils/service/FortyTwoEventService.java
+++ b/gg-calendar-api/src/main/java/gg/calendar/api/user/utils/service/FortyTwoEventService.java
@@ -40,9 +40,9 @@ public class FortyTwoEventService {
 
 	private void convertAndSaveEvent(FortyTwoEventResponse event) {
 		String description = event.getDescription();
-		if (description != null && description.length() > 255) {
-			description = description.substring(0, 255);
-		}
+		// if (description != null && description.length() > 255) {
+		// 	description = description.substring(0, 255);
+		// }
 		PublicSchedule publicSchedule = PublicSchedule.builder()
 			.classification(DetailClassification.EVENT)
 			.eventTag(determineEventTag(event))

--- a/gg-calendar-api/src/main/java/gg/calendar/api/user/utils/service/ScheduleNotiService.java
+++ b/gg-calendar-api/src/main/java/gg/calendar/api/user/utils/service/ScheduleNotiService.java
@@ -7,7 +7,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import gg.data.calendar.PrivateSchedule;
-import gg.data.calendar.type.DetailClassification;
 import gg.data.calendar.type.ScheduleStatus;
 import gg.repo.calendar.PrivateScheduleRepository;
 import gg.repo.calendar.PublicScheduleRepository;
@@ -21,10 +20,10 @@ public class ScheduleNotiService {
 	private final PublicScheduleRepository publicScheduleRepository;
 	private final PrivateScheduleRepository privateScheduleRepository;
 	private final MessageSender messageSender;
-	private static final String SCHEDULE_MESSAGE_D_DAY = "📆일정요정🧚으로부터 알림이 도착했습니다.\n"
-		+ "📧42gg캘린더📧와 <<오늘>>의 일정을 확인해보세요!\n";
-	private static final String SCHEDULE_MESSAGE_BEFORE_D_DAY = "📅일정요정🧚으로부터 알림이 도착했습니다.\n\n"
-		+ "📧42gg캘린더📧와 >>내일<<의 일정을 확인해보세요!\n";
+	private static final String SCHEDULE_MESSAGE_D_DAY =
+		"📆일정요정🧚으로부터 알림이 도착했습니다.\n" + "📧42gg캘린더📧와 <<오늘>>의 일정을 확인해보세요!\n";
+	private static final String SCHEDULE_MESSAGE_BEFORE_D_DAY =
+		"📅일정요정🧚으로부터 알림이 도착했습니다.\n\n" + "📧42gg캘린더📧와 >>내일<<의 일정을 확인해보세요!\n";
 
 	@Transactional
 	public void sendScheduleNotifications() {
@@ -37,19 +36,18 @@ public class ScheduleNotiService {
 		List<PrivateSchedule> alarmSchedule = privateScheduleRepository.findSchedulesWithAlarmForBothDays(startOfDay,
 			endOfDay, startDday, endDday, ScheduleStatus.ACTIVATE);
 		for (PrivateSchedule schedule : alarmSchedule) {
-			String message = schedule.getPublicSchedule().getStartTime()
-				.isBefore(currentTime.plusDays(1))
-				? SCHEDULE_MESSAGE_D_DAY : SCHEDULE_MESSAGE_BEFORE_D_DAY;
+			String message =
+				schedule.getPublicSchedule().getStartTime().isBefore(currentTime.plusDays(1)) ? SCHEDULE_MESSAGE_D_DAY :
+					SCHEDULE_MESSAGE_BEFORE_D_DAY;
 			messageSender.send(schedule.getUser().getIntraId(),
-				message + "printf('일정: " + schedule.getPublicSchedule().getTitle() + "');\n"
-					+ "System.out.println(" + makeLink(schedule) + ");\n\n");
+				message + "printf('일정: " + schedule.getPublicSchedule().getTitle() + "');\n");
 		}
 	}
 
-	public String makeLink(PrivateSchedule schedule) {
-		boolean flag = schedule.getPublicSchedule().getClassification() == DetailClassification.JOB_NOTICE;
-		return flag ? schedule.getPublicSchedule().getLink() :
-			"https://gg.42seoul.kr/calendar/detail/" + schedule.getId();
-	}
+	// public String makeLink(PrivateSchedule schedule) {
+	// 	boolean flag = schedule.getPublicSchedule().getClassification() == DetailClassification.JOB_NOTICE;
+	// 	return flag ? schedule.getPublicSchedule().getLink() :
+	// 		"https://gg.42seoul.kr/calendar/detail/" + schedule.getId();
+	// }
 }
 

--- a/gg-calendar-api/src/test/java/gg/calendar/api/admin/schedule/privateschedule/controller/PrivateScheduleAdminControllerTest.java
+++ b/gg-calendar-api/src/test/java/gg/calendar/api/admin/schedule/privateschedule/controller/PrivateScheduleAdminControllerTest.java
@@ -81,7 +81,7 @@ public class PrivateScheduleAdminControllerTest {
 
 			// when
 			String response = mockMvc.perform(
-					get("/admin/calendar/private/{id}", privateSchedule.getId()).header("Authorization",
+					get("/calendar/admin/private/{id}", privateSchedule.getId()).header("Authorization",
 						"Bearer " + accessToken))
 				.andDo(print())
 				.andExpect(status().isOk()).andReturn().getResponse().getContentAsString();
@@ -111,7 +111,7 @@ public class PrivateScheduleAdminControllerTest {
 
 			// when
 			String response = mockMvc.perform(
-					get("/admin/calendar/private/qweksd").header("Authorization",
+					get("/calendar/admin/private/qweksd").header("Authorization",
 						"Bearer " + accessToken))
 				.andDo(print())
 				.andExpect(status().isBadRequest()).andReturn().getResponse().getContentAsString();
@@ -130,7 +130,7 @@ public class PrivateScheduleAdminControllerTest {
 
 			// when
 			String response = mockMvc.perform(
-					get("/admin/calendar/private/500123").header("Authorization",
+					get("/calendar/admin/private/500123").header("Authorization",
 						"Bearer " + accessToken))
 				.andDo(print())
 				.andExpect(status().isNotFound()).andReturn().getResponse().getContentAsString();
@@ -149,7 +149,7 @@ public class PrivateScheduleAdminControllerTest {
 
 			// when
 			String response = mockMvc.perform(
-					get("/admin/calendar/private/{id}", privateSchedule.getId()).header("Authorization",
+					get("/calendar/admin/private/{id}", privateSchedule.getId()).header("Authorization",
 						"Bearer " + accessToken))
 				.andDo(print())
 				.andExpect(status().isNotFound()).andReturn().getResponse().getContentAsString();
@@ -173,7 +173,7 @@ public class PrivateScheduleAdminControllerTest {
 
 			// when
 			mockMvc.perform(
-					patch("/admin/calendar/private/{id}", privateSchedule.getId()).header("Authorization",
+					patch("/calendar/admin/private/{id}", privateSchedule.getId()).header("Authorization",
 						"Bearer " + accessToken))
 				.andDo(print())
 				.andExpect(status().isOk());
@@ -193,7 +193,7 @@ public class PrivateScheduleAdminControllerTest {
 
 			// when
 			String response = mockMvc.perform(
-					patch("/admin/calendar/private/qweksd").header("Authorization",
+					patch("/calendar/admin/private/qweksd").header("Authorization",
 						"Bearer " + accessToken))
 				.andDo(print())
 				.andExpect(status().isBadRequest()).andReturn().getResponse().getContentAsString();
@@ -212,7 +212,7 @@ public class PrivateScheduleAdminControllerTest {
 
 			// when
 			String response = mockMvc.perform(
-					patch("/admin/calendar/private/500123").header("Authorization",
+					patch("/calendar/admin/private/500123").header("Authorization",
 						"Bearer " + accessToken))
 				.andDo(print())
 				.andExpect(status().isNotFound()).andReturn().getResponse().getContentAsString();
@@ -232,7 +232,7 @@ public class PrivateScheduleAdminControllerTest {
 
 			// when
 			String response = mockMvc.perform(
-					patch("/admin/calendar/private/{id}", privateSchedule.getId()).header("Authorization",
+					patch("/calendar/admin/private/{id}", privateSchedule.getId()).header("Authorization",
 						"Bearer " + accessToken))
 				.andDo(print())
 				.andExpect(status().isForbidden()).andReturn().getResponse().getContentAsString();

--- a/gg-calendar-api/src/test/java/gg/calendar/api/admin/schedule/publicschedule/controller/PublicScheduleAdminControllerTest.java
+++ b/gg-calendar-api/src/test/java/gg/calendar/api/admin/schedule/publicschedule/controller/PublicScheduleAdminControllerTest.java
@@ -115,7 +115,7 @@ public class PublicScheduleAdminControllerTest {
 				.build();
 
 			// when
-			mockMvc.perform(post("/admin/calendar/public/event").header("Authorization", "Bearer " + accessToken)
+			mockMvc.perform(post("/calendar/admin/public/event").header("Authorization", "Bearer " + accessToken)
 					.contentType(MediaType.APPLICATION_JSON)
 					.content(objectMapper.writeValueAsString(publicScheduleReqDto)))
 				.andDo(print())
@@ -160,7 +160,7 @@ public class PublicScheduleAdminControllerTest {
 				.endTime(LocalDateTime.now().plusDays(10))
 				.build();
 
-			mockMvc.perform(post("/admin/calendar/public/event").header("Authorization", "Bearer " + accessToken)
+			mockMvc.perform(post("/calendar/admin/public/event").header("Authorization", "Bearer " + accessToken)
 					.contentType(MediaType.APPLICATION_JSON)
 					.content(objectMapper.writeValueAsString(requestDto)))
 				.andDo(print())
@@ -181,7 +181,7 @@ public class PublicScheduleAdminControllerTest {
 				.endTime(LocalDateTime.now().plusDays(10))
 				.build();
 
-			mockMvc.perform(post("/admin/calendar/public/event").header("Authorization", "Bearer " + accessToken)
+			mockMvc.perform(post("/calendar/admin/public/event").header("Authorization", "Bearer " + accessToken)
 					.contentType(MediaType.APPLICATION_JSON)
 					.content(objectMapper.writeValueAsString(requestDto)))
 				.andDo(print())
@@ -201,7 +201,7 @@ public class PublicScheduleAdminControllerTest {
 				.endTime(LocalDateTime.now().plusDays(10))
 				.build();
 
-			mockMvc.perform(post("/admin/calendar/public/event").header("Authorization", "Bearer " + accessToken)
+			mockMvc.perform(post("/calendar/admin/public/event").header("Authorization", "Bearer " + accessToken)
 					.contentType(MediaType.APPLICATION_JSON)
 					.content(objectMapper.writeValueAsString(requestDto)))
 				.andDo(print())
@@ -224,7 +224,7 @@ public class PublicScheduleAdminControllerTest {
 				.build();
 
 			// when
-			mockMvc.perform(post("/admin/calendar/public/job").header("Authorization", "Bearer " + accessToken)
+			mockMvc.perform(post("/calendar/admin/public/job").header("Authorization", "Bearer " + accessToken)
 					.contentType(MediaType.APPLICATION_JSON)
 					.content(objectMapper.writeValueAsString(publicScheduleAdminReqDto)))
 				.andDo(print())
@@ -271,7 +271,7 @@ public class PublicScheduleAdminControllerTest {
 				.endTime(LocalDateTime.now().plusDays(10))
 				.build();
 
-			mockMvc.perform(post("/admin/calendar/public/job").header("Authorization", "Bearer " + accessToken)
+			mockMvc.perform(post("/calendar/admin/public/job").header("Authorization", "Bearer " + accessToken)
 					.contentType(MediaType.APPLICATION_JSON)
 					.content(objectMapper.writeValueAsString(requestDto)))
 				.andDo(print())
@@ -293,7 +293,7 @@ public class PublicScheduleAdminControllerTest {
 				.endTime(LocalDateTime.now().plusDays(10))
 				.build();
 
-			mockMvc.perform(post("/admin/calendar/public/job").header("Authorization", "Bearer " + accessToken)
+			mockMvc.perform(post("/calendar/admin/public/job").header("Authorization", "Bearer " + accessToken)
 					.contentType(MediaType.APPLICATION_JSON)
 					.content(objectMapper.writeValueAsString(requestDto)))
 				.andDo(print())
@@ -314,7 +314,7 @@ public class PublicScheduleAdminControllerTest {
 				.endTime(LocalDateTime.now().plusDays(10))
 				.build();
 
-			mockMvc.perform(post("/admin/calendar/public/job").header("Authorization", "Bearer " + accessToken)
+			mockMvc.perform(post("/calendar/admin/public/job").header("Authorization", "Bearer " + accessToken)
 					.contentType(MediaType.APPLICATION_JSON)
 					.content(objectMapper.writeValueAsString(requestDto)))
 				.andDo(print())
@@ -335,7 +335,7 @@ public class PublicScheduleAdminControllerTest {
 				.endTime(LocalDateTime.now().plusDays(10))
 				.build();
 
-			mockMvc.perform(post("/admin/calendar/public/job").header("Authorization", "Bearer " + accessToken)
+			mockMvc.perform(post("/calendar/admin/public/job").header("Authorization", "Bearer " + accessToken)
 					.contentType(MediaType.APPLICATION_JSON)
 					.content(objectMapper.writeValueAsString(requestDto)))
 				.andDo(print())
@@ -355,7 +355,7 @@ public class PublicScheduleAdminControllerTest {
 
 			// when
 			String response = mockMvc.perform(
-					get("/admin/calendar/public/{id}", publicSchedule.getId()).header("Authorization",
+					get("/calendar/admin/public/{id}", publicSchedule.getId()).header("Authorization",
 						"Bearer " + accessToken))
 				.andDo(print())
 				.andExpect(status().isOk()).andReturn().getResponse().getContentAsString();
@@ -385,7 +385,7 @@ public class PublicScheduleAdminControllerTest {
 
 			// when
 			String response = mockMvc.perform(
-					get("/admin/calendar/public/qweksd").header("Authorization",
+					get("/calendar/admin/public/qweksd").header("Authorization",
 						"Bearer " + accessToken))
 				.andDo(print())
 				.andExpect(status().isBadRequest()).andReturn().getResponse().getContentAsString();
@@ -402,7 +402,7 @@ public class PublicScheduleAdminControllerTest {
 
 			// when
 			String response = mockMvc.perform(
-					get("/admin/calendar/public/500123").header("Authorization",
+					get("/calendar/admin/public/500123").header("Authorization",
 						"Bearer " + accessToken))
 				.andDo(print())
 				.andExpect(status().isNotFound()).andReturn().getResponse().getContentAsString();
@@ -448,7 +448,7 @@ public class PublicScheduleAdminControllerTest {
 
 			// when
 			String response = mockMvc.perform(
-					put("/admin/calendar/public/{id}", publicSchedule.getId()).header("Authorization",
+					put("/calendar/admin/public/{id}", publicSchedule.getId()).header("Authorization",
 							"Bearer " + accessToken)
 						.contentType(MediaType.APPLICATION_JSON)
 						.content(objectMapper.writeValueAsString(publicScheduleAdminUpdateReqDto)))
@@ -494,7 +494,7 @@ public class PublicScheduleAdminControllerTest {
 
 			// when
 			String response = mockMvc.perform(
-					put("/admin/calendar/public/{id}", publicSchedule.getId()).header("Authorization",
+					put("/calendar/admin/public/{id}", publicSchedule.getId()).header("Authorization",
 							"Bearer " + accessToken)
 						.contentType(MediaType.APPLICATION_JSON)
 						.content(objectMapper.writeValueAsString(publicScheduleAdminUpdateReqDto)))
@@ -534,7 +534,7 @@ public class PublicScheduleAdminControllerTest {
 
 			// when
 			String response = mockMvc.perform(
-					put("/admin/calendar/public/{id}", publicSchedule.getId()).header("Authorization",
+					put("/calendar/admin/public/{id}", publicSchedule.getId()).header("Authorization",
 							"Bearer " + accessToken)
 						.contentType(MediaType.APPLICATION_JSON)
 						.content(objectMapper.writeValueAsString(publicScheduleAdminUpdateReqDto)))
@@ -574,7 +574,7 @@ public class PublicScheduleAdminControllerTest {
 
 			// when
 			String response = mockMvc.perform(
-					put("/admin/calendar/public/{id}", publicSchedule.getId()).header("Authorization",
+					put("/calendar/admin/public/{id}", publicSchedule.getId()).header("Authorization",
 							"Bearer " + accessToken)
 						.contentType(MediaType.APPLICATION_JSON)
 						.content(objectMapper.writeValueAsString(publicScheduleAdminUpdateReqDto)))
@@ -614,7 +614,7 @@ public class PublicScheduleAdminControllerTest {
 
 			// when
 			String response = mockMvc.perform(
-					put("/admin/calendar/public/100").header("Authorization", "Bearer " + accessToken)
+					put("/calendar/admin/public/100").header("Authorization", "Bearer " + accessToken)
 						.contentType(MediaType.APPLICATION_JSON)
 						.content(objectMapper.writeValueAsString(publicScheduleAdminUpdateReqDto)))
 				.andDo(print())
@@ -653,7 +653,7 @@ public class PublicScheduleAdminControllerTest {
 
 			// when
 			String response = mockMvc.perform(
-					put("/admin/calendar/public/asdasdasd").header("Authorization", "Bearer " + accessToken)
+					put("/calendar/admin/public/asdasdasd").header("Authorization", "Bearer " + accessToken)
 						.contentType(MediaType.APPLICATION_JSON)
 						.content(objectMapper.writeValueAsString(publicScheduleAdminUpdateReqDto)))
 				.andDo(print())
@@ -695,7 +695,7 @@ public class PublicScheduleAdminControllerTest {
 
 			// when & then
 			String response = mockMvc.perform(
-					put("/admin/calendar/public/{id}", publicSchedule.getId())
+					put("/calendar/admin/public/{id}", publicSchedule.getId())
 						.header("Authorization", "Bearer " + accessToken)
 						.contentType(MediaType.APPLICATION_JSON)
 						.content(objectMapper.writeValueAsString(publicScheduleAdminUpdateReqDto))
@@ -726,7 +726,7 @@ public class PublicScheduleAdminControllerTest {
 			PublicSchedule publicSchedule = publicScheduleAdminMockData.createPublicSchedule();
 
 			// when
-			mockMvc.perform(patch("/admin/calendar/public/{id}", publicSchedule.getId()).header("Authorization",
+			mockMvc.perform(patch("/calendar/admin/public/{id}", publicSchedule.getId()).header("Authorization",
 						"Bearer " + accessToken)
 					.contentType(MediaType.APPLICATION_JSON))
 				.andDo(print())
@@ -760,7 +760,7 @@ public class PublicScheduleAdminControllerTest {
 				ScheduleStatus.ACTIVATE);
 			privateScheduleAdminRepository.save(privateSchedule1);
 			privateScheduleAdminRepository.save(privateSchedule2);
-			mockMvc.perform(patch("/admin/calendar/public/{id}", publicSchedule.getId()).header("Authorization",
+			mockMvc.perform(patch("/calendar/admin/public/{id}", publicSchedule.getId()).header("Authorization",
 						"Bearer " + accessToken)
 					.contentType(MediaType.APPLICATION_JSON))
 				.andDo(print())
@@ -782,7 +782,7 @@ public class PublicScheduleAdminControllerTest {
 			PublicSchedule publicSchedule = publicScheduleAdminMockData.createPublicSchedule();
 
 			// when
-			mockMvc.perform(patch("/admin/calendar/public/qwe1asdv").header("Authorization",
+			mockMvc.perform(patch("/calendar/admin/public/qwe1asdv").header("Authorization",
 						"Bearer " + accessToken)
 					.contentType(MediaType.APPLICATION_JSON))
 				.andDo(print())
@@ -800,7 +800,7 @@ public class PublicScheduleAdminControllerTest {
 			PublicSchedule publicSchedule = publicScheduleAdminMockData.createPublicSchedule();
 
 			// when
-			mockMvc.perform(patch("/admin/calendar/public/50123125").header("Authorization",
+			mockMvc.perform(patch("/calendar/admin/public/50123125").header("Authorization",
 						"Bearer " + accessToken)
 					.contentType(MediaType.APPLICATION_JSON))
 				.andDo(print())

--- a/gg-calendar-api/src/test/java/gg/calendar/api/admin/schedule/totalschedule/controller/TotalScheduleAdminControllerTest.java
+++ b/gg-calendar-api/src/test/java/gg/calendar/api/admin/schedule/totalschedule/controller/TotalScheduleAdminControllerTest.java
@@ -122,7 +122,7 @@ class TotalScheduleAdminControllerTest {
 			// when
 			// multivalue map 을 통해서 값이 넘어옴
 			String response = mockMvc.perform(
-					get("/admin/calendar/list/{detailClassification}", tags).header("Authorization",
+					get("/calendar/admin/list/{detailClassification}", tags).header("Authorization",
 						"Bearer " + accessToken))
 				.andDo(print())
 				.andExpect(status().isOk())
@@ -149,7 +149,7 @@ class TotalScheduleAdminControllerTest {
 
 			// when
 			String response = mockMvc.perform(
-					get("/admin/calendar/list/{detailClassification}", "qweksd").header("Authorization",
+					get("/calendar/admin/list/{detailClassification}", "qweksd").header("Authorization",
 						"Bearer " + accessToken))
 				.andDo(print())
 				.andExpect(status().isBadRequest())
@@ -181,7 +181,7 @@ class TotalScheduleAdminControllerTest {
 
 			// when
 			String response = mockMvc.perform(
-					get("/admin/calendar/search/").header("Authorization", "Bearer " + accessToken).params(params))
+					get("/calendar/admin/search/").header("Authorization", "Bearer " + accessToken).params(params))
 				.andDo(print())
 				.andExpect(status().isOk())
 				.andReturn()
@@ -246,7 +246,7 @@ class TotalScheduleAdminControllerTest {
 
 			// when
 			String response = mockMvc.perform(
-					get("/admin/calendar/search/").header("Authorization", "Bearer " + accessToken).params(params))
+					get("/calendar/admin/search/").header("Authorization", "Bearer " + accessToken).params(params))
 				.andDo(print())
 				.andExpect(status().isOk())
 				.andReturn()
@@ -293,7 +293,7 @@ class TotalScheduleAdminControllerTest {
 
 			// when
 			String response = mockMvc.perform(
-					get("/admin/calendar/search/").header("Authorization", "Bearer " + accessToken).params(params))
+					get("/calendar/admin/search/").header("Authorization", "Bearer " + accessToken).params(params))
 				.andDo(print())
 				.andExpect(status().isBadRequest())
 				.andReturn()
@@ -317,7 +317,7 @@ class TotalScheduleAdminControllerTest {
 			publicScheduleAdminMockData.createPublicSchedulePrivate(5);
 
 			// when
-			mockMvc.perform(get("/admin/calendar/total?page=1&size=30")
+			mockMvc.perform(get("/calendar/admin/total?page=1&size=30")
 					.header("Authorization", "Bearer " + accessToken))
 				.andExpect(status().isOk())
 				.andDo(print()) // 응답 출력

--- a/gg-data/src/main/java/gg/data/calendar/PublicSchedule.java
+++ b/gg-data/src/main/java/gg/data/calendar/PublicSchedule.java
@@ -9,6 +9,7 @@ import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Lob;
 
 import gg.data.BaseTimeEntity;
 import gg.data.calendar.type.DetailClassification;
@@ -51,6 +52,8 @@ public class PublicSchedule extends BaseTimeEntity {
 	@Column(nullable = false)
 	private String title;
 
+	@Lob
+	@Column(columnDefinition = "TEXT")
 	private String content;
 
 	private String link;

--- a/gg-pingpong-api/src/main/java/gg/pingpong/api/global/config/SwaggerConfig.java
+++ b/gg-pingpong-api/src/main/java/gg/pingpong/api/global/config/SwaggerConfig.java
@@ -23,7 +23,6 @@ public class SwaggerConfig {
 			.build();
 	}
 
-
 	@Bean
 	public GroupedOpenApi agendaAdminGroup() {
 		return GroupedOpenApi.builder()
@@ -46,7 +45,7 @@ public class SwaggerConfig {
 	public GroupedOpenApi calendarAdmin() {
 		return GroupedOpenApi.builder()
 			.group("calendar admin")
-			.pathsToMatch("/admin/calendar/**")
+			.pathsToMatch("/calendar/admin/**")
 			.packagesToScan("gg.calendar.api.admin")
 			.build();
 	}

--- a/gg-pingpong-api/src/main/java/gg/pingpong/api/global/scheduler/CalendarEventScheduler.java
+++ b/gg-pingpong-api/src/main/java/gg/pingpong/api/global/scheduler/CalendarEventScheduler.java
@@ -19,9 +19,7 @@ public class CalendarEventScheduler extends AbstractScheduler {
 		this.fortyTwoEventService = fortyTwoEventService;
 		this.scheduleCheckService = scheduleCheckService;
 		this.scheduleNotiService = scheduleNotiService;
-		// this.setCron("0 0 0 * * *");
-		this.setCron("0 */5 * * * *");
-
+		this.setCron("0 0 0 * * *");
 	}
 
 	@Override

--- a/gg-pingpong-api/src/main/java/gg/pingpong/api/global/scheduler/CalendarEventScheduler.java
+++ b/gg-pingpong-api/src/main/java/gg/pingpong/api/global/scheduler/CalendarEventScheduler.java
@@ -19,7 +19,9 @@ public class CalendarEventScheduler extends AbstractScheduler {
 		this.fortyTwoEventService = fortyTwoEventService;
 		this.scheduleCheckService = scheduleCheckService;
 		this.scheduleNotiService = scheduleNotiService;
-		this.setCron("0 0 0 * * *");
+		// this.setCron("0 0 0 * * *");
+		this.setCron("0 */5 * * * *");
+
 	}
 
 	@Override

--- a/gg-pingpong-api/src/main/resources/db/migration/V4__calendar.sql
+++ b/gg-pingpong-api/src/main/resources/db/migration/V4__calendar.sql
@@ -7,7 +7,7 @@ CREATE TABLE public_schedule (
                                  tech_tag VARCHAR(50),
                                  author VARCHAR(255) NOT NULL,
                                  title VARCHAR(255) NOT NULL,
-                                 content VARCHAR(255),
+                                 content TEXT,
                                  link VARCHAR(255),
                                  status VARCHAR(50) NOT NULL,
                                  shared_count INT NOT NULL,


### PR DESCRIPTION
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - admin/calendar/list/detail_classification API 반환 순서 역순으로 수정
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - JPA 쿼리문 수정(findAllByClassification -> findAllByClassificationOrderByIdDesc)
 ## 💡Issue 번호 <!-- issue number을 link 시켜주세요 (ex. "- close #4242") -->
 - #1195 